### PR TITLE
fix: json output

### DIFF
--- a/internal/cmd/clear.go
+++ b/internal/cmd/clear.go
@@ -34,6 +34,8 @@ func runClear(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to clear current session expiry: %w", err)
 	}
 
-	fmt.Println("Cleared all stored state (session, viewer URL, agent, function, session expiry).")
-	return nil
+	return PrintResult("Cleared all stored state (session, viewer URL, agent, function, session expiry).", map[string]any{
+		"cleared": []string{"session", "viewer_url", "agent", "function", "session_expiry"},
+		"success": true,
+	})
 }

--- a/internal/cmd/files.go
+++ b/internal/cmd/files.go
@@ -62,7 +62,7 @@ func init() {
 
 	// Download command flags
 	filesDownloadCmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID (uses current session if not specified)")
-	filesDownloadCmd.Flags().StringVarP(&filesDownloadOutput, "output", "o", "", "Output file path (defaults to current directory)")
+	filesDownloadCmd.Flags().StringVar(&filesDownloadOutput, "path", "", "Output file path (defaults to current directory)")
 }
 
 func runFilesList(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/page.go
+++ b/internal/cmd/page.go
@@ -798,5 +798,5 @@ func init() {
 	_ = pageFormFillCmd.MarkFlagRequired("data")
 
 	// screenshot flags
-	pageScreenshotCmd.Flags().StringVarP(&pageScreenshotOutput, "output", "o", "", "Output path for the screenshot (defaults to temp directory)")
+	pageScreenshotCmd.Flags().StringVar(&pageScreenshotOutput, "path", "", "Output path for the screenshot (defaults to temp directory)")
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
@@ -68,8 +69,10 @@ func init() {
 	rootCmd.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Printf("notte version %s\n", Version)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return PrintResult(fmt.Sprintf("notte version %s", Version), map[string]any{
+				"version": Version,
+			})
 		},
 	})
 }

--- a/tests/integration/json_output_test.go
+++ b/tests/integration/json_output_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestJSONOutputValidity tests that commands produce valid JSON when using -o json.
+// Commands that produce invalid JSON will be logged and the test will fail.
+func TestJSONOutputValidity(t *testing.T) {
+	// Start a session for commands that need one
+	result := runCLI(t, "sessions", "start", "--headless")
+	requireSuccess(t, result)
+
+	var startResp struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &startResp); err != nil {
+		t.Fatalf("Failed to parse session start response: %v", err)
+	}
+	sessionID := startResp.SessionID
+	defer cleanupSession(t, sessionID)
+
+	// Wait for session to be ready
+	time.Sleep(2 * time.Second)
+
+	// Navigate to a page for commands that need page content
+	result = runCLIWithTimeout(t, 120*time.Second, "page", "goto", "https://example.com", "--session-id", sessionID)
+	requireSuccess(t, result)
+
+	// Commands to test, grouped by requirements
+	tests := []struct {
+		name       string
+		args       []string
+		skipReason string // if non-empty, skip with this reason
+	}{
+		// List commands (no setup required)
+		{"sessions list", []string{"sessions", "list"}, ""},
+		{"agents list", []string{"agents", "list"}, ""},
+		{"personas list", []string{"personas", "list"}, ""},
+		{"profiles list", []string{"profiles", "list"}, ""},
+		{"vaults list", []string{"vaults", "list"}, ""},
+		{"functions list", []string{"functions", "list"}, ""},
+		{"files list", []string{"files", "list"}, ""},
+
+		// Session commands
+		{"sessions status", []string{"sessions", "status", "--session-id", sessionID}, ""},
+		{"sessions cookies", []string{"sessions", "cookies", "--session-id", sessionID}, ""},
+		{"sessions network", []string{"sessions", "network", "--session-id", sessionID}, ""},
+		{"sessions observe", []string{"sessions", "observe", "--session-id", sessionID}, ""},
+		{"sessions scrape", []string{"sessions", "scrape", "--session-id", sessionID}, ""},
+		{"sessions replay", []string{"sessions", "replay", "--session-id", sessionID}, ""},
+		{"sessions offset", []string{"sessions", "offset", "--session-id", sessionID}, ""},
+		{"sessions workflow-code", []string{"sessions", "workflow-code", "--session-id", sessionID}, ""},
+
+		// Page commands
+		{"page observe", []string{"page", "observe", "--session-id", sessionID}, ""},
+		{"page scrape", []string{"page", "scrape", "--session-id", sessionID}, ""},
+		{"page scroll-down", []string{"page", "scroll-down", "--session-id", sessionID}, ""},
+		{"page scroll-up", []string{"page", "scroll-up", "--session-id", sessionID}, ""},
+		{"page back", []string{"page", "back", "--session-id", sessionID}, ""},
+		{"page forward", []string{"page", "forward", "--session-id", sessionID}, ""},
+		{"page reload", []string{"page", "reload", "--session-id", sessionID}, ""},
+		{"page eval-js", []string{"page", "eval-js", "document.title", "--session-id", sessionID}, ""},
+
+		// Auth commands
+		{"auth status", []string{"auth", "status"}, ""},
+
+		// Fixed commands - now produce valid JSON
+		{"clear", []string{"clear"}, ""},
+		{"sessions code", []string{"sessions", "code", "--session-id", sessionID}, ""},
+		{"sessions viewer", []string{"sessions", "viewer", "--session-id", sessionID}, ""},
+		{"version", []string{"version"}, ""},
+		{"page screenshot", []string{"page", "screenshot", "--session-id", sessionID}, ""},
+
+		// files download - will fail but error should still be valid JSON
+		{"files download", []string{"files", "download", "nonexistent.txt", "--session-id", sessionID}, ""},
+
+		// Known broken commands - skip these (pass through to external tools)
+		{"skill add", []string{"skill", "add"}, "passes through to npx, no JSON support"},
+		{"skill remove", []string{"skill", "remove"}, "passes through to npx, no JSON support"},
+	}
+
+	var brokenCommands []string
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skipReason != "" {
+				t.Skipf("Skipping: %s", tc.skipReason)
+				return
+			}
+
+			result := runCLIWithTimeout(t, 60*time.Second, tc.args...)
+
+			// Check if stdout is valid JSON
+			stdout := strings.TrimSpace(result.Stdout)
+			stderr := strings.TrimSpace(result.Stderr)
+
+			// If command failed, check stderr for valid JSON error
+			if result.ExitCode != 0 {
+				if stderr == "" {
+					brokenCommands = append(brokenCommands, tc.name)
+					t.Errorf("%s: command failed with no stderr output", tc.name)
+					return
+				}
+
+				// Only parse the first line of stderr (ignore "exit status 1" etc.)
+				stderrFirstLine := strings.Split(stderr, "\n")[0]
+
+				// Try to parse stderr as JSON error
+				var parsed any
+				if err := json.Unmarshal([]byte(stderrFirstLine), &parsed); err != nil {
+					brokenCommands = append(brokenCommands, tc.name)
+					t.Errorf("%s: command failed with invalid JSON error: %v\nStderr: %s",
+						tc.name, err, stderrFirstLine)
+					return
+				}
+
+				t.Logf("%s: valid JSON error (command failed as expected)", tc.name)
+				return
+			}
+
+			// Command succeeded - check stdout
+			if stdout == "" {
+				t.Logf("%s: empty output (acceptable)", tc.name)
+				return
+			}
+
+			// Try to parse as JSON
+			var parsed any
+			if err := json.Unmarshal([]byte(stdout), &parsed); err != nil {
+				brokenCommands = append(brokenCommands, tc.name)
+				t.Errorf("%s: invalid JSON output: %v\nStdout: %s\nStderr: %s",
+					tc.name, err, stdout, stderr)
+				return
+			}
+
+			t.Logf("%s: valid JSON", tc.name)
+		})
+	}
+
+	if len(brokenCommands) > 0 {
+		t.Logf("\nCommands with broken JSON output: %v", brokenCommands)
+	}
+}
+


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves JSON output consistency across the CLI by updating several commands to properly support the `-o json` flag.

**Key Changes:**
- Updated `clear`, `version`, `sessions code`, and `sessions viewer` commands to use the `PrintResult` helper function for consistent JSON output
- Renamed file output path flags from `--output/-o` to `--path` in `files download` and `page screenshot` to avoid conflicts with the global `--output/-o` flag (which controls text vs JSON format)
- Added `--session-id` flag to `sessions viewer` command for consistency
- Added comprehensive integration test to validate JSON output across all CLI commands

**Implementation Details:**
- The `PrintResult` function properly handles both text and JSON modes, printing human-readable messages in text mode and structured JSON in JSON mode
- In JSON mode, informational messages are sent to stderr to keep stdout clean for machine parsing
- The `sessions code` command now returns the full API response in JSON mode instead of just the Python script
- The integration test automatically validates that all commands produce valid JSON when `-o json` is used

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The changes are well-structured and follow existing patterns in the codebase. The use of the existing `PrintResult` helper ensures consistency, the flag renaming fixes a real conflict, and the comprehensive integration test provides validation of the changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/cmd/clear.go | Updated to use `PrintResult` for consistent JSON output support |
| internal/cmd/files.go | Renamed flag from `--output/-o` to `--path` to avoid conflict with global output format flag |
| internal/cmd/page.go | Renamed screenshot flag from `--output/-o` to `--path` to avoid conflict with global output format flag |
| internal/cmd/root.go | Updated version command to use `PrintResult` for consistent JSON output support |
| internal/cmd/sessions.go | Added JSON output support for `sessions code` and `sessions viewer` commands, plus new `--session-id` flag for viewer command |
| tests/integration/json_output_test.go | New comprehensive integration test validating JSON output for all CLI commands |

</details>



<sub>Last reviewed commit: ab08df8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->