### PR TITLE
make generate

### DIFF
--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -83,7 +83,7 @@ func PrintListOrEmpty(items any, emptyMsg string) (bool, error) {
 // In JSON mode, returns the full response. In text mode without instructions,
 // returns just the markdown. With instructions, checks data.success and returns
 // the extracted data or an error message.
-func PrintScrapeResponse(resp *api.ScrapeResponse, hasInstructions bool) error {
+func PrintScrapeResponse(resp *api.DataSpace, hasInstructions bool) error {
 	// JSON mode: return full response
 	if IsJSONOutput() {
 		return GetFormatter().Print(resp)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Regenerated API client code from the latest OpenAPI specification, which updated several response type definitions.

Major changes:
- `ApiExecutionResponse`: removed `Session` field and optional `Timestamp` field, added required `StartedAt` and `EndedAt` timestamp fields
- `Observation`: new type introduced with `EndedAt`, `Metadata`, `Screenshot`, `Space`, and `StartedAt` fields
- `ObserveResponse` and `ScrapeResponse`: removed and replaced with `Observation` and `DataSpace` respectively
- Updated `PrintScrapeResponse` in `output_helpers.go` to use `*api.DataSpace` parameter type

The changes are API schema updates reflected in generated code - all existing functionality is preserved since `DataSpace` contains the same fields (`Markdown`, `Structured`) that the helper function uses.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is an automated code generation PR that updates API client types from the OpenAPI spec. The changes are mechanical and maintain backward compatibility - the updated types contain equivalent fields that existing code depends on. No custom logic was modified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/api/client.gen.go | Auto-generated API client code from OpenAPI spec - updated type definitions for `ApiExecutionResponse`, `Observation`, and response types |
| internal/cmd/output_helpers.go | Updated `PrintScrapeResponse` function signature to accept `*api.DataSpace` instead of `*api.ScrapeResponse` - functionally equivalent since `DataSpace` contains the same fields |

</details>



<sub>Last reviewed commit: 72a6cc9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->