### PR TITLE
make files usage more streamlined

### DIFF
--- a/internal/cmd/page.go
+++ b/internal/cmd/page.go
@@ -287,7 +287,14 @@ func runPageDownload(cmd *cobra.Command, args []string) error {
 		action["selector"] = selector
 	}
 
-	return executePageAction(cmd, action)
+	if err := executePageAction(cmd, action); err != nil {
+		return err
+	}
+
+	if !IsJSONOutput() {
+		fmt.Println("List downloaded files with: notte files list")
+	}
+	return nil
 }
 
 var pageUploadCmd = &cobra.Command{


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverses the default behavior of `notte files list` to show downloaded files from a session by default (instead of uploaded files). It also improves the file download flow to properly handle presigned URLs from the API, and adds helpful user guidance messages.

Key changes:
- Swapped default flag values: `--uploads` now defaults to false, `--downloads` to true
- Modified `runFilesDownload` to parse JSON response for presigned URL and download from it
- Updated tests to reflect new behavior with two-server setup (API + file server)
- Added user-friendly messages pointing to relevant commands

Issues found:
- The `--downloads` flag on line 62 has no effect - the code only checks `filesListUploadsFlag` to determine behavior

<h3>Confidence Score: 3/5</h3>

- This PR has one logic bug where a flag is defined but never used, which could confuse users
- The implementation is functional and tests pass, but the `--downloads` flag has no effect on behavior since it's never checked in the code. This creates a confusing UX where users might try to explicitly set `--downloads` expecting different behavior. The presigned URL changes and test updates are solid.
- Pay attention to `internal/cmd/files.go` line 62 where the unused flag is defined

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/cmd/files.go | Swapped default behavior for files list (now downloads by default), improved file download to use presigned URLs, added helpful user messages. Contains logic bug where `--downloads` flag is unused. |
| internal/cmd/files_test.go | Updated tests to match new flag defaults and presigned URL flow for file downloads. Tests correctly validate the new behavior. |
| internal/cmd/page.go | Added helpful message after page download pointing users to `notte files list` command. |

</details>



<sub>Last reviewed commit: e099942</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->