### PR TITLE
Fix goreleaser release retries on existing assets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,6 +48,9 @@ archives:
     files:
       - README.md
 
+release:
+  replace_existing_artifacts: true
+
 checksum:
   name_template: "checksums.txt"
 


### PR DESCRIPTION
## Summary
- Add `release.replace_existing_artifacts: true` to `.goreleaser.yaml` so GoReleaser replaces assets that already exist on a release instead of failing with `422 Validation Failed - already_exists`
- Prevents release workflow failures when retrying after a partial upload

## Test plan
- [ ] Merge and tag a new release to verify the workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `release.replace_existing_artifacts: true` to `.goreleaser.yaml` to prevent `422 Validation Failed - already_exists` errors when retrying partial release uploads. This is a standard GoReleaser configuration that allows the CI/CD pipeline to safely retry failed release workflows without manual intervention.

- Simple configuration change with no code modifications
- Follows GoReleaser v2 best practices for robust CI/CD workflows
- Properly formatted and placed in the correct YAML section

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-documented configuration addition that follows GoReleaser best practices. It only adds a release configuration option without modifying any build logic or dependencies. The option prevents workflow failures during retries without introducing any security or functionality risks.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .goreleaser.yaml | Added `replace_existing_artifacts: true` to prevent release retry failures |

</details>



<sub>Last reviewed commit: 537055c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->