### PR TITLE
fix: trim keys from page observe json

### DIFF
--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -622,9 +622,17 @@ func runSessionObserve(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// JSON mode: return full response
+	// JSON mode: return filtered response (exclude screenshot and space.actions)
 	if IsJSONOutput() {
-		return GetFormatter().Print(resp.JSON200)
+		filtered := map[string]any{
+			"ended_at":   resp.JSON200.EndedAt,
+			"metadata":   resp.JSON200.Metadata,
+			"started_at": resp.JSON200.StartedAt,
+			"space": map[string]any{
+				"description": resp.JSON200.Space.Description,
+			},
+		}
+		return GetFormatter().Print(filtered)
 	}
 
 	// Text mode: return only the page description


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR filters the JSON output for the page observe command to exclude large fields (`screenshot` and `space.actions`) while retaining essential observation data (`ended_at`, `metadata`, `started_at`, `space.description`).

- Reduces JSON output size by filtering unnecessary fields in `runSessionObserve`
- Maintains backward compatibility for text mode output
- Clean implementation using `map[string]any` for filtered response

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is straightforward and well-scoped: it filters JSON output to exclude bulky fields while preserving essential data. The implementation is clean, doesn't affect text mode output, and has no logical errors or security concerns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/cmd/sessions.go | Filters JSON output to exclude `screenshot` and `space.actions` fields, reducing response size while preserving essential observation data |

</details>



<sub>Last reviewed commit: c0a9aed</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->