### PR TITLE
fix: remove mention of navigate

### DIFF
--- a/skills/notte-browser/SKILL.md
+++ b/skills/notte-browser/SKILL.md
@@ -18,7 +18,7 @@ notte auth login
 # 2. Start a browser session
 notte sessions start
 
-# 3. Navigate and observe
+# 3. Goto and observe
 notte page goto "https://example.com"
 notte page observe
 notte page screenshot


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated documentation comment to use "Goto" instead of "Navigate" to accurately reflect the actual CLI command (`notte page goto`). The change aligns the Quick Start documentation with the command syntax used throughout the codebase.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Score reflects a simple documentation fix that corrects terminology. The only minor concern is potential inconsistency with other documentation files that may need similar updates.
- Consider checking `skills/notte-browser/references/session-management.md` for similar terminology updates

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| skills/notte-browser/SKILL.md | Updated comment from "Navigate and observe" to "Goto and observe" to match actual command name |

</details>



<sub>Last reviewed commit: 4094cc6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->