### PR TITLE
set default timeout to 60s

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -57,7 +57,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "text", "Output format (text, json)")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable color output")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
-	rootCmd.PersistentFlags().IntVar(&requestTimeout, "timeout", 30, "API request timeout in seconds")
+	rootCmd.PersistentFlags().IntVar(&requestTimeout, "timeout", 60, "API request timeout in seconds")
 	rootCmd.PersistentFlags().BoolVarP(&yesFlag, "yes", "y", false, "Skip confirmation prompts")
 
 	// Set up confirmation state before each command


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Increased the default `--timeout` flag value from 30 seconds to 60 seconds for all API requests throughout the CLI.

- The change doubles the default timeout for API operations, which should help prevent timeouts on slower connections or longer-running operations
- The timeout remains configurable via the `--timeout` flag, so users can still adjust it as needed
- This is applied globally to all API operations through `GetContextWithTimeout`, which is used extensively across sessions, agents, vaults, profiles, and other commands

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a simple one-line modification to increase a default timeout value. The timeout remains user-configurable, all existing tests remain valid (they override the timeout), and the change is backwards compatible. No logical, syntax, or security issues present.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/cmd/root.go | Increased default API timeout from 30s to 60s, no issues found |

</details>



<sub>Last reviewed commit: 78293ee</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->