### PR TITLE
Rename --proxies to --proxy and add --proxy-country flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ notte sessions start \
   --user-agent <string>                   # Custom user agent
   --viewport-width <pixels>               # Viewport width
   --viewport-height <pixels>              # Viewport height
-  --proxies                               # Use default proxy rotation
+  --proxy                                  # Use default proxy rotation
+  --proxy-country <code>                  # Proxy with specific country (e.g. us, gb, fr)
   --solve-captchas                        # Automatically solve captchas
   --use-file-storage                      # Enable file storage for downloads
   --cdp-url <url>                         # CDP URL of remote session provider

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -22,8 +22,10 @@ import (
 )
 
 // Manual flags for proxies (union type not auto-generated)
-var sessionsStartProxy bool
-var sessionsStartProxyCountry string
+var (
+	sessionsStartProxy        bool
+	sessionsStartProxyCountry string
+)
 
 var (
 	sessionID                 string

--- a/internal/cmd/sessions_test.go
+++ b/internal/cmd/sessions_test.go
@@ -108,7 +108,7 @@ func TestRunSessionsStart(t *testing.T) {
 	origHeadless := SessionStartHeadless
 	origBrowser := SessionStartBrowserType
 	origTimeout := SessionStartIdleTimeoutMinutes
-	origProxies := sessionsStartProxies
+	origProxies := sessionsStartProxy
 	origSolve := SessionStartSolveCaptchas
 	origVW := SessionStartViewportWidth
 	origVH := SessionStartViewportHeight
@@ -119,7 +119,7 @@ func TestRunSessionsStart(t *testing.T) {
 		SessionStartHeadless = origHeadless
 		SessionStartBrowserType = origBrowser
 		SessionStartIdleTimeoutMinutes = origTimeout
-		sessionsStartProxies = origProxies
+		sessionsStartProxy = origProxies
 		SessionStartSolveCaptchas = origSolve
 		SessionStartViewportWidth = origVW
 		SessionStartViewportHeight = origVH
@@ -131,7 +131,7 @@ func TestRunSessionsStart(t *testing.T) {
 	SessionStartHeadless = false
 	SessionStartBrowserType = "firefox"
 	SessionStartIdleTimeoutMinutes = 5
-	sessionsStartProxies = true
+	sessionsStartProxy = true
 	SessionStartSolveCaptchas = true
 	SessionStartViewportWidth = 1280
 	SessionStartViewportHeight = 720
@@ -145,11 +145,11 @@ func TestRunSessionsStart(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
-	cmd.Flags().BoolVar(&sessionsStartProxies, "proxies", false, "")
+	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.Flags().BoolVar(&SessionStartUseFileStorage, "file-storage", false, "")
 	_ = cmd.Flags().Set("headless", "false")
-	_ = cmd.Flags().Set("proxies", "true")
+	_ = cmd.Flags().Set("proxy", "true")
 	_ = cmd.Flags().Set("solve-captchas", "true")
 	_ = cmd.Flags().Set("file-storage", "true")
 	cmd.SetContext(context.Background())
@@ -179,7 +179,7 @@ func TestRunSessionsStart_Minimal(t *testing.T) {
 	origHeadless := SessionStartHeadless
 	origBrowser := SessionStartBrowserType
 	origTimeout := SessionStartIdleTimeoutMinutes
-	origProxies := sessionsStartProxies
+	origProxies := sessionsStartProxy
 	origSolve := SessionStartSolveCaptchas
 	origVW := SessionStartViewportWidth
 	origVH := SessionStartViewportHeight
@@ -189,7 +189,7 @@ func TestRunSessionsStart_Minimal(t *testing.T) {
 		SessionStartHeadless = origHeadless
 		SessionStartBrowserType = origBrowser
 		SessionStartIdleTimeoutMinutes = origTimeout
-		sessionsStartProxies = origProxies
+		sessionsStartProxy = origProxies
 		SessionStartSolveCaptchas = origSolve
 		SessionStartViewportWidth = origVW
 		SessionStartViewportHeight = origVH
@@ -200,7 +200,7 @@ func TestRunSessionsStart_Minimal(t *testing.T) {
 	SessionStartHeadless = true
 	SessionStartBrowserType = ""
 	SessionStartIdleTimeoutMinutes = 0
-	sessionsStartProxies = false
+	sessionsStartProxy = false
 	SessionStartSolveCaptchas = false
 	SessionStartViewportWidth = 0
 	SessionStartViewportHeight = 0
@@ -213,7 +213,7 @@ func TestRunSessionsStart_Minimal(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
-	cmd.Flags().BoolVar(&sessionsStartProxies, "proxies", false, "")
+	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())
 
@@ -1045,7 +1045,7 @@ func TestSessionsStart_SetsCurrentSession(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
-	cmd.Flags().BoolVar(&sessionsStartProxies, "proxies", false, "")
+	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())
 
@@ -1252,7 +1252,7 @@ func TestSessionsStart_SavesExpiry(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
-	cmd.Flags().BoolVar(&sessionsStartProxies, "proxies", false, "")
+	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())
 
@@ -1323,7 +1323,7 @@ func TestSessionsStart_AutoClearsExpiredSession(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
-	cmd.Flags().BoolVar(&sessionsStartProxies, "proxies", false, "")
+	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())
 
@@ -1392,7 +1392,7 @@ func TestSessionsStart_DoesNotAutoClearNonExpiredSession(t *testing.T) {
 
 	cmd := &cobra.Command{}
 	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
-	cmd.Flags().BoolVar(&sessionsStartProxies, "proxies", false, "")
+	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())
 

--- a/skills/notte-browser/SKILL.md
+++ b/skills/notte-browser/SKILL.md
@@ -48,7 +48,8 @@ notte sessions start [flags]
   --headless                 Run in headless mode (default: true)
   --idle-timeout-minutes     Idle timeout in minutes
   --max-duration-minutes     Maximum session lifetime in minutes
-  --proxies                  Use default proxies
+  --proxy                    Use default proxies
+  --proxy-country <code>     Proxy country code (e.g. us, gb, fr)
   --solve-captchas           Automatically solve captchas
   --viewport-width           Viewport width in pixels
   --viewport-height          Viewport height in pixels
@@ -488,7 +489,7 @@ If you're getting blocked or seeing CAPTCHAs, try enabling our residential proxi
 
  ```bash
  notte sessions stop
- notte sessions start --proxies
+ notte sessions start --proxy
  ```
 
 **Note**: Always stop the current session before starting a new one with different parameters. Session configuration cannot be changed mid-session.

--- a/skills/notte-browser/references/session-management.md
+++ b/skills/notte-browser/references/session-management.md
@@ -49,7 +49,7 @@ notte sessions start \
   --browser-type chromium \       # Browser type
   --idle-timeout-minutes 10 \     # Close after 10 min of inactivity
   --max-duration-minutes 60 \     # Maximum 60 min session lifetime
-  --proxies \                     # Use rotating proxies
+  --proxy \                       # Use rotating proxies
   --solve-captchas \              # Auto-solve CAPTCHAs
   --viewport-width 1920 \         # Custom viewport
   --viewport-height 1080 \


### PR DESCRIPTION
## Summary
- Renames `--proxies` boolean flag to `--proxy`
- Adds `--proxy-country` flag accepting ISO 3166-1 alpha-2 country codes (e.g. `us`, `gb`, `fr`) for country-specific proxy routing
- When both `--proxy` and `--proxy-country` are provided, `--proxy-country` takes precedence

## Test plan
- [ ] `go build ./...` compiles successfully
- [ ] `notte sessions start --proxy` — verify existing boolean proxy behavior works
- [ ] `notte sessions start --proxy-country us` — verify session starts with US proxy
- [ ] `notte sessions start --proxy --proxy-country gb` — verify country takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Renamed `--proxies` flag to `--proxy` and added `--proxy-country` flag for country-specific proxy routing.

- Renamed `--proxies` boolean flag to `--proxy` across all files for improved naming consistency
- Added `--proxy-country` flag accepting ISO 3166-1 alpha-2 country codes (e.g., `us`, `gb`, `fr`)
- Implemented clear precedence logic where `--proxy-country` takes priority over `--proxy` when both are provided
- Updated documentation consistently in README, SKILL.md, and reference files with correct flag names and examples

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple, well-executed feature addition with proper flag handling, clear precedence logic, appropriate error handling, and consistent documentation updates across all files
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Renamed `--proxies` to `--proxy` and added `--proxy-country` flag documentation |
| internal/cmd/sessions.go | Implemented `--proxy` and `--proxy-country` flags with proper precedence logic and API integration |

</details>



<sub>Last reviewed commit: 7a85f03</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->