### PR TITLE
feat: add session extra http headers

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -603,6 +603,9 @@ type ApiSessionStartRequest struct {
 	// ChromeArgs Overwrite the chrome instance arguments
 	ChromeArgs *[]string `json:"chrome_args"`
 
+	// ExtraHttpHeaders Extra HTTP headers to be sent with every request.
+	ExtraHttpHeaders *map[string]interface{} `json:"extra_http_headers"`
+
 	// Headless Whether to run the session in headless mode.
 	Headless *bool `json:"headless,omitempty"`
 
@@ -1408,6 +1411,9 @@ type GlobalScrapeRequest struct {
 	// ChromeArgs Overwrite the chrome instance arguments
 	ChromeArgs *[]string `json:"chrome_args"`
 
+	// ExtraHttpHeaders Extra HTTP headers to be sent with every request.
+	ExtraHttpHeaders *map[string]interface{} `json:"extra_http_headers"`
+
 	// Headless Whether to run the session in headless mode.
 	Headless *bool `json:"headless,omitempty"`
 
@@ -1942,6 +1948,18 @@ type RootModelUnionDictStrAnyListDictStrAny0 map[string]interface{}
 
 // RootModelUnionDictStrAnyListDictStrAny1 defines model for .
 type RootModelUnionDictStrAnyListDictStrAny1 = []map[string]interface{}
+
+// RunFunctionRequest defines model for RunFunctionRequest.
+type RunFunctionRequest struct {
+	// Stream Whether to stream logs, or only return final response
+	Stream *bool `json:"stream,omitempty"`
+
+	// Variables The variables to run the workflow with
+	Variables map[string]interface{} `json:"variables"`
+
+	// WorkflowId The ID of the function to run
+	WorkflowId string `json:"workflow_id"`
+}
 
 // SMSResponse defines model for SMSResponse.
 type SMSResponse struct {
@@ -3019,6 +3037,9 @@ type FunctionCreateMultipartRequestBody = BodyFunctionCreateFunctionsPost
 
 // FunctionUpdateMultipartRequestBody defines body for FunctionUpdate for multipart/form-data ContentType.
 type FunctionUpdateMultipartRequestBody = BodyFunctionUpdateFunctionsFunctionIdPost
+
+// FunctionRunStartJSONRequestBody defines body for FunctionRunStart for application/json ContentType.
+type FunctionRunStartJSONRequestBody = RunFunctionRequest
 
 // FunctionRunUpdateMetadataJSONRequestBody defines body for FunctionRunUpdateMetadata for application/json ContentType.
 type FunctionRunUpdateMetadataJSONRequestBody = FunctionRunUpdateRequest
@@ -8054,8 +8075,10 @@ type ClientInterface interface {
 	// ListFunctionRunsByFunctionId request
 	ListFunctionRunsByFunctionId(ctx context.Context, functionId string, params *ListFunctionRunsByFunctionIdParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// FunctionRunStart request
-	FunctionRunStart(ctx context.Context, functionId string, params *FunctionRunStartParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// FunctionRunStartWithBody request with any body
+	FunctionRunStartWithBody(ctx context.Context, functionId string, params *FunctionRunStartParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	FunctionRunStart(ctx context.Context, functionId string, params *FunctionRunStartParams, body FunctionRunStartJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// FunctionRunStop request
 	FunctionRunStop(ctx context.Context, functionId string, runId string, params *FunctionRunStopParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8388,8 +8411,20 @@ func (c *Client) ListFunctionRunsByFunctionId(ctx context.Context, functionId st
 	return c.Client.Do(req)
 }
 
-func (c *Client) FunctionRunStart(ctx context.Context, functionId string, params *FunctionRunStartParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFunctionRunStartRequest(c.Server, functionId, params)
+func (c *Client) FunctionRunStartWithBody(ctx context.Context, functionId string, params *FunctionRunStartParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFunctionRunStartRequestWithBody(c.Server, functionId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FunctionRunStart(ctx context.Context, functionId string, params *FunctionRunStartParams, body FunctionRunStartJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFunctionRunStartRequest(c.Server, functionId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -10241,8 +10276,19 @@ func NewListFunctionRunsByFunctionIdRequest(server string, functionId string, pa
 	return req, nil
 }
 
-// NewFunctionRunStartRequest generates requests for FunctionRunStart
-func NewFunctionRunStartRequest(server string, functionId string, params *FunctionRunStartParams) (*http.Request, error) {
+// NewFunctionRunStartRequest calls the generic FunctionRunStart builder with application/json body
+func NewFunctionRunStartRequest(server string, functionId string, params *FunctionRunStartParams, body FunctionRunStartJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewFunctionRunStartRequestWithBody(server, functionId, params, "application/json", bodyReader)
+}
+
+// NewFunctionRunStartRequestWithBody generates requests for FunctionRunStart with any type of body
+func NewFunctionRunStartRequestWithBody(server string, functionId string, params *FunctionRunStartParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10267,10 +10313,12 @@ func NewFunctionRunStartRequest(server string, functionId string, params *Functi
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -13827,8 +13875,10 @@ type ClientWithResponsesInterface interface {
 	// ListFunctionRunsByFunctionIdWithResponse request
 	ListFunctionRunsByFunctionIdWithResponse(ctx context.Context, functionId string, params *ListFunctionRunsByFunctionIdParams, reqEditors ...RequestEditorFn) (*ListFunctionRunsByFunctionIdResult, error)
 
-	// FunctionRunStartWithResponse request
-	FunctionRunStartWithResponse(ctx context.Context, functionId string, params *FunctionRunStartParams, reqEditors ...RequestEditorFn) (*FunctionRunStartResult, error)
+	// FunctionRunStartWithBodyWithResponse request with any body
+	FunctionRunStartWithBodyWithResponse(ctx context.Context, functionId string, params *FunctionRunStartParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FunctionRunStartResult, error)
+
+	FunctionRunStartWithResponse(ctx context.Context, functionId string, params *FunctionRunStartParams, body FunctionRunStartJSONRequestBody, reqEditors ...RequestEditorFn) (*FunctionRunStartResult, error)
 
 	// FunctionRunStopWithResponse request
 	FunctionRunStopWithResponse(ctx context.Context, functionId string, runId string, params *FunctionRunStopParams, reqEditors ...RequestEditorFn) (*FunctionRunStopResult, error)
@@ -15497,9 +15547,17 @@ func (c *ClientWithResponses) ListFunctionRunsByFunctionIdWithResponse(ctx conte
 	return ParseListFunctionRunsByFunctionIdResult(rsp)
 }
 
-// FunctionRunStartWithResponse request returning *FunctionRunStartResult
-func (c *ClientWithResponses) FunctionRunStartWithResponse(ctx context.Context, functionId string, params *FunctionRunStartParams, reqEditors ...RequestEditorFn) (*FunctionRunStartResult, error) {
-	rsp, err := c.FunctionRunStart(ctx, functionId, params, reqEditors...)
+// FunctionRunStartWithBodyWithResponse request with arbitrary body returning *FunctionRunStartResult
+func (c *ClientWithResponses) FunctionRunStartWithBodyWithResponse(ctx context.Context, functionId string, params *FunctionRunStartParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FunctionRunStartResult, error) {
+	rsp, err := c.FunctionRunStartWithBody(ctx, functionId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFunctionRunStartResult(rsp)
+}
+
+func (c *ClientWithResponses) FunctionRunStartWithResponse(ctx context.Context, functionId string, params *FunctionRunStartParams, body FunctionRunStartJSONRequestBody, reqEditors ...RequestEditorFn) (*FunctionRunStartResult, error) {
+	rsp, err := c.FunctionRunStart(ctx, functionId, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -511,7 +511,7 @@ func runSessionsStart(cmd *cobra.Command, args []string) error {
 	}
 
 	// Handle extra HTTP headers (map type not auto-generated)
-	if sessionsStartExtraHttpHeaders != "" {
+	if cmd.Flags().Changed("extra-http-headers") {
 		var headers map[string]interface{}
 		if err := json.Unmarshal([]byte(sessionsStartExtraHttpHeaders), &headers); err != nil {
 			return fmt.Errorf("invalid JSON for --extra-http-headers: %w", err)

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -21,10 +21,11 @@ import (
 	"github.com/nottelabs/notte-cli/internal/config"
 )
 
-// Manual flags for proxies (union type not auto-generated)
+// Manual flags for proxies and extra headers (union types not auto-generated)
 var (
-	sessionsStartProxy        bool
-	sessionsStartProxyCountry string
+	sessionsStartProxy            bool
+	sessionsStartProxyCountry     string
+	sessionsStartExtraHttpHeaders string
 )
 
 var (
@@ -332,6 +333,8 @@ func init() {
 	// Manual flags for proxies (union type: bool | array of proxy objects)
 	sessionsStartCmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "Use default proxies")
 	sessionsStartCmd.Flags().StringVar(&sessionsStartProxyCountry, "proxy-country", "", "Proxy country code (e.g. us, gb, fr). Implies --proxy")
+	// Manual flag for extra HTTP headers (map type not auto-generated)
+	sessionsStartCmd.Flags().StringVar(&sessionsStartExtraHttpHeaders, "extra-http-headers", "", `Extra HTTP headers as JSON (e.g. '{"Authorization": "Bearer xxx"}')`)
 
 	// Status command flags
 	sessionsStatusCmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID (uses current session if not specified)")
@@ -505,6 +508,15 @@ func runSessionsStart(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to set proxies: %w", err)
 		}
 		body.Proxies = &proxies
+	}
+
+	// Handle extra HTTP headers (map type not auto-generated)
+	if sessionsStartExtraHttpHeaders != "" {
+		var headers map[string]interface{}
+		if err := json.Unmarshal([]byte(sessionsStartExtraHttpHeaders), &headers); err != nil {
+			return fmt.Errorf("invalid JSON for --extra-http-headers: %w", err)
+		}
+		body.ExtraHttpHeaders = &headers
 	}
 
 	params := &api.SessionStartParams{}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for passing extra HTTP headers when starting a browser session via the CLI, exposing a new `--extra-http-headers` flag that accepts a JSON string and forwards the parsed map to the API. It also regenerates `client.gen.go` to include the `ExtraHttpHeaders` field on `ApiSessionStartRequest` / `GlobalScrapeRequest` and to properly wire up `FunctionRunStart` with a JSON request body.

- `--extra-http-headers` flag is registered correctly, uses `cmd.Flags().Changed()` for detection (consistent with proxy flag handling), and includes clear JSON parse error reporting.
- The `client.gen.go` changes are auto-generated; `ExtraHttpHeaders` is typed `*map[string]interface{}` (not `*map[string]string`) — this is an upstream OpenAPI schema concern already acknowledged in a previous thread.
- `ExtraHttpHeaders` is missing the `omitempty` JSON tag in both `ApiSessionStartRequest` and `GlobalScrapeRequest`, so it will serialize as `"extra_http_headers": null` in every API request where it is not set. This is consistent with the existing `ChromeArgs` field in the same structs, so it appears intentional from the spec, but worth confirming with the API owner that `null` is handled the same as field-absent.
- As a follow-up opportunity: `internal/cmd/functions.go` contains a now-stale comment ("The generated client doesn't support request body for FunctionRunStart") and a manual HTTP workaround; now that the generated client supports a typed request body, this code could be simplified in a follow-up PR.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; implementation is correct and consistent with existing patterns, with only a minor serialization nuance worth confirming upstream.
- The CLI-side changes are clean and follow the established proxy-flag pattern. The generated client changes are mechanical (auto-generated) with no logic errors. The only open question is whether the API tolerates `"extra_http_headers": null` the same as field-absent, since the field lacks `omitempty` — but this is consistent with `ChromeArgs` in the same struct and is an upstream schema concern, not a bug introduced here.
- No files require special attention; the minor `omitempty` observation in `internal/api/client.gen.go` should be addressed in the upstream OpenAPI spec if needed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/cmd/sessions.go | Adds `--extra-http-headers` flag with correct `cmd.Flags().Changed()` guard, proper JSON unmarshaling, and clear error messages; consistent with the existing proxy flag pattern. |
| internal/api/client.gen.go | Auto-generated client update adds `ExtraHttpHeaders` to `ApiSessionStartRequest` / `GlobalScrapeRequest` and properly wires up `FunctionRunStart` with a JSON request body; no critical issues, but `ExtraHttpHeaders` lacks `omitempty` which causes it to serialize as `null` in every request where it is not set. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/cmd/functions.go`, line 558-567 ([link](https://github.com/nottelabs/notte-cli/blob/843cb4466df0d9ecdf9766c13b40e83f3f1e4af8/internal/cmd/functions.go#L558-L567)) 

   **Stale comment and field name mismatch in API request body**

   The comment on line 558 ("The generated client doesn't support request body for FunctionRunStart") is now outdated. The regenerated `client.gen.go` now includes a properly typed `FunctionRunStart` method that accepts `FunctionRunStartJSONRequestBody`:

   ```go
   func (c *Client) FunctionRunStart(ctx context.Context, functionId string, params *FunctionRunStartParams, body FunctionRunStartJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
   ```

   More critically, there is a field name mismatch: the generated `RunFunctionRequest` struct expects `"workflow_id"`:

   ```go
   type RunFunctionRequest struct {
       WorkflowId string `json:"workflow_id"`
   }
   ```

   But the manual request here sends `"function_id"` (line 561). This means the function identifier will be silently dropped from the request body, and only variables will be sent. 

   Consider replacing this manual HTTP construction with the generated `FunctionRunStart` method using the proper field name, or at minimum align the field name with the schema.

2. `internal/cmd/functions.go`, line 558-574 ([link](https://github.com/nottelabs/notte-cli/blob/843cb4466df0d9ecdf9766c13b40e83f3f1e4af8/internal/cmd/functions.go#L558-L574)) 

   **Stale workaround and field name mismatch with new generated client**

   This PR updates the generated client so that `FunctionRunStart` now accepts a typed `FunctionRunStartJSONRequestBody` (i.e. `RunFunctionRequest`). The comment at line 558 stating "The generated client doesn't support request body for FunctionRunStart" is therefore no longer accurate.

   More importantly, there is a semantic discrepancy between the field this manual request sends and what the new generated `RunFunctionRequest` struct models:

   - Manual request (here): `"function_id": functionID`
   - Generated `RunFunctionRequest` struct: `workflow_id string \`json:"workflow_id"\``

   If the server's accepted field name is `workflow_id`, the manual request body is sending an unrecognised key (`function_id`), which could silently result in the function not being identified correctly on the server side. Conversely, if the server expects `function_id`, then the new generated struct is wrong.

   Now that the generated client supports a typed body, consider migrating this function to use `client.Client().FunctionRunStartWithResponse(...)` with a `RunFunctionRequest{WorkflowId: functionID, Variables: variables}` to eliminate the manual HTTP call and reconcile the field name difference.

3. `internal/api/client.gen.go`, line 606-607 ([link](https://github.com/nottelabs/notte-cli/blob/843cb4466df0d9ecdf9766c13b40e83f3f1e4af8/internal/api/client.gen.go#L606-L607)) 

   **Missing `omitempty` may send `null` to server**

   `ExtraHttpHeaders` is typed as a pointer (`*map[string]interface{}`) but lacks `omitempty` in its JSON tag, just like `ChromeArgs`. This means when the pointer is `nil` (i.e. the flag is not provided), the field will be serialised as `"extra_http_headers": null` in the request body rather than being omitted entirely.

   Compare this to optional fields like `Headless` and `IdleTimeoutMinutes` which use `omitempty` and are therefore omitted when nil. If the server does not accept `null` for `extra_http_headers`, this will cause unexpected API errors for every session start request that does not supply extra headers.

   The same applies to `GlobalScrapeRequest.ExtraHttpHeaders` at line ~1414.

   Since this is auto-generated code, the fix belongs in the OpenAPI schema definition (marking the field as not nullable / adding a default, which causes oapi-codegen to emit `omitempty`).
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: 843cb44</sub>

<!-- /greptile_comment -->