### PR TITLE
tmp: omit empty extra http headers for now

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -604,7 +604,7 @@ type ApiSessionStartRequest struct {
 	ChromeArgs *[]string `json:"chrome_args"`
 
 	// ExtraHttpHeaders Extra HTTP headers to be sent with every request.
-	ExtraHttpHeaders *map[string]interface{} `json:"extra_http_headers"`
+	ExtraHttpHeaders *map[string]interface{} `json:"extra_http_headers,omitempty"`
 
 	// Headless Whether to run the session in headless mode.
 	Headless *bool `json:"headless,omitempty"`
@@ -1412,7 +1412,7 @@ type GlobalScrapeRequest struct {
 	ChromeArgs *[]string `json:"chrome_args"`
 
 	// ExtraHttpHeaders Extra HTTP headers to be sent with every request.
-	ExtraHttpHeaders *map[string]interface{} `json:"extra_http_headers"`
+	ExtraHttpHeaders *map[string]interface{} `json:"extra_http_headers,omitempty"`
 
 	// Headless Whether to run the session in headless mode.
 	Headless *bool `json:"headless,omitempty"`


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `omitempty` to the `ExtraHttpHeaders` JSON struct tag in `ApiSessionStartRequest` and `GlobalScrapeRequest` inside the generated API client, acting as a temporary workaround to prevent the field from being serialised when it is not set.

- The change is applied directly to `internal/api/client.gen.go`, which is fully overwritten by `make generate` (`scripts/generate.sh`). No corresponding fixup was added to the generation script, so the change will be silently lost the next time the client is regenerated from the OpenAPI spec.
- `omitempty` on a `*map[string]interface{}` pointer only suppresses serialisation when the pointer is `nil`; a caller that sets the field to a non-nil empty map (`&map[string]interface{}{}`) will still have `{}` sent in the request body.
- A durable solution would be to add a `sed` post-processing step in `scripts/generate.sh` (matching the pattern of existing fixups) so the `omitempty` annotation is re-applied automatically on every regeneration.

<h3>Confidence Score: 3/5</h3>

- Safe to merge as a short-term workaround, but the fix will be lost on the next code regeneration without an accompanying change to the generation script.
- The functional change is minimal and low-risk (adding `omitempty` narrows what is sent over the wire, which is the stated intent). However, because it edits a generated file without updating the generator, it is inherently fragile and will regress silently. Additionally, the fix does not fully cover the empty-map case.
- internal/api/client.gen.go — manual edits risk being overwritten; scripts/generate.sh should be updated alongside.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/api/client.gen.go | Adds `omitempty` to `ExtraHttpHeaders` in `ApiSessionStartRequest` and `GlobalScrapeRequest`; manual edits to a generated file that will be overwritten on the next `make generate` run, and `omitempty` on a pointer type does not omit empty (non-nil) maps. |

</details>

<sub>Last reviewed commit: ba996e4</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->