### PR TITLE
fix: replay mp4

### DIFF
--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -36,6 +36,7 @@ var (
 	sessionCookiesSetFile     string
 	sessionNetworkURLsOnly    bool
 	sessionNetworkPath        string
+	sessionReplayOutput       string
 )
 
 // GetCurrentSessionID returns the session ID from flag, env var, or file (in priority order)
@@ -273,9 +274,14 @@ var sessionsNetworkCmd = &cobra.Command{
 
 var sessionsReplayCmd = &cobra.Command{
 	Use:   "replay",
-	Short: "Get replay URL/data for the session",
-	Args:  cobra.NoArgs,
-	RunE:  runSessionReplay,
+	Short: "Download session replay video",
+	Long: `Download the replay video (MP4) for a session.
+
+Examples:
+  notte sessions replay                       # saves to temp directory
+  notte sessions replay --path replay.mp4    # saves to specified path`,
+	Args: cobra.NoArgs,
+	RunE: runSessionReplay,
 }
 
 var sessionsOffsetCmd = &cobra.Command{
@@ -371,6 +377,7 @@ func init() {
 
 	// Replay command flags
 	sessionsReplayCmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID (uses current session if not specified)")
+	sessionsReplayCmd.Flags().StringVar(&sessionReplayOutput, "path", "", "Output path for the replay video (defaults to temp directory)")
 
 	// Offset command flags
 	sessionsOffsetCmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID (uses current session if not specified)")
@@ -1074,12 +1081,36 @@ func runSessionReplay(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Wrap raw body for formatter compatibility
-	result := map[string]interface{}{
-		"session_id":  sessionID,
-		"replay_data": string(resp.Body),
+	// Determine output path
+	outputPath := sessionReplayOutput
+	if outputPath == "" {
+		// Default to temp directory
+		tmpDir := os.TempDir()
+		outputPath = filepath.Join(tmpDir, fmt.Sprintf("notte-replay-%s.mp4", sessionID))
 	}
-	return GetFormatter().Print(result)
+
+	// Clean the path to resolve any ".." components
+	outputPath = filepath.Clean(outputPath)
+
+	// Create directory if it doesn't exist
+	dir := filepath.Dir(outputPath)
+	if dir != "." && dir != "/" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+	}
+
+	// Write the replay video file
+	err = os.WriteFile(outputPath, resp.Body, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to write replay video: %w", err)
+	}
+
+	return PrintResult(fmt.Sprintf("Replay video saved: %s", outputPath), map[string]any{
+		"path":       outputPath,
+		"session_id": sessionID,
+		"success":    true,
+	})
 }
 
 func runSessionOffset(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `sessions replay` so that the MP4 binary payload returned by the API is written to disk rather than being passed to a text formatter (which would have produced garbage output). A new `--path` flag lets callers specify the destination; when omitted the file is saved to the OS temp directory.

Key changes:
- Adds `--path` flag (`sessionReplayOutput` variable) to the `sessions replay` sub-command.
- Resolves and cleans the output path with `filepath.Clean`, creates missing parent directories via `os.MkdirAll`, then writes `resp.Body` with `os.WriteFile`.
- Updates the command `Short`/`Long` descriptions and examples accordingly.
- Replaces the old `GetFormatter().Print(result)` call (which wrapped binary data in a `map[string]interface{}`) with a `PrintResult` call that surfaces the saved path and session ID.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a targeted bug fix with no unintended side-effects.
- The change is small and well-scoped: it corrects a clear defect (binary data being piped to a text formatter), adds a useful `--path` flag, handles directory creation, and uses standard library primitives (`os.WriteFile`, `filepath.Clean`, `os.MkdirAll`) correctly. No existing functionality is broken; the only observable behavioral change is the desired one.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cmd/sessions.go | Replaces the broken formatter-print path (which would have printed raw MP4 bytes as a JSON string) with a proper file-write flow: resolves the output path, creates intermediate directories, writes binary data, and prints a structured success result. |

</details>

<sub>Last reviewed commit: 3b05d1a</sub>

<!-- /greptile_comment -->