### PR TITLE
fix: always send variables field in function run/schedule requests

### DIFF
--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -559,11 +559,7 @@ func runFunctionRun(cmd *cobra.Command, args []string) error {
 	// so we need to make a manual request with the function_id in the body
 	requestBody := map[string]interface{}{
 		"function_id": functionID,
-	}
-
-	// Add variables if any were provided
-	if len(variables) > 0 {
-		requestBody["variables"] = variables
+		"variables":   variables,
 	}
 
 	bodyJSON, err := json.Marshal(requestBody)
@@ -783,8 +779,10 @@ func runFunctionSchedule(cmd *cobra.Command, args []string) error {
 	ctx, cancel := GetContextWithTimeout(cmd.Context())
 	defer cancel()
 
+	emptyVars := make(map[string]interface{})
 	body := api.FunctionScheduleSetJSONRequestBody{
-		Cron: functionCronExpression,
+		Cron:      functionCronExpression,
+		Variables: &emptyVars,
 	}
 
 	params := &api.FunctionScheduleSetParams{}


### PR DESCRIPTION
## Summary
- Always include `variables` field (as `{}` when empty) in the `functions run` request body — the API now requires it
- Set `Variables` to an empty map on `functions schedule` request body so it's serialized instead of omitted

Fixes 3 integration test failures: `TestFunctionIDResolution`, `TestFunctionRun`, `TestFunctionsScheduleAndUnschedule`

## Test plan
- [ ] Verify `notte functions run` works without `--var`/`--vars` flags
- [ ] Verify `notte functions run --var key=value` still works
- [ ] Verify `notte functions schedule` works
- [ ] Integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two API serialization issues where required fields were being omitted from request bodies, causing integration test failures.

- **`runFunctionRun`**: Removes the `len(variables) > 0` guard so `"variables"` is always serialized (as `{}` when no variables are provided), matching the API's requirement.
- **`runFunctionSchedule`**: Initializes `Variables` to `&emptyVars` (a pointer to an empty `map[string]interface{}`) so the field is serialized as `"variables": {}` instead of being omitted due to the `omitempty` JSON tag on the `*map[string]interface{}` pointer.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it makes minimal, targeted fixes to ensure required API fields are always serialized.
- The changes are small, well-scoped, and correct. `variables` in `runFunctionRun` was already initialized to an empty map, so always including it is a safe no-op when no variables are provided. In `runFunctionSchedule`, assigning a non-nil pointer to `Variables` correctly forces JSON serialization despite the `omitempty` tag. No logic is altered beyond ensuring the fields are present in the serialized body.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cmd/functions.go | Always includes `variables` field in function run request body and initializes `Variables` to an empty map pointer for schedule requests so it is serialized rather than omitted. |

</details>

<sub>Last reviewed commit: 2641b15</sub>

<!-- /greptile_comment -->