### PR TITLE
Add NOTTE_CONFIG_DIR override for config path

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ const (
 	CurrentViewerURLFile     = "current_viewer_url"
 	CurrentAgentFile         = "current_agent"
 	CurrentSessionExpiryFile = "current_session_expiry"
+	EnvConfigDir             = "NOTTE_CONFIG_DIR"
 	EnvAPIURL                = "NOTTE_API_URL"
 	EnvConsoleURL            = "NOTTE_CONSOLE_URL"
 	EnvSessionID             = "NOTTE_SESSION_ID"
@@ -44,6 +45,9 @@ type Config struct {
 func Dir() (string, error) {
 	if testConfigDir != "" {
 		return filepath.Join(testConfigDir, ConfigDirName), nil
+	}
+	if envDir := os.Getenv(EnvConfigDir); envDir != "" {
+		return filepath.Join(envDir, ConfigDirName), nil
 	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,6 +42,41 @@ func TestLoadConfig_WithValues(t *testing.T) {
 	}
 }
 
+func TestDir_EnvOverride(t *testing.T) {
+	customDir := t.TempDir()
+	t.Setenv("NOTTE_CONFIG_DIR", customDir)
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := filepath.Join(customDir, ConfigDirName)
+	if dir != expected {
+		t.Errorf("expected %q, got %q", expected, dir)
+	}
+}
+
+func TestDir_DefaultUsesHome(t *testing.T) {
+	// Ensure env var is not set
+	t.Setenv("NOTTE_CONFIG_DIR", "")
+
+	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("unexpected error getting home dir: %v", err)
+	}
+
+	expected := filepath.Join(homeDir, ConfigDirName)
+	if dir != expected {
+		t.Errorf("expected %q, got %q", expected, dir)
+	}
+}
+
 func TestSaveConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.json")


### PR DESCRIPTION
## Summary
- Add support for `NOTTE_CONFIG_DIR` to override the base config directory path.
- Keep the existing test-only config directory override taking precedence over the environment variable.
- Add tests covering both the env override path and the default home-directory fallback.

## Testing
- Not run (not requested).
- Existing unit tests updated in `internal/config/config_test.go` to verify `Dir()` behavior for both override and default cases.