### PR TITLE
feat: updated replay

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -121,12 +121,14 @@ const (
 	DeepseekdeepseekR1                    LlmModel = "deepseek/deepseek-r1"
 	Geminigemini25Flash                   LlmModel = "gemini/gemini-2.5-flash"
 	GroqgptOss120b                        LlmModel = "groq/gpt-oss-120b"
+	MinimaxminimaxM25                     LlmModel = "minimax/minimax-m2.5"
 	MoonshotkimiK25                       LlmModel = "moonshot/kimi-k2.5"
 	Openaigpt4o                           LlmModel = "openai/gpt-4o"
 	Openroutergooglegemma327bIt           LlmModel = "openrouter/google/gemma-3-27b-it"
 	PerplexitysonarPro                    LlmModel = "perplexity/sonar-pro"
 	TogetherAimetaLlamallama3370bInstruct LlmModel = "together_ai/meta-llama/llama-3.3-70b-instruct"
 	VertexAigemini25Flash                 LlmModel = "vertex_ai/gemini-2.5-flash"
+	Xaigrok41FastNonReasoning             LlmModel = "xai/grok-4-1-fast-non-reasoning"
 )
 
 // Defines values for NetworkLogFileType.
@@ -529,6 +531,11 @@ type AgentStatusResponse struct {
 
 	// Url The URL that the agent started on
 	Url *string `json:"url,omitempty"`
+}
+
+// AnythingStartRequest defines model for AnythingStartRequest.
+type AnythingStartRequest struct {
+	Task string `json:"task"`
 }
 
 // ApiAgentStartRequest defines model for ApiAgentStartRequest.
@@ -1274,6 +1281,12 @@ type FunctionRunUpdateRequest struct {
 // FunctionRunUpdateRequestStatus The status of the workflow run
 type FunctionRunUpdateRequestStatus string
 
+// FunctionScheduleCreateRequest defines model for FunctionScheduleCreateRequest.
+type FunctionScheduleCreateRequest struct {
+	Cron      string                  `json:"cron"`
+	Variables *map[string]interface{} `json:"variables,omitempty"`
+}
+
 // GetCookiesResponse defines model for GetCookiesResponse.
 type GetCookiesResponse struct {
 	Cookies []Cookie `json:"cookies"`
@@ -1937,6 +1950,15 @@ type ReloadAction struct {
 	Type        *string `json:"type,omitempty"`
 }
 
+// ReplayResponse defines model for ReplayResponse.
+type ReplayResponse struct {
+	ExpiresAt       string  `json:"expires_at"`
+	Mp4Url          *string `json:"mp4_url,omitempty"`
+	PlaylistContent *string `json:"playlist_content,omitempty"`
+	VideoDurationMs *int    `json:"video_duration_ms,omitempty"`
+	VideoStartMs    *int    `json:"video_start_ms,omitempty"`
+}
+
 // RootModelUnionDictStrAnyListDictStrAny defines model for RootModel_Union_dict_str__Any___list_dict_str__Any____.
 type RootModelUnionDictStrAnyListDictStrAny struct {
 	union json.RawMessage
@@ -2524,12 +2546,6 @@ type WebSocketUrls struct {
 	Recording string `json:"recording"`
 }
 
-// WorkflowScheduleCreateRequest defines model for WorkflowScheduleCreateRequest.
-type WorkflowScheduleCreateRequest struct {
-	Cron      string                  `json:"cron"`
-	Variables *map[string]interface{} `json:"variables,omitempty"`
-}
-
 // ListAgentsParams defines parameters for ListAgents.
 type ListAgentsParams struct {
 	// Page Page number
@@ -2562,12 +2578,6 @@ type AgentStatusParams struct {
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
 
-// AgentReplayParams defines parameters for AgentReplay.
-type AgentReplayParams struct {
-	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
-	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
-}
-
 // AgentStopParams defines parameters for AgentStop.
 type AgentStopParams struct {
 	SessionId           string  `form:"session_id" json:"session_id"`
@@ -2582,6 +2592,12 @@ type GetScriptParams struct {
 
 	// InferResponseFormat Whether to infer response_format schema for scrape calls that have instructions but no schema
 	InferResponseFormat *bool   `form:"infer_response_format,omitempty" json:"infer_response_format,omitempty"`
+	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
+	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
+}
+
+// AnythingStartParams defines parameters for AnythingStart.
+type AnythingStartParams struct {
 	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
@@ -2605,7 +2621,7 @@ type ListFunctionsParams struct {
 
 // FunctionCreateParams defines parameters for FunctionCreate.
 type FunctionCreateParams struct {
-	// Restricted Whether to restrict the workflow code
+	// Restricted Whether to restrict the function code
 	Restricted          *bool   `form:"restricted,omitempty" json:"restricted,omitempty"`
 	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
@@ -2886,8 +2902,8 @@ type PageScreenshotParams struct {
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
 
-// SessionReplayParams defines parameters for SessionReplay.
-type SessionReplayParams struct {
+// GetSessionReplayParams defines parameters for GetSessionReplay.
+type GetSessionReplayParams struct {
 	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
@@ -3033,6 +3049,9 @@ type VaultCredentialsAddParams struct {
 // AgentStartJSONRequestBody defines body for AgentStart for application/json ContentType.
 type AgentStartJSONRequestBody = ApiAgentStartRequest
 
+// AnythingStartJSONRequestBody defines body for AnythingStart for application/json ContentType.
+type AnythingStartJSONRequestBody = AnythingStartRequest
+
 // FunctionCreateMultipartRequestBody defines body for FunctionCreate for multipart/form-data ContentType.
 type FunctionCreateMultipartRequestBody = BodyFunctionCreateFunctionsPost
 
@@ -3046,7 +3065,7 @@ type FunctionRunStartJSONRequestBody = RunFunctionRequest
 type FunctionRunUpdateMetadataJSONRequestBody = FunctionRunUpdateRequest
 
 // FunctionScheduleSetJSONRequestBody defines body for FunctionScheduleSet for application/json ContentType.
-type FunctionScheduleSetJSONRequestBody = WorkflowScheduleCreateRequest
+type FunctionScheduleSetJSONRequestBody = FunctionScheduleCreateRequest
 
 // PersonaCreateJSONRequestBody defines body for PersonaCreate for application/json ContentType.
 type PersonaCreateJSONRequestBody = PersonaCreateRequest
@@ -8046,14 +8065,16 @@ type ClientInterface interface {
 	// AgentStatus request
 	AgentStatus(ctx context.Context, agentId string, params *AgentStatusParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// AgentReplay request
-	AgentReplay(ctx context.Context, agentId string, params *AgentReplayParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// AgentStop request
 	AgentStop(ctx context.Context, agentId string, params *AgentStopParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetScript request
 	GetScript(ctx context.Context, agentId string, params *GetScriptParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// AnythingStartWithBody request with any body
+	AnythingStartWithBody(ctx context.Context, params *AnythingStartParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	AnythingStart(ctx context.Context, params *AnythingStartParams, body AnythingStartJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListFunctions request
 	ListFunctions(ctx context.Context, params *ListFunctionsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8183,8 +8204,8 @@ type ClientInterface interface {
 	// PageScreenshot request
 	PageScreenshot(ctx context.Context, sessionId string, params *PageScreenshotParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// SessionReplay request
-	SessionReplay(ctx context.Context, sessionId string, params *SessionReplayParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetSessionReplay request
+	GetSessionReplay(ctx context.Context, sessionId string, params *GetSessionReplayParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SessionStop request
 	SessionStop(ctx context.Context, sessionId string, params *SessionStopParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -8292,18 +8313,6 @@ func (c *Client) AgentStatus(ctx context.Context, agentId string, params *AgentS
 	return c.Client.Do(req)
 }
 
-func (c *Client) AgentReplay(ctx context.Context, agentId string, params *AgentReplayParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewAgentReplayRequest(c.Server, agentId, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) AgentStop(ctx context.Context, agentId string, params *AgentStopParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewAgentStopRequest(c.Server, agentId, params)
 	if err != nil {
@@ -8318,6 +8327,30 @@ func (c *Client) AgentStop(ctx context.Context, agentId string, params *AgentSto
 
 func (c *Client) GetScript(ctx context.Context, agentId string, params *GetScriptParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetScriptRequest(c.Server, agentId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AnythingStartWithBody(ctx context.Context, params *AnythingStartParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAnythingStartRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) AnythingStart(ctx context.Context, params *AnythingStartParams, body AnythingStartJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewAnythingStartRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -8880,8 +8913,8 @@ func (c *Client) PageScreenshot(ctx context.Context, sessionId string, params *P
 	return c.Client.Do(req)
 }
 
-func (c *Client) SessionReplay(ctx context.Context, sessionId string, params *SessionReplayParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSessionReplayRequest(c.Server, sessionId, params)
+func (c *Client) GetSessionReplay(ctx context.Context, sessionId string, params *GetSessionReplayParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSessionReplayRequest(c.Server, sessionId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -9397,66 +9430,6 @@ func NewAgentStatusRequest(server string, agentId string, params *AgentStatusPar
 	return req, nil
 }
 
-// NewAgentReplayRequest generates requests for AgentReplay
-func NewAgentReplayRequest(server string, agentId string, params *AgentReplayParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "agent_id", runtime.ParamLocationPath, agentId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/agents/%s/replay", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-
-		if params.XNotteRequestOrigin != nil {
-			var headerParam0 string
-
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-request-origin", headerParam0)
-		}
-
-		if params.XNotteSdkVersion != nil {
-			var headerParam1 string
-
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-sdk-version", headerParam1)
-		}
-
-	}
-
-	return req, nil
-}
-
 // NewAgentStopRequest generates requests for AgentStop
 func NewAgentStopRequest(server string, agentId string, params *AgentStopParams) (*http.Request, error) {
 	var err error
@@ -9599,6 +9572,72 @@ func NewGetScriptRequest(server string, agentId string, params *GetScriptParams)
 	if err != nil {
 		return nil, err
 	}
+
+	if params != nil {
+
+		if params.XNotteRequestOrigin != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-request-origin", headerParam0)
+		}
+
+		if params.XNotteSdkVersion != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-sdk-version", headerParam1)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewAnythingStartRequest calls the generic AnythingStart builder with application/json body
+func NewAnythingStartRequest(server string, params *AnythingStartParams, body AnythingStartJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewAnythingStartRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewAnythingStartRequestWithBody generates requests for AnythingStart with any type of body
+func NewAnythingStartRequestWithBody(server string, params *AnythingStartParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/anything/start")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -12442,8 +12481,8 @@ func NewPageScreenshotRequest(server string, sessionId string, params *PageScree
 	return req, nil
 }
 
-// NewSessionReplayRequest generates requests for SessionReplay
-func NewSessionReplayRequest(server string, sessionId string, params *SessionReplayParams) (*http.Request, error) {
+// NewGetSessionReplayRequest generates requests for GetSessionReplay
+func NewGetSessionReplayRequest(server string, sessionId string, params *GetSessionReplayParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -13846,14 +13885,16 @@ type ClientWithResponsesInterface interface {
 	// AgentStatusWithResponse request
 	AgentStatusWithResponse(ctx context.Context, agentId string, params *AgentStatusParams, reqEditors ...RequestEditorFn) (*AgentStatusResult, error)
 
-	// AgentReplayWithResponse request
-	AgentReplayWithResponse(ctx context.Context, agentId string, params *AgentReplayParams, reqEditors ...RequestEditorFn) (*AgentReplayResult, error)
-
 	// AgentStopWithResponse request
 	AgentStopWithResponse(ctx context.Context, agentId string, params *AgentStopParams, reqEditors ...RequestEditorFn) (*AgentStopResult, error)
 
 	// GetScriptWithResponse request
 	GetScriptWithResponse(ctx context.Context, agentId string, params *GetScriptParams, reqEditors ...RequestEditorFn) (*GetScriptResult, error)
+
+	// AnythingStartWithBodyWithResponse request with any body
+	AnythingStartWithBodyWithResponse(ctx context.Context, params *AnythingStartParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AnythingStartResult, error)
+
+	AnythingStartWithResponse(ctx context.Context, params *AnythingStartParams, body AnythingStartJSONRequestBody, reqEditors ...RequestEditorFn) (*AnythingStartResult, error)
 
 	// ListFunctionsWithResponse request
 	ListFunctionsWithResponse(ctx context.Context, params *ListFunctionsParams, reqEditors ...RequestEditorFn) (*ListFunctionsResult, error)
@@ -13983,8 +14024,8 @@ type ClientWithResponsesInterface interface {
 	// PageScreenshotWithResponse request
 	PageScreenshotWithResponse(ctx context.Context, sessionId string, params *PageScreenshotParams, reqEditors ...RequestEditorFn) (*PageScreenshotResult, error)
 
-	// SessionReplayWithResponse request
-	SessionReplayWithResponse(ctx context.Context, sessionId string, params *SessionReplayParams, reqEditors ...RequestEditorFn) (*SessionReplayResult, error)
+	// GetSessionReplayWithResponse request
+	GetSessionReplayWithResponse(ctx context.Context, sessionId string, params *GetSessionReplayParams, reqEditors ...RequestEditorFn) (*GetSessionReplayResult, error)
 
 	// SessionStopWithResponse request
 	SessionStopWithResponse(ctx context.Context, sessionId string, params *SessionStopParams, reqEditors ...RequestEditorFn) (*SessionStopResult, error)
@@ -14113,28 +14154,6 @@ func (r AgentStatusResult) StatusCode() int {
 	return 0
 }
 
-type AgentReplayResult struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON422      *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r AgentReplayResult) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r AgentReplayResult) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type AgentStopResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -14175,6 +14194,29 @@ func (r GetScriptResult) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetScriptResult) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type AnythingStartResult struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r AnythingStartResult) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r AnythingStartResult) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -15008,14 +15050,15 @@ func (r PageScreenshotResult) StatusCode() int {
 	return 0
 }
 
-type SessionReplayResult struct {
+type GetSessionReplayResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON200      *ReplayResponse
 	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r SessionReplayResult) Status() string {
+func (r GetSessionReplayResult) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -15023,7 +15066,7 @@ func (r SessionReplayResult) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r SessionReplayResult) StatusCode() int {
+func (r GetSessionReplayResult) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -15458,15 +15501,6 @@ func (c *ClientWithResponses) AgentStatusWithResponse(ctx context.Context, agent
 	return ParseAgentStatusResult(rsp)
 }
 
-// AgentReplayWithResponse request returning *AgentReplayResult
-func (c *ClientWithResponses) AgentReplayWithResponse(ctx context.Context, agentId string, params *AgentReplayParams, reqEditors ...RequestEditorFn) (*AgentReplayResult, error) {
-	rsp, err := c.AgentReplay(ctx, agentId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseAgentReplayResult(rsp)
-}
-
 // AgentStopWithResponse request returning *AgentStopResult
 func (c *ClientWithResponses) AgentStopWithResponse(ctx context.Context, agentId string, params *AgentStopParams, reqEditors ...RequestEditorFn) (*AgentStopResult, error) {
 	rsp, err := c.AgentStop(ctx, agentId, params, reqEditors...)
@@ -15483,6 +15517,23 @@ func (c *ClientWithResponses) GetScriptWithResponse(ctx context.Context, agentId
 		return nil, err
 	}
 	return ParseGetScriptResult(rsp)
+}
+
+// AnythingStartWithBodyWithResponse request with arbitrary body returning *AnythingStartResult
+func (c *ClientWithResponses) AnythingStartWithBodyWithResponse(ctx context.Context, params *AnythingStartParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*AnythingStartResult, error) {
+	rsp, err := c.AnythingStartWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAnythingStartResult(rsp)
+}
+
+func (c *ClientWithResponses) AnythingStartWithResponse(ctx context.Context, params *AnythingStartParams, body AnythingStartJSONRequestBody, reqEditors ...RequestEditorFn) (*AnythingStartResult, error) {
+	rsp, err := c.AnythingStart(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseAnythingStartResult(rsp)
 }
 
 // ListFunctionsWithResponse request returning *ListFunctionsResult
@@ -15889,13 +15940,13 @@ func (c *ClientWithResponses) PageScreenshotWithResponse(ctx context.Context, se
 	return ParsePageScreenshotResult(rsp)
 }
 
-// SessionReplayWithResponse request returning *SessionReplayResult
-func (c *ClientWithResponses) SessionReplayWithResponse(ctx context.Context, sessionId string, params *SessionReplayParams, reqEditors ...RequestEditorFn) (*SessionReplayResult, error) {
-	rsp, err := c.SessionReplay(ctx, sessionId, params, reqEditors...)
+// GetSessionReplayWithResponse request returning *GetSessionReplayResult
+func (c *ClientWithResponses) GetSessionReplayWithResponse(ctx context.Context, sessionId string, params *GetSessionReplayParams, reqEditors ...RequestEditorFn) (*GetSessionReplayResult, error) {
+	rsp, err := c.GetSessionReplay(ctx, sessionId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseSessionReplayResult(rsp)
+	return ParseGetSessionReplayResult(rsp)
 }
 
 // SessionStopWithResponse request returning *SessionStopResult
@@ -16174,32 +16225,6 @@ func ParseAgentStatusResult(rsp *http.Response) (*AgentStatusResult, error) {
 	return response, nil
 }
 
-// ParseAgentReplayResult parses an HTTP response from a AgentReplayWithResponse call
-func ParseAgentReplayResult(rsp *http.Response) (*AgentReplayResult, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &AgentReplayResult{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest HTTPValidationError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseAgentStopResult parses an HTTP response from a AgentStopWithResponse call
 func ParseAgentStopResult(rsp *http.Response) (*AgentStopResult, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -16249,6 +16274,39 @@ func ParseGetScriptResult(rsp *http.Response) (*GetScriptResult, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AgentFunctionCodeResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseAnythingStartResult parses an HTTP response from a AnythingStartWithResponse call
+func ParseAnythingStartResult(rsp *http.Response) (*AnythingStartResult, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &AnythingStartResult{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17447,20 +17505,27 @@ func ParsePageScreenshotResult(rsp *http.Response) (*PageScreenshotResult, error
 	return response, nil
 }
 
-// ParseSessionReplayResult parses an HTTP response from a SessionReplayWithResponse call
-func ParseSessionReplayResult(rsp *http.Response) (*SessionReplayResult, error) {
+// ParseGetSessionReplayResult parses an HTTP response from a GetSessionReplayWithResponse call
+func ParseGetSessionReplayResult(rsp *http.Response) (*GetSessionReplayResult, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &SessionReplayResult{
+	response := &GetSessionReplayResult{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ReplayResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/internal/cmd/agents.go
+++ b/internal/cmd/agents.go
@@ -389,8 +389,26 @@ func runAgentReplay(cmd *cobra.Command, args []string) error {
 	ctx, cancel := GetContextWithTimeout(cmd.Context())
 	defer cancel()
 
-	params := &api.AgentReplayParams{}
-	resp, err := client.Client().AgentReplayWithResponse(ctx, agentID, params)
+	// Get agent status to find the session ID
+	statusParams := &api.AgentStatusParams{}
+	statusResp, err := client.Client().AgentStatusWithResponse(ctx, agentID, statusParams)
+	if err != nil {
+		return fmt.Errorf("API request failed: %w", err)
+	}
+
+	if err := HandleAPIResponse(statusResp.HTTPResponse, statusResp.Body); err != nil {
+		return err
+	}
+
+	if statusResp.JSON200 == nil {
+		return fmt.Errorf("unexpected empty response from agent status API")
+	}
+
+	agentSessionID := statusResp.JSON200.SessionId
+
+	// Get session replay using the agent's session ID
+	replayParams := &api.GetSessionReplayParams{}
+	resp, err := client.Client().GetSessionReplayWithResponse(ctx, agentSessionID, replayParams)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)
 	}
@@ -399,10 +417,9 @@ func runAgentReplay(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Wrap raw body for formatter compatibility
-	result := map[string]interface{}{
-		"agent_id":    agentID,
-		"replay_data": string(resp.Body),
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected empty response from replay API")
 	}
-	return GetFormatter().Print(result)
+
+	return GetFormatter().Print(resp.JSON200)
 }

--- a/internal/cmd/agents.go
+++ b/internal/cmd/agents.go
@@ -405,6 +405,9 @@ func runAgentReplay(cmd *cobra.Command, args []string) error {
 	}
 
 	agentSessionID := statusResp.JSON200.SessionId
+	if agentSessionID == "" {
+		return fmt.Errorf("agent %s has no associated session ID", agentID)
+	}
 
 	// Get session replay using the agent's session ID
 	replayParams := &api.GetSessionReplayParams{}

--- a/internal/cmd/agents_test.go
+++ b/internal/cmd/agents_test.go
@@ -269,7 +269,10 @@ func TestRunAgentWorkflowCode(t *testing.T) {
 
 func TestRunAgentReplay(t *testing.T) {
 	server := setupAgentTest(t)
-	server.AddResponse("/agents/"+agentIDTest+"/replay", 200, "replay-data")
+	// Mock agent status to return session_id
+	server.AddResponse("/agents/"+agentIDTest, 200, `{"agent_id":"agent_123","session_id":"sess_456","created_at":"2024-01-01T00:00:00Z","status":"closed","task":"test","replay_start_offset":0,"replay_stop_offset":100,"steps":[]}`)
+	// Mock session replay endpoint
+	server.AddResponse("/sessions/sess_456/replay", 200, `{"mp4_url":"https://example.com/video.mp4","expires_at":"2099-01-01T00:00:00Z"}`)
 
 	origFormat := outputFormat
 	outputFormat = "json"

--- a/internal/cmd/agentstart_flags.gen.go
+++ b/internal/cmd/agentstart_flags.gen.go
@@ -67,7 +67,7 @@ var (
 func RegisterAgentStartFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&AgentStartMaxSteps, "max-steps", 0, "The maximum number of steps the agent should take")
 	cmd.Flags().StringVar(&AgentStartPersonaId, "persona-id", "", "The persona to use for the agent")
-	cmd.Flags().StringVar(&AgentStartReasoningModel, "reasoning-model", "", "The reasoning model to use (openai/gpt-4o, gemini/gemini-2.5-flash, vertex_ai/gemini-2.5-flash, openrouter/google/gemma-3-27b-it, cerebras/gpt-oss-120b, groq/gpt-oss-120b, perplexity/sonar-pro, deepseek/deepseek-r1, together_ai/meta-llama/llama-3.3-70b-instruct, anthropic/claude-sonnet-4-5-20250929, moonshot/kimi-k2.5)")
+	cmd.Flags().StringVar(&AgentStartReasoningModel, "reasoning-model", "", "The reasoning model to use (openai/gpt-4o, gemini/gemini-2.5-flash, vertex_ai/gemini-2.5-flash, openrouter/google/gemma-3-27b-it, cerebras/gpt-oss-120b, groq/gpt-oss-120b, perplexity/sonar-pro, deepseek/deepseek-r1, together_ai/meta-llama/llama-3.3-70b-instruct, anthropic/claude-sonnet-4-5-20250929, moonshot/kimi-k2.5, xai/grok-4-1-fast-non-reasoning, minimax/minimax-m2.5)")
 	cmd.Flags().StringVar(&AgentStartResponseFormat, "response-format-json", "", "response-format configuration (JSON file path, e.g., @config.json)")
 	cmd.Flags().StringVar(&AgentStartSessionId, "session-id", "", "The ID of the session to run the agent on")
 	cmd.Flags().IntVar(&AgentStartSessionOffset, "session-offset", 0, "[Experimental] The step from which the agent should gather information from in the session. If none, fresh memory")

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -1115,7 +1115,11 @@ func runSessionReplay(cmd *cobra.Command, args []string) error {
 	}
 
 	// Download the replay video from the presigned URL
-	httpResp, err := http.Get(*replay.Mp4Url) //nolint:gosec // URL is from trusted API response
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, *replay.Mp4Url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create download request: %w", err)
+	}
+	httpResp, err := http.DefaultClient.Do(req) //nolint:gosec // URL is from trusted API response
 	if err != nil {
 		return fmt.Errorf("failed to download replay video: %w", err)
 	}

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -1071,14 +1071,28 @@ func runSessionReplay(cmd *cobra.Command, args []string) error {
 	ctx, cancel := GetContextWithTimeout(cmd.Context())
 	defer cancel()
 
-	params := &api.SessionReplayParams{}
-	resp, err := client.Client().SessionReplayWithResponse(ctx, sessionID, params)
+	params := &api.GetSessionReplayParams{}
+	resp, err := client.Client().GetSessionReplayWithResponse(ctx, sessionID, params)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)
 	}
 
 	if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
 		return err
+	}
+
+	if resp.JSON200 == nil {
+		return fmt.Errorf("unexpected empty response from replay API")
+	}
+
+	replay := resp.JSON200
+
+	// If no mp4_url, return the raw response data
+	if replay.Mp4Url == nil || *replay.Mp4Url == "" {
+		return PrintResult("No replay video available for this session.", map[string]any{
+			"session_id": sessionID,
+			"success":    false,
+		})
 	}
 
 	// Determine output path
@@ -1100,8 +1114,24 @@ func runSessionReplay(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Download the replay video from the presigned URL
+	httpResp, err := http.Get(*replay.Mp4Url) //nolint:gosec // URL is from trusted API response
+	if err != nil {
+		return fmt.Errorf("failed to download replay video: %w", err)
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download replay video: HTTP %d", httpResp.StatusCode)
+	}
+
+	videoData, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read replay video: %w", err)
+	}
+
 	// Write the replay video file
-	err = os.WriteFile(outputPath, resp.Body, 0o644)
+	err = os.WriteFile(outputPath, videoData, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to write replay video: %w", err)
 	}

--- a/internal/cmd/sessions_test.go
+++ b/internal/cmd/sessions_test.go
@@ -748,7 +748,11 @@ func TestRunSessionNetwork(t *testing.T) {
 
 func TestRunSessionReplay(t *testing.T) {
 	server := setupSessionTest(t)
-	server.AddResponse("/sessions/"+sessionIDTest+"/replay", 200, `replay-data`)
+	// Mock the mp4 download endpoint
+	server.AddResponseWithHeaders("/replay-video.mp4", 200, "fake-video-data", map[string]string{"Content-Type": "video/mp4"})
+	// Return ReplayResponse JSON with mp4_url pointing to mock server
+	replayJSON := fmt.Sprintf(`{"mp4_url":"%s/replay-video.mp4","expires_at":"2099-01-01T00:00:00Z"}`, server.URL())
+	server.AddResponse("/sessions/"+sessionIDTest+"/replay", 200, replayJSON)
 
 	origFormat := outputFormat
 	outputFormat = "json"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the replay flow for both sessions and agents by replacing the old `AgentReplay` / `SessionReplay` API paths with a unified `GetSessionReplay` endpoint that returns a typed `ReplayResponse` (containing a presigned `mp4_url`). `runSessionReplay` now downloads the video from the presigned URL and saves it to disk, while `runAgentReplay` adds a preliminary agent-status lookup to resolve the `session_id` before delegating to the same endpoint. Both previously-flagged issues (missing empty-`session_id` guard and context-unaware HTTP download) have been resolved in this revision.

Key changes:
- `runAgentReplay` now fetches agent status first to obtain the `session_id`, with an explicit guard for an empty ID, then calls `GetSessionReplayWithResponse`
- `runSessionReplay` parses the structured `ReplayResponse`, gracefully handles a missing `mp4_url`, and downloads the video using a context-aware `http.NewRequestWithContext` call
- Generated client updated: `SessionReplay` → `GetSessionReplay`, `AgentReplay` removed, `ReplayResponse` type added, two new LLM model constants added
- Tests updated to mock both the status and replay endpoints, and the video download endpoint

<h3>Confidence Score: 5/5</h3>

- Safe to merge — both previously-flagged concerns are resolved and the single remaining P2 is a non-blocking memory optimisation.
- All critical issues from prior review rounds (empty `session_id` guard and context-less HTTP download) have been addressed. The only remaining note is a P2 best-practice suggestion to stream the video with `io.Copy` instead of buffering it entirely in memory with `io.ReadAll`, which does not affect correctness for typical file sizes.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cmd/sessions.go | Refactored `runSessionReplay` to parse a `ReplayResponse` JSON object, extract the presigned `mp4_url`, and download the video using a context-aware HTTP request. A minor memory concern exists: the full video is buffered in-memory via `io.ReadAll` before writing to disk. |
| internal/cmd/agents.go | Rewrote `runAgentReplay` to first fetch agent status for the `session_id`, then delegate to the `GetSessionReplay` endpoint. Previous concerns (empty session ID guard) are now properly addressed. |
| internal/cmd/agents_test.go | Updated `TestRunAgentReplay` to mock both the agent status endpoint and the session replay endpoint, accurately reflecting the new two-step lookup. |
| internal/cmd/sessions_test.go | Updated `TestRunSessionReplay` to mock the `ReplayResponse` JSON and the presigned video download endpoint, keeping tests in sync with the new download flow. |
| internal/api/client.gen.go | Generated file — renames `SessionReplay` → `GetSessionReplay`, removes `AgentReplay`, adds `AnythingStart`, `ReplayResponse`, and new LLM model constants. No issues; changes are consistent with the API evolution. |
| internal/cmd/agentstart_flags.gen.go | Generated file — adds `xai/grok-4-1-fast-non-reasoning` and `minimax/minimax-m2.5` to the `--reasoning-model` help text. Trivial, no issues. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/cmd/sessions.go
Line: 1132-1138

Comment:
**Buffer entire video in memory before writing**

`io.ReadAll` reads the full video body into a `[]byte` before `os.WriteFile` flushes it to disk. For large replay recordings this doubles the peak memory usage. Streaming directly to the file with `io.Copy` would avoid the extra allocation:

```suggestion
	// Write the replay video file
	f, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
	if err != nil {
		return fmt.Errorf("failed to write replay video: %w", err)
	}
	defer func() { _ = f.Close() }()

	if _, err = io.Copy(f, httpResp.Body); err != nil {
		return fmt.Errorf("failed to write replay video: %w", err)
	}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: Video download ignores command cont..."](https://github.com/nottelabs/notte-cli/commit/0bc07ff29ba475a4aadc1d4b680894d557475e15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=21121165)</sub>

<!-- /greptile_comment -->