### PR TITLE
Fix text formatter for struct slices and regenerate API client

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -467,9 +467,6 @@ type AgentResponse struct {
 	// CreatedAt The creation time of the agent
 	CreatedAt FlexibleTime `json:"created_at"`
 
-	// CreditUsage Credit usage for the agent. None if the agent is still running
-	CreditUsage *float32 `json:"credit_usage,omitempty"`
-
 	// Saved Whether the agent is saved as a workflow
 	Saved *bool `json:"saved,omitempty"`
 
@@ -494,18 +491,6 @@ type AgentStatusResponse struct {
 
 	// CreatedAt The creation time of the agent
 	CreatedAt FlexibleTime `json:"created_at"`
-
-	// CreditUsage Credit usage for the agent. None if the agent is still running
-	CreditUsage *float32 `json:"credit_usage,omitempty"`
-
-	// Replay The session replay in `.webp` format
-	Replay *string `json:"replay,omitempty"`
-
-	// ReplayStartOffset The start offset of the replay
-	ReplayStartOffset int `json:"replay_start_offset"`
-
-	// ReplayStopOffset The stop offset of the replay
-	ReplayStopOffset int `json:"replay_stop_offset"`
 
 	// Saved Whether the agent is saved as a workflow
 	Saved *bool `json:"saved,omitempty"`
@@ -1594,18 +1579,6 @@ type LegacyAgentStatusResponse struct {
 	// CreatedAt The creation time of the agent
 	CreatedAt FlexibleTime `json:"created_at"`
 
-	// CreditUsage Credit usage for the agent. None if the agent is still running
-	CreditUsage *float32 `json:"credit_usage,omitempty"`
-
-	// Replay The session replay in `.webp` format
-	Replay *string `json:"replay,omitempty"`
-
-	// ReplayStartOffset The start offset of the replay
-	ReplayStartOffset int `json:"replay_start_offset"`
-
-	// ReplayStopOffset The stop offset of the replay
-	ReplayStopOffset int `json:"replay_stop_offset"`
-
 	// Saved Whether the agent is saved as a workflow
 	Saved *bool `json:"saved,omitempty"`
 
@@ -2228,9 +2201,6 @@ type SessionResponse struct {
 
 	// CreatedAt Session creation time
 	CreatedAt FlexibleTime `json:"created_at"`
-
-	// CreditUsage Credit usage for the session. None
-	CreditUsage *float32 `json:"credit_usage,omitempty"`
 
 	// Duration Session duration
 	Duration *string `json:"duration,omitempty"`

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -274,6 +274,121 @@ func TestTextFormatter_Print_PointerField(t *testing.T) {
 	})
 }
 
+func TestTextFormatter_Print_StructWithSliceOfStructs(t *testing.T) {
+	type ParameterInfo struct {
+		Default *string
+		Name    string
+		Type    *string
+	}
+
+	type FunctionResponse struct {
+		Name      string
+		Variables []ParameterInfo
+		Versions  []string
+	}
+
+	t.Run("slice of structs with pointer fields", func(t *testing.T) {
+		var buf bytes.Buffer
+		f := &TextFormatter{Writer: &buf, NoColor: true}
+
+		typeStr := "string"
+		defaultVal := "today"
+		data := FunctionResponse{
+			Name: "my-function",
+			Variables: []ParameterInfo{
+				{Name: "restaurant_id"},
+				{Name: "date", Type: &typeStr, Default: &defaultVal},
+				{Name: "party_size"},
+			},
+			Versions: []string{"v1", "v2"},
+		}
+
+		err := f.Print(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		output := buf.String()
+
+		// Must NOT contain memory addresses
+		if strings.Contains(output, "0x") {
+			t.Errorf("expected no memory addresses in output, got %q", output)
+		}
+
+		// Must contain the variable names
+		if !strings.Contains(output, "restaurant_id") {
+			t.Errorf("expected 'restaurant_id' in output, got %q", output)
+		}
+		if !strings.Contains(output, "date") {
+			t.Errorf("expected 'date' in output, got %q", output)
+		}
+		if !strings.Contains(output, "party_size") {
+			t.Errorf("expected 'party_size' in output, got %q", output)
+		}
+
+		// Must contain optional fields when set
+		if !strings.Contains(output, "string") {
+			t.Errorf("expected Type 'string' in output, got %q", output)
+		}
+		if !strings.Contains(output, "today") {
+			t.Errorf("expected Default 'today' in output, got %q", output)
+		}
+
+		// Must still contain the Versions field properly
+		if !strings.Contains(output, "v1") || !strings.Contains(output, "v2") {
+			t.Errorf("expected versions in output, got %q", output)
+		}
+
+		// Must contain the Variables label
+		if !strings.Contains(output, "Variables:") {
+			t.Errorf("expected 'Variables:' label in output, got %q", output)
+		}
+	})
+
+	t.Run("empty slice of structs", func(t *testing.T) {
+		var buf bytes.Buffer
+		f := &TextFormatter{Writer: &buf, NoColor: true}
+
+		data := FunctionResponse{
+			Name:      "my-function",
+			Variables: []ParameterInfo{},
+			Versions:  []string{"v1"},
+		}
+
+		err := f.Print(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		output := buf.String()
+		if strings.Contains(output, "0x") {
+			t.Errorf("expected no memory addresses in output, got %q", output)
+		}
+	})
+
+	t.Run("nil slice of structs is hidden", func(t *testing.T) {
+		var buf bytes.Buffer
+		f := &TextFormatter{Writer: &buf, NoColor: true}
+
+		data := FunctionResponse{
+			Name:      "my-function",
+			Variables: nil,
+			Versions:  []string{"v1"},
+		}
+
+		err := f.Print(data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		output := buf.String()
+		// Nil slices should be skipped entirely
+		if strings.Contains(output, "Variables:") {
+			t.Errorf("expected nil Variables to be hidden, got %q", output)
+		}
+	})
+}
+
 func TestTextFormatter_PrintError(t *testing.T) {
 	var buf bytes.Buffer
 	f := &TextFormatter{Writer: &buf, NoColor: true}

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -112,7 +112,9 @@ func (f *TextFormatter) printStructWithIndent(data any, indent string) error {
 		// Handle slices of structs with readable formatting
 		if fieldValue.Kind() == reflect.Slice {
 			_ = w.Flush()
-			f.printSliceField(fieldValue, label, indent)
+			if err := f.printSliceField(fieldValue, label, indent); err != nil {
+				return err
+			}
 			w = tabwriter.NewWriter(f.Writer, 0, 0, 2, ' ', 0)
 			continue
 		}
@@ -123,10 +125,10 @@ func (f *TextFormatter) printStructWithIndent(data any, indent string) error {
 	return w.Flush()
 }
 
-func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent string) {
+func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent string) error {
 	if v.Len() == 0 {
-		_, _ = fmt.Fprintf(f.Writer, "%s\t[]\n", label)
-		return
+		_, err := fmt.Fprintf(f.Writer, "%s\t[]\n", label)
+		return err
 	}
 
 	// Check if it's a slice of structs
@@ -135,18 +137,24 @@ func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent st
 		elemType = elemType.Elem()
 	}
 	if elemType.Kind() == reflect.Struct {
-		_, _ = fmt.Fprintln(f.Writer, label)
+		if _, err := fmt.Fprintln(f.Writer, label); err != nil {
+			return err
+		}
 		for i := 0; i < v.Len(); i++ {
 			elem := v.Index(i)
 			if elem.Kind() == reflect.Ptr {
 				elem = elem.Elem()
 			}
 			if i > 0 {
-				_, _ = fmt.Fprintln(f.Writer)
+				if _, err := fmt.Fprintln(f.Writer); err != nil {
+					return err
+				}
 			}
-			_ = f.printStructWithIndent(elem.Interface(), indent+"  ")
+			if err := f.printStructWithIndent(elem.Interface(), indent+"  "); err != nil {
+				return err
+			}
 		}
-		return
+		return nil
 	}
 
 	// For slices of primitives, join as comma-separated
@@ -154,7 +162,8 @@ func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent st
 	for i := 0; i < v.Len(); i++ {
 		items[i] = fmt.Sprintf("%v", v.Index(i).Interface())
 	}
-	_, _ = fmt.Fprintf(f.Writer, "%s\t[%s]\n", label, strings.Join(items, ", "))
+	_, err := fmt.Fprintf(f.Writer, "%s\t[%s]\n", label, strings.Join(items, ", "))
+	return err
 }
 
 func (f *TextFormatter) printSlice(data any) error {

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -125,7 +125,7 @@ func (f *TextFormatter) printStructWithIndent(data any, indent string) error {
 
 func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent string) {
 	if v.Len() == 0 {
-		fmt.Fprintf(f.Writer, "%s\t[]\n", label)
+		_, _ = fmt.Fprintf(f.Writer, "%s\t[]\n", label)
 		return
 	}
 
@@ -135,14 +135,14 @@ func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent st
 		elemType = elemType.Elem()
 	}
 	if elemType.Kind() == reflect.Struct {
-		fmt.Fprintln(f.Writer, label)
+		_, _ = fmt.Fprintln(f.Writer, label)
 		for i := 0; i < v.Len(); i++ {
 			elem := v.Index(i)
 			if elem.Kind() == reflect.Ptr {
 				elem = elem.Elem()
 			}
 			if i > 0 {
-				fmt.Fprintln(f.Writer)
+				_, _ = fmt.Fprintln(f.Writer)
 			}
 			_ = f.printStructWithIndent(elem.Interface(), indent+"  ")
 		}
@@ -154,7 +154,7 @@ func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent st
 	for i := 0; i < v.Len(); i++ {
 		items[i] = fmt.Sprintf("%v", v.Index(i).Interface())
 	}
-	fmt.Fprintf(f.Writer, "%s\t[%s]\n", label, strings.Join(items, ", "))
+	_, _ = fmt.Fprintf(f.Writer, "%s\t[%s]\n", label, strings.Join(items, ", "))
 }
 
 func (f *TextFormatter) printSlice(data any) error {

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -109,10 +109,52 @@ func (f *TextFormatter) printStructWithIndent(data any, indent string) error {
 			continue
 		}
 
+		// Handle slices of structs with readable formatting
+		if fieldValue.Kind() == reflect.Slice {
+			_ = w.Flush()
+			f.printSliceField(fieldValue, label, indent)
+			w = tabwriter.NewWriter(f.Writer, 0, 0, 2, ' ', 0)
+			continue
+		}
+
 		_, _ = fmt.Fprintf(w, "%s\t%v\n", label, fieldValue.Interface())
 	}
 
 	return w.Flush()
+}
+
+func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent string) {
+	if v.Len() == 0 {
+		fmt.Fprintf(f.Writer, "%s\t[]\n", label)
+		return
+	}
+
+	// Check if it's a slice of structs
+	elemType := v.Type().Elem()
+	if elemType.Kind() == reflect.Ptr {
+		elemType = elemType.Elem()
+	}
+	if elemType.Kind() == reflect.Struct {
+		fmt.Fprintln(f.Writer, label)
+		for i := 0; i < v.Len(); i++ {
+			elem := v.Index(i)
+			if elem.Kind() == reflect.Ptr {
+				elem = elem.Elem()
+			}
+			if i > 0 {
+				fmt.Fprintln(f.Writer)
+			}
+			_ = f.printStructWithIndent(elem.Interface(), indent+"  ")
+		}
+		return
+	}
+
+	// For slices of primitives, join as comma-separated
+	items := make([]string, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		items[i] = fmt.Sprintf("%v", v.Index(i).Interface())
+	}
+	fmt.Fprintf(f.Writer, "%s\t[%s]\n", label, strings.Join(items, ", "))
 }
 
 func (f *TextFormatter) printSlice(data any) error {


### PR DESCRIPTION
- Render slices of structs with readable field output instead of memory addresses
- Join primitive slices as comma-separated values
- Remove deprecated credit_usage and replay fields from generated client

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the text formatter to render slices of structs with human-readable field output (instead of memory addresses) and joins primitive slices as comma-separated values, with corresponding test coverage. It also regenerates the API client to remove deprecated `credit_usage`, `replay`, and related fields from response types.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core logic is correct and well-tested, with only a minor column-alignment cosmetic issue remaining

The only open finding is a P2 formatting nit: primitive-slice rows bypass the tabwriter and won't align with sibling fields. No P0/P1 defects remain, and the previously flagged error-propagation concern from the earlier review thread is fully resolved in this PR.

internal/output/text.go — primitive-slice formatting written directly to f.Writer instead of through the tabwriter

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/output/text.go | Adds printSliceField to handle struct-slice and primitive-slice rendering; primitive slices bypass the tabwriter so their tab separator won't align with tabwriter-formatted sibling fields |
| internal/output/output_test.go | Adds three thorough subtests for slice-of-structs rendering: non-empty with pointer fields, empty slice, and nil slice; coverage looks good |
| internal/api/client.gen.go | Removes deprecated credit_usage, replay, replay_start_offset, and replay_stop_offset fields from AgentResponse, AgentStatusResponse, LegacyAgentStatusResponse, and SessionResponse; straightforward schema regeneration |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ainternal%2Foutput%2Ftext.go%3A164-166%0A**Primitive-slice%20output%20bypasses%20tabwriter%20alignment**%0A%0A%60printSliceField%60%20writes%20primitive-slice%20values%20%28and%20empty%20slices%29%20directly%20to%20%60f.Writer%60%20with%20a%20literal%20%60%5Ct%60%2C%20while%20all%20sibling%20non-slice%20fields%20go%20through%20a%20%60tabwriter%60.%20When%20a%20struct%20has%20both%20kinds%20of%20fields%2C%20the%20primitive-slice%20row%20won't%20column-align%20with%20the%20rest.%20A%20simple%20fix%20is%20to%20route%20this%20output%20through%20the%20caller's%20tabwriter%20%E2%80%94%20either%20by%20returning%20a%20formatted%20string%20to%20be%20written%20via%20%60w%60%2C%20or%20by%20accepting%20the%20%60tabwriter.Writer%60%20as%20a%20parameter.%0A%0A%60%60%60go%0A%2F%2F%20Example%3A%20write%20into%20the%20shared%20tabwriter%20w%20in%20printStructWithIndent%0A_%2C%20_%20%3D%20fmt.Fprintf%28w%2C%20%22%25s%5Ct%5B%25s%5D%5Cn%22%2C%20label%2C%20strings.Join%28items%2C%20%22%2C%20%22%29%29%0A%60%60%60%0A%0A&repo=nottelabs%2Fnotte-cli"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/output/text.go
Line: 164-166

Comment:
**Primitive-slice output bypasses tabwriter alignment**

`printSliceField` writes primitive-slice values (and empty slices) directly to `f.Writer` with a literal `\t`, while all sibling non-slice fields go through a `tabwriter`. When a struct has both kinds of fields, the primitive-slice row won't column-align with the rest. A simple fix is to route this output through the caller's tabwriter — either by returning a formatted string to be written via `w`, or by accepting the `tabwriter.Writer` as a parameter.

```go
// Example: write into the shared tabwriter w in printStructWithIndent
_, _ = fmt.Fprintf(w, "%s\t[%s]\n", label, strings.Join(items, ", "))
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["Propagate errors from printSliceField in..."](https://github.com/nottelabs/notte-cli/commit/3e376509fdb74d81ee7365b14ee8d631b14a6f7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=21121997)</sub>

<!-- /greptile_comment -->