### PR TITLE
Add CLI version update check and upgrade prompt

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nottelabs/notte-cli/internal/auth"
 	"github.com/nottelabs/notte-cli/internal/config"
 	"github.com/nottelabs/notte-cli/internal/output"
+	"github.com/nottelabs/notte-cli/internal/update"
 )
 
 var (
@@ -43,7 +44,24 @@ Get started:
 
 // Execute runs the CLI
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	// Start background update check (nil-safe; returns nil for dev builds)
+	checker := update.NewChecker(Version)
+	if checker != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		go checker.Run(ctx)
+	}
+
+	err := rootCmd.Execute()
+
+	// Show update notification after command output
+	if checker != nil {
+		if result := checker.GetResult(); result != nil {
+			update.PrintUpdateNotification(result, os.Stderr, os.Stdin, yesFlag, IsJSONOutput(), noColor)
+		}
+	}
+
+	if err != nil {
 		formatter := GetFormatter()
 		formatter.PrintError(err)
 		os.Exit(1)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ const (
 	EnvSessionID             = "NOTTE_SESSION_ID"
 	EnvFunctionID            = "NOTTE_FUNCTION_ID"
 	EnvAgentID               = "NOTTE_AGENT_ID"
+	EnvNoUpdateCheck         = "NOTTE_NO_UPDATE_CHECK"
 )
 
 // testConfigDir allows overriding the config directory for testing.

--- a/internal/update/cache.go
+++ b/internal/update/cache.go
@@ -1,0 +1,66 @@
+package update
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// CacheFileName is the name of the update check cache file.
+	CacheFileName = "update_check.json"
+	// CheckInterval is how often the CLI checks for updates.
+	CheckInterval = 24 * time.Hour
+)
+
+// UpdateCache holds the cached result of the latest version check.
+type UpdateCache struct {
+	LatestVersion  string    `json:"latest_version"`
+	CurrentVersion string    `json:"current_version"`
+	CheckedAt      time.Time `json:"checked_at"`
+	ReleaseURL     string    `json:"release_url,omitempty"`
+}
+
+// LoadCache reads the cache file from the config directory.
+// Returns nil with no error if the file doesn't exist.
+func LoadCache(configDir string) (*UpdateCache, error) {
+	path := filepath.Join(configDir, CacheFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var cache UpdateCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return nil, err
+	}
+	return &cache, nil
+}
+
+// SaveCache writes the cache to disk, creating directories as needed.
+func SaveCache(configDir string, cache *UpdateCache) error {
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(configDir, CacheFileName), data, 0o600)
+}
+
+// IsStale returns true if the cache is older than CheckInterval or if the
+// current version has changed since the last check (e.g. user upgraded).
+func (c *UpdateCache) IsStale(currentVersion string) bool {
+	if time.Since(c.CheckedAt) > CheckInterval {
+		return true
+	}
+	return c.CurrentVersion != currentVersion
+}

--- a/internal/update/cache_test.go
+++ b/internal/update/cache_test.go
@@ -1,0 +1,138 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestLoadCache_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := LoadCache(dir)
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	if cache != nil {
+		t.Fatal("expected nil cache for missing file")
+	}
+}
+
+func TestLoadCache_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, CacheFileName), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadCache(dir)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestSaveAndLoadCache(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().Truncate(time.Second) // JSON loses sub-second precision
+
+	original := &UpdateCache{
+		LatestVersion:  "v0.0.12",
+		CurrentVersion: "0.0.10",
+		CheckedAt:      now,
+		ReleaseURL:     "https://github.com/nottelabs/notte-cli/releases/tag/v0.0.12",
+	}
+
+	if err := SaveCache(dir, original); err != nil {
+		t.Fatalf("SaveCache error: %v", err)
+	}
+
+	loaded, err := LoadCache(dir)
+	if err != nil {
+		t.Fatalf("LoadCache error: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil cache")
+	}
+	if loaded.LatestVersion != original.LatestVersion {
+		t.Errorf("LatestVersion = %q, want %q", loaded.LatestVersion, original.LatestVersion)
+	}
+	if loaded.CurrentVersion != original.CurrentVersion {
+		t.Errorf("CurrentVersion = %q, want %q", loaded.CurrentVersion, original.CurrentVersion)
+	}
+	if loaded.ReleaseURL != original.ReleaseURL {
+		t.Errorf("ReleaseURL = %q, want %q", loaded.ReleaseURL, original.ReleaseURL)
+	}
+}
+
+func TestSaveCache_CreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "dir")
+	cache := &UpdateCache{
+		LatestVersion:  "v1.0.0",
+		CurrentVersion: "0.9.0",
+		CheckedAt:      time.Now(),
+	}
+	if err := SaveCache(dir, cache); err != nil {
+		t.Fatalf("SaveCache should create nested dirs, got error: %v", err)
+	}
+
+	loaded, err := LoadCache(dir)
+	if err != nil {
+		t.Fatalf("LoadCache error: %v", err)
+	}
+	if loaded.LatestVersion != "v1.0.0" {
+		t.Errorf("unexpected version: %q", loaded.LatestVersion)
+	}
+}
+
+func TestUpdateCache_IsStale(t *testing.T) {
+	tests := []struct {
+		name           string
+		cache          UpdateCache
+		currentVersion string
+		want           bool
+	}{
+		{
+			name: "fresh cache same version",
+			cache: UpdateCache{
+				CurrentVersion: "0.0.10",
+				CheckedAt:      time.Now(),
+			},
+			currentVersion: "0.0.10",
+			want:           false,
+		},
+		{
+			name: "old cache same version",
+			cache: UpdateCache{
+				CurrentVersion: "0.0.10",
+				CheckedAt:      time.Now().Add(-25 * time.Hour),
+			},
+			currentVersion: "0.0.10",
+			want:           true,
+		},
+		{
+			name: "fresh cache different version",
+			cache: UpdateCache{
+				CurrentVersion: "0.0.10",
+				CheckedAt:      time.Now(),
+			},
+			currentVersion: "0.0.11",
+			want:           true,
+		},
+		{
+			name: "old cache different version",
+			cache: UpdateCache{
+				CurrentVersion: "0.0.10",
+				CheckedAt:      time.Now().Add(-25 * time.Hour),
+			},
+			currentVersion: "0.0.11",
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cache.IsStale(tt.currentVersion)
+			if got != tt.want {
+				t.Errorf("IsStale(%q) = %v, want %v", tt.currentVersion, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -1,0 +1,55 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const (
+	// DefaultGitHubReleasesURL is the endpoint for the latest release.
+	DefaultGitHubReleasesURL = "https://api.github.com/repos/nottelabs/notte-cli/releases/latest"
+)
+
+// githubReleasesURL is the URL used for checking the latest release.
+// It can be overridden in tests via setReleasesURL.
+var githubReleasesURL = DefaultGitHubReleasesURL
+
+// ReleaseInfo holds the relevant fields from the GitHub API response.
+type ReleaseInfo struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+}
+
+// CheckLatestVersion queries GitHub for the latest release.
+// Returns nil, nil if the request fails (failures are silent and non-blocking).
+func CheckLatestVersion(ctx context.Context, httpClient *http.Client) (*ReleaseInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubReleasesURL, nil)
+	if err != nil {
+		return nil, nil //nolint:nilerr // silent failure by design
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "notte-cli-update-checker")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, nil //nolint:nilerr // silent failure by design
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil // silent failure for non-200 responses
+	}
+
+	var release ReleaseInfo
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, nil //nolint:nilerr // silent failure by design
+	}
+
+	if release.TagName == "" {
+		return nil, fmt.Errorf("empty tag_name in GitHub response")
+	}
+
+	return &release, nil
+}

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -36,7 +36,7 @@ func CheckLatestVersion(ctx context.Context, httpClient *http.Client) (*ReleaseI
 	if err != nil {
 		return nil, nil //nolint:nilerr // silent failure by design
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, nil // silent failure for non-200 responses

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -1,0 +1,141 @@
+package update
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// setReleasesURL overrides the GitHub releases URL for testing and returns
+// a cleanup function that restores the original value.
+func setReleasesURL(t *testing.T, url string) {
+	t.Helper()
+	orig := githubReleasesURL
+	githubReleasesURL = url
+	t.Cleanup(func() { githubReleasesURL = orig })
+}
+
+func TestCheckLatestVersion_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") != "application/vnd.github+json" {
+			t.Error("expected Accept header")
+		}
+		if r.Header.Get("User-Agent") != "notte-cli-update-checker" {
+			t.Error("expected User-Agent header")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"tag_name": "v0.0.12", "html_url": "https://github.com/nottelabs/notte-cli/releases/tag/v0.0.12"}`))
+	}))
+	defer server.Close()
+	setReleasesURL(t, server.URL)
+
+	ctx := context.Background()
+	release, err := CheckLatestVersion(ctx, server.Client())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if release == nil {
+		t.Fatal("expected non-nil release")
+	}
+	if release.TagName != "v0.0.12" {
+		t.Errorf("TagName = %q, want %q", release.TagName, "v0.0.12")
+	}
+	if release.HTMLURL != "https://github.com/nottelabs/notte-cli/releases/tag/v0.0.12" {
+		t.Errorf("HTMLURL = %q, want release URL", release.HTMLURL)
+	}
+}
+
+func TestCheckLatestVersion_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+	setReleasesURL(t, server.URL)
+
+	ctx := context.Background()
+	release, err := CheckLatestVersion(ctx, server.Client())
+	if err != nil {
+		t.Fatalf("expected nil error on HTTP error, got %v", err)
+	}
+	if release != nil {
+		t.Fatal("expected nil release on HTTP error")
+	}
+}
+
+func TestCheckLatestVersion_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	setReleasesURL(t, server.URL)
+
+	ctx := context.Background()
+	release, err := CheckLatestVersion(ctx, server.Client())
+	if err != nil {
+		t.Fatalf("expected nil error on server error, got %v", err)
+	}
+	if release != nil {
+		t.Fatal("expected nil release on server error")
+	}
+}
+
+func TestCheckLatestVersion_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	setReleasesURL(t, server.URL)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	release, err := CheckLatestVersion(ctx, server.Client())
+	if err != nil {
+		t.Fatalf("expected nil error on timeout, got %v", err)
+	}
+	if release != nil {
+		t.Fatal("expected nil release on timeout")
+	}
+}
+
+func TestCheckLatestVersion_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not valid json`))
+	}))
+	defer server.Close()
+	setReleasesURL(t, server.URL)
+
+	ctx := context.Background()
+	release, err := CheckLatestVersion(ctx, server.Client())
+	if err != nil {
+		t.Fatalf("expected nil error on invalid JSON, got %v", err)
+	}
+	if release != nil {
+		t.Fatal("expected nil release on invalid JSON")
+	}
+}
+
+func TestCheckLatestVersion_EmptyTagName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"tag_name": "", "html_url": ""}`))
+	}))
+	defer server.Close()
+	setReleasesURL(t, server.URL)
+
+	ctx := context.Background()
+	release, err := CheckLatestVersion(ctx, server.Client())
+	if err == nil {
+		t.Fatal("expected error for empty tag_name")
+	}
+	if release != nil {
+		t.Fatal("expected nil release for empty tag_name")
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,193 @@
+package update
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/muesli/termenv"
+	"golang.org/x/term"
+
+	"github.com/nottelabs/notte-cli/internal/config"
+)
+
+// Result holds the outcome of an update check.
+type Result struct {
+	CurrentVersion  string
+	LatestVersion   string
+	ReleaseURL      string
+	UpdateAvailable bool
+}
+
+// Checker manages the async update check lifecycle.
+type Checker struct {
+	currentVersion string
+	configDir      string
+	result         *Result
+	done           chan struct{}
+}
+
+// NewChecker creates a Checker. Returns nil if version is "dev" or
+// NOTTE_NO_UPDATE_CHECK is set.
+func NewChecker(currentVersion string) *Checker {
+	if currentVersion == "dev" {
+		return nil
+	}
+	if os.Getenv(config.EnvNoUpdateCheck) != "" {
+		return nil
+	}
+
+	configDir, err := config.Dir()
+	if err != nil {
+		return nil
+	}
+
+	return &Checker{
+		currentVersion: currentVersion,
+		configDir:      configDir,
+		done:           make(chan struct{}),
+	}
+}
+
+// Run performs the update check. It reads the cache first; if the cache is
+// fresh, it uses cached data. Otherwise it queries GitHub and updates the cache.
+// This method is designed to be called in a goroutine.
+func (c *Checker) Run(ctx context.Context) {
+	defer close(c.done)
+
+	// Try loading cached result first
+	cache, _ := LoadCache(c.configDir)
+	if cache != nil && !cache.IsStale(c.currentVersion) {
+		newer, err := IsNewer(c.currentVersion, cache.LatestVersion)
+		if err == nil && newer {
+			c.result = &Result{
+				CurrentVersion:  c.currentVersion,
+				LatestVersion:   cache.LatestVersion,
+				ReleaseURL:      cache.ReleaseURL,
+				UpdateAvailable: true,
+			}
+		}
+		return
+	}
+
+	// Query GitHub for the latest release
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	release, err := CheckLatestVersion(ctx, httpClient)
+	if err != nil || release == nil {
+		return // silent failure
+	}
+
+	// Save to cache regardless of whether an update is available
+	newCache := &UpdateCache{
+		LatestVersion:  release.TagName,
+		CurrentVersion: c.currentVersion,
+		CheckedAt:      time.Now(),
+		ReleaseURL:     release.HTMLURL,
+	}
+	_ = SaveCache(c.configDir, newCache) // best-effort
+
+	// Check if the latest version is newer
+	newer, err := IsNewer(c.currentVersion, release.TagName)
+	if err != nil || !newer {
+		return
+	}
+
+	c.result = &Result{
+		CurrentVersion:  c.currentVersion,
+		LatestVersion:   release.TagName,
+		ReleaseURL:      release.HTMLURL,
+		UpdateAvailable: true,
+	}
+}
+
+// GetResult blocks until the check completes and returns the result.
+// Returns nil if no update is available or the check failed.
+func (c *Checker) GetResult() *Result {
+	<-c.done
+	return c.result
+}
+
+// PrintUpdateNotification displays the update message and optionally
+// prompts to upgrade. It writes to stderr to avoid polluting stdout.
+func PrintUpdateNotification(result *Result, out io.Writer, in io.Reader, skipConfirm bool, jsonMode bool, noColor bool) {
+	if jsonMode {
+		return
+	}
+	if result == nil || !result.UpdateAvailable {
+		return
+	}
+
+	termOut := termenv.NewOutput(os.Stderr)
+	colorize := func(s string, color termenv.ANSIColor) string {
+		if noColor {
+			return s
+		}
+		return termOut.String(s).Foreground(color).String()
+	}
+
+	// Print a blank line to separate from command output
+	fmt.Fprintln(out)
+
+	// Update available message (yellow)
+	current := formatVersion(result.CurrentVersion)
+	latest := formatVersion(result.LatestVersion)
+	fmt.Fprintln(out, colorize(
+		fmt.Sprintf("Update available for Notte CLI (%s \u2192 %s) The latest update may fix any errors that occurred.", current, latest),
+		termenv.ANSIYellow,
+	))
+
+	// Changelog link (cyan)
+	changelogURL := result.ReleaseURL
+	if changelogURL == "" {
+		changelogURL = fmt.Sprintf("https://github.com/nottelabs/notte-cli/releases/tag/%s", latest)
+	}
+	fmt.Fprintln(out, colorize(
+		fmt.Sprintf("Changelog: %s", changelogURL),
+		termenv.ANSICyan,
+	))
+
+	// Check if stdin is a terminal for interactive prompt
+	isTerminal := false
+	if f, ok := in.(*os.File); ok {
+		isTerminal = term.IsTerminal(int(f.Fd()))
+	}
+
+	if !isTerminal && !skipConfirm {
+		// Non-interactive: just show the notification, no prompt
+		return
+	}
+
+	// Prompt for upgrade
+	if skipConfirm {
+		fmt.Fprintln(out, "? Would you like to upgrade now? yes")
+	} else {
+		fmt.Fprint(out, "? Would you like to upgrade now? [Y/n]: ")
+		reader := bufio.NewReader(in)
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			return
+		}
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response == "n" || response == "no" {
+			return
+		}
+	}
+
+	// Perform upgrade
+	method := DetectInstallMethod()
+	fmt.Fprintln(out, colorize("> Upgrading Notte CLI...", termenv.ANSIGreen))
+
+	if err := RunUpgrade(out, method); err != nil {
+		fmt.Fprintln(out, colorize(fmt.Sprintf("> Upgrade failed: %s", err), termenv.ANSIRed))
+		return
+	}
+
+	if method == UpgradeHomebrew {
+		fmt.Fprintln(out, colorize("> Success! Notte CLI has been upgraded successfully!", termenv.ANSIGreen))
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -131,12 +131,12 @@ func PrintUpdateNotification(result *Result, out io.Writer, in io.Reader, skipCo
 	}
 
 	// Print a blank line to separate from command output
-	fmt.Fprintln(out)
+	_, _ = fmt.Fprintln(out)
 
 	// Update available message (yellow)
 	current := formatVersion(result.CurrentVersion)
 	latest := formatVersion(result.LatestVersion)
-	fmt.Fprintln(out, colorize(
+	_, _ = fmt.Fprintln(out, colorize(
 		fmt.Sprintf("Update available for Notte CLI (%s \u2192 %s) The latest update may fix any errors that occurred.", current, latest),
 		termenv.ANSIYellow,
 	))
@@ -146,7 +146,7 @@ func PrintUpdateNotification(result *Result, out io.Writer, in io.Reader, skipCo
 	if changelogURL == "" {
 		changelogURL = fmt.Sprintf("https://github.com/nottelabs/notte-cli/releases/tag/%s", latest)
 	}
-	fmt.Fprintln(out, colorize(
+	_, _ = fmt.Fprintln(out, colorize(
 		fmt.Sprintf("Changelog: %s", changelogURL),
 		termenv.ANSICyan,
 	))
@@ -164,9 +164,9 @@ func PrintUpdateNotification(result *Result, out io.Writer, in io.Reader, skipCo
 
 	// Prompt for upgrade
 	if skipConfirm {
-		fmt.Fprintln(out, "? Would you like to upgrade now? yes")
+		_, _ = fmt.Fprintln(out, "? Would you like to upgrade now? yes")
 	} else {
-		fmt.Fprint(out, "? Would you like to upgrade now? [Y/n]: ")
+		_, _ = fmt.Fprint(out, "? Would you like to upgrade now? [Y/n]: ")
 		reader := bufio.NewReader(in)
 		response, err := reader.ReadString('\n')
 		if err != nil {
@@ -180,14 +180,14 @@ func PrintUpdateNotification(result *Result, out io.Writer, in io.Reader, skipCo
 
 	// Perform upgrade
 	method := DetectInstallMethod()
-	fmt.Fprintln(out, colorize("> Upgrading Notte CLI...", termenv.ANSIGreen))
+	_, _ = fmt.Fprintln(out, colorize("> Upgrading Notte CLI...", termenv.ANSIGreen))
 
 	if err := RunUpgrade(out, method); err != nil {
-		fmt.Fprintln(out, colorize(fmt.Sprintf("> Upgrade failed: %s", err), termenv.ANSIRed))
+		_, _ = fmt.Fprintln(out, colorize(fmt.Sprintf("> Upgrade failed: %s", err), termenv.ANSIRed))
 		return
 	}
 
 	if method == UpgradeHomebrew {
-		fmt.Fprintln(out, colorize("> Success! Notte CLI has been upgraded successfully!", termenv.ANSIGreen))
+		_, _ = fmt.Fprintln(out, colorize("> Success! Notte CLI has been upgraded successfully!", termenv.ANSIGreen))
 	}
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,168 @@
+package update
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNewChecker_DevVersion(t *testing.T) {
+	checker := NewChecker("dev")
+	if checker != nil {
+		t.Fatal("expected nil checker for dev version")
+	}
+}
+
+func TestNewChecker_EnvDisabled(t *testing.T) {
+	t.Setenv("NOTTE_NO_UPDATE_CHECK", "1")
+	checker := NewChecker("0.0.10")
+	if checker != nil {
+		t.Fatal("expected nil checker when NOTTE_NO_UPDATE_CHECK is set")
+	}
+}
+
+func TestNewChecker_ValidVersion(t *testing.T) {
+	t.Setenv("NOTTE_NO_UPDATE_CHECK", "")
+	// Unset the env var completely to ensure it doesn't interfere
+	os.Unsetenv("NOTTE_NO_UPDATE_CHECK")
+
+	checker := NewChecker("0.0.10")
+	if checker == nil {
+		t.Fatal("expected non-nil checker for valid version")
+	}
+	if checker.currentVersion != "0.0.10" {
+		t.Errorf("currentVersion = %q, want %q", checker.currentVersion, "0.0.10")
+	}
+}
+
+func TestPrintUpdateNotification_JSONMode(t *testing.T) {
+	var buf bytes.Buffer
+	result := &Result{
+		CurrentVersion:  "0.0.10",
+		LatestVersion:   "v0.0.12",
+		ReleaseURL:      "https://github.com/nottelabs/notte-cli/releases/tag/v0.0.12",
+		UpdateAvailable: true,
+	}
+
+	PrintUpdateNotification(result, &buf, strings.NewReader(""), false, true, false)
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no output in JSON mode, got %q", buf.String())
+	}
+}
+
+func TestPrintUpdateNotification_NilResult(t *testing.T) {
+	var buf bytes.Buffer
+	PrintUpdateNotification(nil, &buf, strings.NewReader(""), false, false, false)
+	if buf.Len() > 0 {
+		t.Errorf("expected no output for nil result, got %q", buf.String())
+	}
+}
+
+func TestPrintUpdateNotification_NotAvailable(t *testing.T) {
+	var buf bytes.Buffer
+	result := &Result{
+		CurrentVersion:  "0.0.12",
+		LatestVersion:   "v0.0.12",
+		UpdateAvailable: false,
+	}
+
+	PrintUpdateNotification(result, &buf, strings.NewReader(""), false, false, false)
+	if buf.Len() > 0 {
+		t.Errorf("expected no output when no update available, got %q", buf.String())
+	}
+}
+
+func TestPrintUpdateNotification_NonInteractive(t *testing.T) {
+	var buf bytes.Buffer
+	result := &Result{
+		CurrentVersion:  "0.0.10",
+		LatestVersion:   "v0.0.12",
+		ReleaseURL:      "https://github.com/nottelabs/notte-cli/releases/tag/v0.0.12",
+		UpdateAvailable: true,
+	}
+
+	// strings.NewReader is not a terminal, so prompt should be skipped
+	PrintUpdateNotification(result, &buf, strings.NewReader(""), false, false, true)
+
+	output := buf.String()
+	if !strings.Contains(output, "Update available") {
+		t.Error("expected update notification in output")
+	}
+	if !strings.Contains(output, "v0.0.10") {
+		t.Error("expected current version in output")
+	}
+	if !strings.Contains(output, "v0.0.12") {
+		t.Error("expected latest version in output")
+	}
+	if !strings.Contains(output, "Changelog:") {
+		t.Error("expected changelog link in output")
+	}
+	// Should NOT contain the prompt since stdin is not a terminal
+	if strings.Contains(output, "Would you like to upgrade now?") {
+		t.Error("should not prompt in non-interactive mode")
+	}
+}
+
+func TestPrintUpdateNotification_NoColor(t *testing.T) {
+	var buf bytes.Buffer
+	result := &Result{
+		CurrentVersion:  "0.0.10",
+		LatestVersion:   "v0.0.12",
+		ReleaseURL:      "https://github.com/nottelabs/notte-cli/releases/tag/v0.0.12",
+		UpdateAvailable: true,
+	}
+
+	PrintUpdateNotification(result, &buf, strings.NewReader(""), false, false, true)
+
+	output := buf.String()
+	// Should not contain ANSI escape codes
+	if strings.Contains(output, "\033[") {
+		t.Error("expected no ANSI escape codes with noColor=true")
+	}
+	if !strings.Contains(output, "Update available for Notte CLI") {
+		t.Error("expected update message in output")
+	}
+}
+
+func TestPrintUpdateNotification_DeclineUpgrade(t *testing.T) {
+	var buf bytes.Buffer
+	result := &Result{
+		CurrentVersion:  "0.0.10",
+		LatestVersion:   "v0.0.12",
+		ReleaseURL:      "https://github.com/nottelabs/notte-cli/releases/tag/v0.0.12",
+		UpdateAvailable: true,
+	}
+
+	// Simulate typing "n" - but since strings.NewReader is not a terminal,
+	// the prompt won't appear. Test that skipConfirm=false + non-terminal = no prompt.
+	PrintUpdateNotification(result, &buf, strings.NewReader("n\n"), false, false, true)
+
+	output := buf.String()
+	if strings.Contains(output, "Upgrading") {
+		t.Error("should not upgrade when user declines")
+	}
+}
+
+func TestResult_Fields(t *testing.T) {
+	r := &Result{
+		CurrentVersion:  "0.0.10",
+		LatestVersion:   "v0.0.12",
+		ReleaseURL:      "https://example.com/release",
+		UpdateAvailable: true,
+	}
+
+	if r.CurrentVersion != "0.0.10" {
+		t.Errorf("unexpected CurrentVersion: %q", r.CurrentVersion)
+	}
+	if r.LatestVersion != "v0.0.12" {
+		t.Errorf("unexpected LatestVersion: %q", r.LatestVersion)
+	}
+	if r.ReleaseURL != "https://example.com/release" {
+		t.Errorf("unexpected ReleaseURL: %q", r.ReleaseURL)
+	}
+	if !r.UpdateAvailable {
+		t.Error("expected UpdateAvailable to be true")
+	}
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"bytes"
-	"os"
 	"strings"
 	"testing"
 )
@@ -23,9 +22,8 @@ func TestNewChecker_EnvDisabled(t *testing.T) {
 }
 
 func TestNewChecker_ValidVersion(t *testing.T) {
+	// Set to empty string so the check is not disabled
 	t.Setenv("NOTTE_NO_UPDATE_CHECK", "")
-	// Unset the env var completely to ensure it doesn't interfere
-	os.Unsetenv("NOTTE_NO_UPDATE_CHECK")
 
 	checker := NewChecker("0.0.10")
 	if checker == nil {

--- a/internal/update/upgrade.go
+++ b/internal/update/upgrade.go
@@ -1,0 +1,70 @@
+package update
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// UpgradeMethod represents how the CLI was installed.
+type UpgradeMethod int
+
+const (
+	// UpgradeHomebrew indicates the CLI was installed via Homebrew.
+	UpgradeHomebrew UpgradeMethod = iota
+	// UpgradeManual indicates the install method could not be detected.
+	UpgradeManual
+)
+
+// DetectInstallMethod checks how the CLI was installed.
+func DetectInstallMethod() UpgradeMethod {
+	brewPath, err := exec.LookPath("brew")
+	if err != nil || brewPath == "" {
+		return UpgradeManual
+	}
+
+	// Check if notte was installed via Homebrew
+	cmd := exec.Command("brew", "list", "notte")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return UpgradeManual
+	}
+
+	return UpgradeHomebrew
+}
+
+// RunUpgrade performs the upgrade using the detected method.
+func RunUpgrade(out io.Writer, method UpgradeMethod) error {
+	switch method {
+	case UpgradeHomebrew:
+		return runHomebrewUpgrade(out)
+	default:
+		return printManualUpgrade(out)
+	}
+}
+
+func runHomebrewUpgrade(out io.Writer) error {
+	cmd := exec.Command("brew", "upgrade", "notte")
+	cmd.Stdout = out
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func printManualUpgrade(out io.Writer) error {
+	_, err := fmt.Fprintln(out, "To upgrade manually, run one of:")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, "  brew install nottelabs/notte-cli/notte")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, "  go install github.com/nottelabs/notte-cli/cmd/notte@latest")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, "Or download from: https://github.com/nottelabs/notte-cli/releases/latest")
+	return err
+}

--- a/internal/update/upgrade_test.go
+++ b/internal/update/upgrade_test.go
@@ -1,0 +1,45 @@
+package update
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestDetectInstallMethod(t *testing.T) {
+	// This test verifies the function runs without panic.
+	// The result depends on the local environment (whether brew is installed).
+	method := DetectInstallMethod()
+	if method != UpgradeHomebrew && method != UpgradeManual {
+		t.Errorf("unexpected install method: %d", method)
+	}
+}
+
+func TestRunUpgrade_Manual(t *testing.T) {
+	var buf bytes.Buffer
+	err := RunUpgrade(&buf, UpgradeManual)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "To upgrade manually") {
+		t.Error("expected manual upgrade instructions")
+	}
+	if !strings.Contains(output, "brew install") {
+		t.Error("expected brew install instruction")
+	}
+	if !strings.Contains(output, "go install") {
+		t.Error("expected go install instruction")
+	}
+	if !strings.Contains(output, "github.com/nottelabs/notte-cli") {
+		t.Error("expected GitHub URL in instructions")
+	}
+}
+
+func TestUpgradeMethod_Constants(t *testing.T) {
+	// Verify the constants have distinct values
+	if UpgradeHomebrew == UpgradeManual {
+		t.Error("UpgradeHomebrew and UpgradeManual should be distinct")
+	}
+}

--- a/internal/update/version.go
+++ b/internal/update/version.go
@@ -1,0 +1,69 @@
+package update
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CompareVersions compares two semver strings (with or without "v" prefix).
+// Returns: -1 if a < b, 0 if a == b, 1 if a > b.
+func CompareVersions(a, b string) (int, error) {
+	aParts, err := parseSemver(a)
+	if err != nil {
+		return 0, fmt.Errorf("invalid version %q: %w", a, err)
+	}
+	bParts, err := parseSemver(b)
+	if err != nil {
+		return 0, fmt.Errorf("invalid version %q: %w", b, err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if aParts[i] < bParts[i] {
+			return -1, nil
+		}
+		if aParts[i] > bParts[i] {
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+// IsNewer returns true if latest is a newer version than current.
+func IsNewer(current, latest string) (bool, error) {
+	cmp, err := CompareVersions(current, latest)
+	if err != nil {
+		return false, err
+	}
+	return cmp < 0, nil
+}
+
+// parseSemver parses a version string into [major, minor, patch].
+func parseSemver(v string) ([3]int, error) {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return [3]int{}, fmt.Errorf("expected MAJOR.MINOR.PATCH, got %q", v)
+	}
+
+	var result [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return [3]int{}, fmt.Errorf("non-numeric segment %q: %w", p, err)
+		}
+		if n < 0 {
+			return [3]int{}, fmt.Errorf("negative segment %d", n)
+		}
+		result[i] = n
+	}
+	return result, nil
+}
+
+// formatVersion ensures a version string has the "v" prefix.
+func formatVersion(v string) string {
+	if strings.HasPrefix(v, "v") {
+		return v
+	}
+	return "v" + v
+}

--- a/internal/update/version_test.go
+++ b/internal/update/version_test.go
@@ -1,0 +1,95 @@
+package update
+
+import (
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		a       string
+		b       string
+		want    int
+		wantErr bool
+	}{
+		{"equal", "0.0.10", "0.0.10", 0, false},
+		{"equal with v prefix", "v0.0.10", "v0.0.10", 0, false},
+		{"equal mixed prefix", "v1.2.3", "1.2.3", 0, false},
+		{"a less than b patch", "0.0.10", "0.0.12", -1, false},
+		{"a greater than b patch", "0.0.12", "0.0.10", 1, false},
+		{"a less than b minor", "0.1.0", "0.2.0", -1, false},
+		{"a less than b major", "1.0.0", "2.0.0", -1, false},
+		{"a greater than b major", "2.0.0", "1.9.99", 1, false},
+		{"complex comparison", "1.2.3", "1.2.4", -1, false},
+		{"major wins over minor", "2.0.0", "1.99.99", 1, false},
+		{"invalid a", "abc", "1.0.0", 0, true},
+		{"invalid b", "1.0.0", "xyz", 0, true},
+		{"too few segments", "1.0", "1.0.0", 0, true},
+		{"too many segments uses first three", "1.0.0.0", "1.0.0", 0, true},
+		{"negative segment", "-1.0.0", "1.0.0", 0, true},
+		{"empty string", "", "1.0.0", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CompareVersions(tt.a, tt.b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CompareVersions(%q, %q) error = %v, wantErr %v", tt.a, tt.b, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+		want    bool
+		wantErr bool
+	}{
+		{"newer available", "0.0.10", "0.0.12", true, false},
+		{"same version", "0.0.10", "0.0.10", false, false},
+		{"older available", "0.0.12", "0.0.10", false, false},
+		{"newer with v prefix", "v0.0.10", "v0.0.12", true, false},
+		{"invalid version", "invalid", "1.0.0", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsNewer(tt.current, tt.latest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsNewer(%q, %q) error = %v, wantErr %v", tt.current, tt.latest, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsNewer(%q, %q) = %v, want %v", tt.current, tt.latest, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"1.0.0", "v1.0.0"},
+		{"v1.0.0", "v1.0.0"},
+		{"0.0.10", "v0.0.10"},
+		{"v0.0.10", "v0.0.10"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := formatVersion(tt.input)
+			if got != tt.want {
+				t.Errorf("formatVersion(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add background version check against GitHub releases API on every CLI invocation
- Cache check results locally (`update_check.json`) with a 24-hour TTL to avoid excessive API calls
- Display update notification after command output when a newer version is available
- Prompt interactive users to upgrade in-place via Homebrew or show manual install instructions
- Support `NOTTE_NO_UPDATE_CHECK` env var and `--yes` flag to control behavior; skip entirely for `dev` builds
- New `internal/update` package with dedicated modules: cache, check, version comparison, upgrade, and orchestration

## Testing

- Unit tests for version comparison (`CompareVersions`, `IsNewer`, `formatVersion`) covering equal, less, greater, v-prefix, and invalid inputs
- Unit tests for cache load/save round-trip, missing file, invalid JSON, nested directory creation, and staleness detection
- Unit tests for GitHub release check with httptest server: success, HTTP errors, timeouts, invalid JSON, empty tag
- Unit tests for upgrade method detection and manual upgrade output
- Unit tests for `PrintUpdateNotification`: JSON mode suppression, nil/no-update result, non-interactive mode, no-color mode, decline upgrade
- Unit tests for `NewChecker` with dev version and `NOTTE_NO_UPDATE_CHECK` env var
- Not run: end-to-end test with actual GitHub API or real Homebrew upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a background update-check feature: a goroutine queries the GitHub releases API (with a 24-hour cache), and after each CLI command the result is shown on stderr with an optional Homebrew upgrade prompt. The implementation is well-structured — error handling is consistently silent/non-blocking, synchronisation via a done channel is race-free, and test coverage is thorough across cache, version comparison, HTTP mocking, and notification paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are style/improvement suggestions with no functional impact on the current code paths.

The feature is functionally correct: done-channel synchronisation is race-free, the cache correctly handles staleness and version changes, and the notification is suppressed in JSON and non-interactive modes. The three comments are P2 — a potential UX stall on cold cache (worth addressing), an inconsistent error return that is already ignored, and a minor Stderr wiring issue with no production impact.

internal/cmd/root.go — the unconditional GetResult() block is the most user-visible concern on cold cache runs.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/cmd/root.go | Integrates background update check with correct context/cancel lifecycle; GetResult() blocks unconditionally which can delay fast-command exit by up to 5 s on cold cache |
| internal/update/update.go | Core orchestration and notification logic; done-channel synchronisation is race-free, but GetResult() blocks until goroutine finishes; termenv colour detection is hardcoded to os.Stderr regardless of the out parameter |
| internal/update/check.go | GitHub API query with silent-failure design; empty tag_name is the only case that returns a non-nil error while every other failure returns (nil, nil); the caller ignores the error anyway |
| internal/update/cache.go | Clean 24-hour TTL cache with correct file permissions (0o600/0o700) and version-change staleness detection |
| internal/update/upgrade.go | Homebrew detection and upgrade; cmd.Stderr is hardcoded to os.Stderr instead of the out parameter, harmless in production but could matter in future callers |
| internal/update/version.go | Clean semver comparison with v-prefix stripping; correctly rejects pre-release or non-numeric segments |
| internal/config/config.go | Adds EnvNoUpdateCheck constant, straightforward |
| internal/update/cache_test.go | Good coverage of round-trip, missing file, invalid JSON, nested dir creation, and staleness |
| internal/update/check_test.go | Uses httptest for GitHub API mocking; covers success, HTTP errors, timeout, invalid JSON, and empty tag |
| internal/update/update_test.go | Tests NewChecker guards and PrintUpdateNotification paths including JSON mode, nil result, non-interactive, no-color, and decline |
| internal/update/upgrade_test.go | Tests DetectInstallMethod (environment-dependent) and RunUpgrade for the manual path |
| internal/update/version_test.go | Thorough table-driven tests for CompareVersions, IsNewer, and formatVersion |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ainternal%2Fcmd%2Froot.go%3A58-62%0A**%60GetResult%28%29%60%20always%20blocks%2C%20adding%20latency%20after%20fast%20commands**%0A%0A%60GetResult%28%29%60%20blocks%20unconditionally%20on%20%60%3C-c.done%60%20until%20the%20background%20goroutine%20closes%20the%20channel.%20When%20the%20cache%20is%20cold%20%28first%20run%2C%20or%20after%20the%2024-hour%20TTL%29%2C%20the%20goroutine%20performs%20a%20network%20call%20with%20a%205-second%20HTTP%20client%20timeout%2C%20so%20%60notte%20version%60%20or%20other%20sub-second%20commands%20will%20hang%20for%20up%20to%205%20seconds%20before%20the%20process%20exits.%0A%0AA%20non-blocking%20%60select%60%20with%20a%20short%20fallback%20would%20preserve%20the%20notification%20for%20most%20cases%20while%20preventing%20the%20stall%3A%0A%0A%60%60%60go%0A%2F%2F%20GetResult%20returns%20the%20update%20check%20result%20if%20it%20is%20ready%2C%0A%2F%2F%20or%20nil%20if%20the%20check%20has%20not%20yet%20completed.%0Afunc%20%28c%20*Checker%29%20GetResult%28%29%20*Result%20%7B%0A%20%20%20%20select%20%7B%0A%20%20%20%20case%20%3C-c.done%3A%0A%20%20%20%20%20%20%20%20return%20c.result%0A%20%20%20%20default%3A%0A%20%20%20%20%20%20%20%20return%20nil%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0AAlternatively%2C%20keeping%20the%20block%20but%20using%20a%20shorter%20%60select%60%20timeout%20%28e.g.%20200%20ms%29%20in%20%60Execute%60%20would%20bound%20the%20worst-case%20wait.%0A%0A%23%23%23%20Issue%202%20of%203%0Ainternal%2Fupdate%2Fcheck.go%3A50-52%0A**Inconsistent%20error%20semantics%20for%20empty%20%60tag_name%60**%0A%0AEvery%20other%20failure%20path%20in%20%60CheckLatestVersion%60%20%E2%80%94%20HTTP%20errors%2C%20decode%20errors%2C%20transport%20errors%20%E2%80%94%20returns%20%60%28nil%2C%20nil%29%60%20with%20a%20%60%2F%2Fnolint%3Anilerr%60%20comment%20explaining%20the%20silent-failure%20design.%20The%20empty%20%60tag_name%60%20case%20is%20the%20sole%20exception%20that%20returns%20a%20non-nil%20error.%20The%20caller%20in%20%60update.go%60%20treats%20%60err%20!%3D%20nil%60%20and%20%60release%20%3D%3D%20nil%60%20identically%20%28silent%20return%29%2C%20so%20the%20error%20is%20never%20observed%20and%20the%20docstring%20promise%20of%20%60%28nil%2C%20nil%29%60%20on%20failure%20is%20violated.%0A%0A%60%60%60suggestion%0A%09if%20release.TagName%20%3D%3D%20%22%22%20%7B%0A%09%09return%20nil%2C%20nil%20%2F%2F%20silent%20failure%3A%20treat%20missing%20tag%20same%20as%20other%20failures%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Ainternal%2Fupdate%2Fupgrade.go%3A51%0A**Homebrew%20subprocess%20stderr%20bypasses%20the%20%60out%60%20parameter**%0A%0A%60cmd.Stderr%60%20is%20hardcoded%20to%20%60os.Stderr%60%20rather%20than%20the%20%60out%20io.Writer%60%20that%20is%20already%20used%20for%20%60cmd.Stdout%60.%20In%20the%20current%20production%20call%20site%20%60out%60%20happens%20to%20be%20%60os.Stderr%60%2C%20so%20behaviour%20is%20identical%2C%20but%20it%20makes%20the%20function%20harder%20to%20test%20and%20violates%20the%20API%20contract%20that%20all%20output%20goes%20through%20%60out%60.%0A%0A%60%60%60suggestion%0A%09cmd.Stderr%20%3D%20out%0A%60%60%60%0A%0A&repo=nottelabs%2Fnotte-cli"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/cmd/root.go
Line: 58-62

Comment:
**`GetResult()` always blocks, adding latency after fast commands**

`GetResult()` blocks unconditionally on `<-c.done` until the background goroutine closes the channel. When the cache is cold (first run, or after the 24-hour TTL), the goroutine performs a network call with a 5-second HTTP client timeout, so `notte version` or other sub-second commands will hang for up to 5 seconds before the process exits.

A non-blocking `select` with a short fallback would preserve the notification for most cases while preventing the stall:

```go
// GetResult returns the update check result if it is ready,
// or nil if the check has not yet completed.
func (c *Checker) GetResult() *Result {
    select {
    case <-c.done:
        return c.result
    default:
        return nil
    }
}
```

Alternatively, keeping the block but using a shorter `select` timeout (e.g. 200 ms) in `Execute` would bound the worst-case wait.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/update/check.go
Line: 50-52

Comment:
**Inconsistent error semantics for empty `tag_name`**

Every other failure path in `CheckLatestVersion` — HTTP errors, decode errors, transport errors — returns `(nil, nil)` with a `//nolint:nilerr` comment explaining the silent-failure design. The empty `tag_name` case is the sole exception that returns a non-nil error. The caller in `update.go` treats `err != nil` and `release == nil` identically (silent return), so the error is never observed and the docstring promise of `(nil, nil)` on failure is violated.

```suggestion
	if release.TagName == "" {
		return nil, nil // silent failure: treat missing tag same as other failures
	}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/update/upgrade.go
Line: 51

Comment:
**Homebrew subprocess stderr bypasses the `out` parameter**

`cmd.Stderr` is hardcoded to `os.Stderr` rather than the `out io.Writer` that is already used for `cmd.Stdout`. In the current production call site `out` happens to be `os.Stderr`, so behaviour is identical, but it makes the function harder to test and violates the API contract that all output goes through `out`.

```suggestion
	cmd.Stderr = out
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Add CLI version update check and upgrade..."](https://github.com/nottelabs/notte-cli/commit/2eb3fccd363cef0ce73ade32d6cad79c5572e9d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=21123985)</sub>

<!-- /greptile_comment -->