### PR TITLE
Fix update checker review feedback

### DIFF
--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -3,7 +3,6 @@ package update
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 )
 
@@ -48,7 +47,7 @@ func CheckLatestVersion(ctx context.Context, httpClient *http.Client) (*ReleaseI
 	}
 
 	if release.TagName == "" {
-		return nil, fmt.Errorf("empty tag_name in GitHub response")
+		return nil, nil // silent failure: treat missing tag same as other failures
 	}
 
 	return &release, nil

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -132,8 +132,8 @@ func TestCheckLatestVersion_EmptyTagName(t *testing.T) {
 
 	ctx := context.Background()
 	release, err := CheckLatestVersion(ctx, server.Client())
-	if err == nil {
-		t.Fatal("expected error for empty tag_name")
+	if err != nil {
+		t.Fatalf("expected nil error for empty tag_name, got %v", err)
 	}
 	if release != nil {
 		t.Fatal("expected nil release for empty tag_name")

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -105,11 +105,15 @@ func (c *Checker) Run(ctx context.Context) {
 	}
 }
 
-// GetResult blocks until the check completes and returns the result.
-// Returns nil if no update is available or the check failed.
+// GetResult returns the update check result if it is ready,
+// or nil if the check has not yet completed.
 func (c *Checker) GetResult() *Result {
-	<-c.done
-	return c.result
+	select {
+	case <-c.done:
+		return c.result
+	default:
+		return nil
+	}
 }
 
 // PrintUpdateNotification displays the update message and optionally

--- a/internal/update/upgrade.go
+++ b/internal/update/upgrade.go
@@ -3,7 +3,6 @@ package update
 import (
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 )
 
@@ -48,7 +47,7 @@ func RunUpgrade(out io.Writer, method UpgradeMethod) error {
 func runHomebrewUpgrade(out io.Writer) error {
 	cmd := exec.Command("brew", "upgrade", "notte")
 	cmd.Stdout = out
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = out
 	return cmd.Run()
 }
 


### PR DESCRIPTION
## Summary
- Make `GetResult()` non-blocking with `select/default` to avoid adding latency after fast commands
- Use consistent `nil, nil` return for empty `tag_name` in `CheckLatestVersion` (matches silent-failure contract)
- Route Homebrew subprocess stderr through the `out` parameter instead of hardcoding `os.Stderr`

Follow-up to #24, addressing Greptile review comments.

## Test plan
- [x] All existing unit tests pass (`go test -race -short ./internal/update/...`)
- [x] Lint clean (`golangci-lint run` — 0 issues)
- [x] Build succeeds (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a targeted follow-up to #24 addressing three review comments: `GetResult()` is made non-blocking via `select/default` (avoiding latency on fast commands), `CheckLatestVersion` returns `nil, nil` for an empty `tag_name` to match its silent-failure contract, and `runHomebrewUpgrade` routes subprocess stderr through the `out` parameter instead of hardcoding `os.Stderr`. All three changes are correct, well-scoped, and covered by tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three fixes are correct and well-tested with no new risk introduced.

No P0 or P1 findings. The select/default pattern in GetResult() is a correct Go memory-model-safe approach, the nil,nil silent-failure extension is consistent, and the stderr routing fix improves testability. All changes are covered by existing tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/update/update.go | GetResult() now uses select/default for non-blocking behavior; termenv color detection still hardcoded to os.Stderr (consistent with caller in root.go) |
| internal/update/check.go | Adds nil,nil return for empty tag_name, matching the established silent-failure contract throughout the function |
| internal/update/check_test.go | Adds TestCheckLatestVersion_EmptyTagName to cover the new nil,nil return path |
| internal/update/upgrade.go | runHomebrewUpgrade now routes cmd.Stderr through the out parameter instead of hardcoding os.Stderr |

</details>

<sub>Reviews (3): Last reviewed commit: ["Address greptile review feedback (greplo..."](https://github.com/nottelabs/notte-cli/commit/91edd79e9ce7b7b2b7cea4164d8360920f642384) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=21127584)</sub>

<!-- /greptile_comment -->