### PR TITLE
Warn when CLI is older than API minimum version

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -20,12 +18,16 @@ const DefaultBaseURL = "https://api.notte.cc"
 // minimum CLI version required for full compatibility.
 const MinCLIVersionHeader = "x-notte-min-cli-version"
 
-// versionWarningOnce ensures the outdated-CLI warning prints at most once per process.
-var versionWarningOnce sync.Once
+// detectedMinVersion stores the minimum CLI version returned by the API.
+// Set once by checkMinVersion; read by root.go to trigger the upgrade prompt.
+var detectedMinVersion string
+var detectOnce sync.Once
 
-// versionWarningWriter is the destination for the version mismatch warning.
-// Defaults to os.Stderr; overridden in tests.
-var versionWarningWriter io.Writer
+// DetectedMinVersion returns the API-required minimum CLI version, or "" if
+// the header was not seen or the CLI is already up to date.
+func DetectedMinVersion() string {
+	return detectedMinVersion
+}
 
 // NotteClient wraps the generated client with auth and resilience
 type NotteClient struct {
@@ -164,29 +166,19 @@ func (t *resilientTransport) RoundTrip(req *http.Request) (*http.Response, error
 }
 
 // checkMinVersion inspects the x-notte-min-cli-version response header and
-// prints a single stderr warning if the running CLI is older than required.
+// stores the required version so the root command can prompt for upgrade.
 func (t *resilientTransport) checkMinVersion(resp *http.Response) {
 	minVersion := resp.Header.Get(MinCLIVersionHeader)
 	if minVersion == "" || t.version == "" || t.version == "dev" {
 		return
 	}
 
-	outdated, err := update.IsNewer(t.version, minVersion)
-	if err != nil || !outdated {
-		return
-	}
-
-	versionWarningOnce.Do(func() {
-		w := versionWarningWriter
-		if w == nil {
-			w = os.Stderr
+	detectOnce.Do(func() {
+		outdated, err := update.IsNewer(t.version, minVersion)
+		if err != nil || !outdated {
+			return
 		}
-		fmt.Fprintf(w,
-			"\nWarning: this CLI version (%s) is older than the minimum required by the API (%s).\n"+
-				"Some commands may return incomplete or incorrect results.\n"+
-				"Run `brew upgrade notte` or visit https://github.com/nottelabs/notte-cli/releases to update.\n\n",
-			t.version, minVersion,
-		)
+		detectedMinVersion = minVersion
 	})
 }
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -4,13 +4,28 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"sync"
 	"time"
 
 	notteErrors "github.com/nottelabs/notte-cli/internal/errors"
+	"github.com/nottelabs/notte-cli/internal/update"
 )
 
 const DefaultBaseURL = "https://api.notte.cc"
+
+// MinCLIVersionHeader is the response header the API uses to advertise the
+// minimum CLI version required for full compatibility.
+const MinCLIVersionHeader = "x-notte-min-cli-version"
+
+// versionWarningOnce ensures the outdated-CLI warning prints at most once per process.
+var versionWarningOnce sync.Once
+
+// versionWarningWriter is the destination for the version mismatch warning.
+// Defaults to os.Stderr; overridden in tests.
+var versionWarningWriter io.Writer
 
 // NotteClient wraps the generated client with auth and resilience
 type NotteClient struct {
@@ -142,7 +157,37 @@ func (t *resilientTransport) RoundTrip(req *http.Request) (*http.Response, error
 		t.circuitBreaker.RecordSuccess()
 	}
 
+	// Check if the API requires a newer CLI version
+	t.checkMinVersion(resp)
+
 	return resp, nil
+}
+
+// checkMinVersion inspects the x-notte-min-cli-version response header and
+// prints a single stderr warning if the running CLI is older than required.
+func (t *resilientTransport) checkMinVersion(resp *http.Response) {
+	minVersion := resp.Header.Get(MinCLIVersionHeader)
+	if minVersion == "" || t.version == "" || t.version == "dev" {
+		return
+	}
+
+	outdated, err := update.IsNewer(t.version, minVersion)
+	if err != nil || !outdated {
+		return
+	}
+
+	versionWarningOnce.Do(func() {
+		w := versionWarningWriter
+		if w == nil {
+			w = os.Stderr
+		}
+		fmt.Fprintf(w,
+			"\nWarning: this CLI version (%s) is older than the minimum required by the API (%s).\n"+
+				"Some commands may return incomplete or incorrect results.\n"+
+				"Run `brew upgrade notte` or visit https://github.com/nottelabs/notte-cli/releases to update.\n\n",
+			t.version, minVersion,
+		)
+	})
 }
 
 func (t *resilientTransport) doWithRetry(req *http.Request) (*http.Response, error) {

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -386,6 +387,88 @@ func TestNotteClient_APIKey(t *testing.T) {
 
 	if got := client.APIKey(); got != "test-api-key-123" {
 		t.Errorf("APIKey() = %q, want %q", got, "test-api-key-123")
+	}
+}
+
+func TestCheckMinVersion_WarnsWhenOutdated(t *testing.T) {
+	versionWarningOnce = sync.Once{}
+	var buf strings.Builder
+	versionWarningWriter = &buf
+	t.Cleanup(func() {
+		versionWarningOnce = sync.Once{}
+		versionWarningWriter = nil
+	})
+
+	rt := &resilientTransport{version: "0.0.10"}
+	resp := &http.Response{
+		Header: http.Header{"X-Notte-Min-Cli-Version": []string{"0.0.12"}},
+	}
+	rt.checkMinVersion(resp)
+
+	output := buf.String()
+	if !strings.Contains(output, "older than the minimum required") {
+		t.Errorf("expected outdated warning, got: %q", output)
+	}
+	if !strings.Contains(output, "0.0.10") || !strings.Contains(output, "0.0.12") {
+		t.Errorf("warning should mention both versions, got: %q", output)
+	}
+}
+
+func TestCheckMinVersion_SilentWhenCurrent(t *testing.T) {
+	versionWarningOnce = sync.Once{}
+	var buf strings.Builder
+	versionWarningWriter = &buf
+	t.Cleanup(func() {
+		versionWarningOnce = sync.Once{}
+		versionWarningWriter = nil
+	})
+
+	rt := &resilientTransport{version: "0.0.12"}
+	resp := &http.Response{
+		Header: http.Header{"X-Notte-Min-Cli-Version": []string{"0.0.12"}},
+	}
+	rt.checkMinVersion(resp)
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no output for current version, got: %q", buf.String())
+	}
+}
+
+func TestCheckMinVersion_SilentWhenNoHeader(t *testing.T) {
+	versionWarningOnce = sync.Once{}
+	var buf strings.Builder
+	versionWarningWriter = &buf
+	t.Cleanup(func() {
+		versionWarningOnce = sync.Once{}
+		versionWarningWriter = nil
+	})
+
+	rt := &resilientTransport{version: "0.0.10"}
+	resp := &http.Response{Header: http.Header{}}
+	rt.checkMinVersion(resp)
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no output without header, got: %q", buf.String())
+	}
+}
+
+func TestCheckMinVersion_SkipsDevVersion(t *testing.T) {
+	versionWarningOnce = sync.Once{}
+	var buf strings.Builder
+	versionWarningWriter = &buf
+	t.Cleanup(func() {
+		versionWarningOnce = sync.Once{}
+		versionWarningWriter = nil
+	})
+
+	rt := &resilientTransport{version: "dev"}
+	resp := &http.Response{
+		Header: http.Header{"X-Notte-Min-Cli-Version": []string{"0.0.12"}},
+	}
+	rt.checkMinVersion(resp)
+
+	if buf.Len() > 0 {
+		t.Errorf("expected no output for dev version, got: %q", buf.String())
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -390,14 +390,14 @@ func TestNotteClient_APIKey(t *testing.T) {
 	}
 }
 
-func TestCheckMinVersion_WarnsWhenOutdated(t *testing.T) {
-	versionWarningOnce = sync.Once{}
-	var buf strings.Builder
-	versionWarningWriter = &buf
-	t.Cleanup(func() {
-		versionWarningOnce = sync.Once{}
-		versionWarningWriter = nil
-	})
+func resetDetectOnce() {
+	detectOnce = sync.Once{}
+	detectedMinVersion = ""
+}
+
+func TestCheckMinVersion_StoresWhenOutdated(t *testing.T) {
+	resetDetectOnce()
+	t.Cleanup(resetDetectOnce)
 
 	rt := &resilientTransport{version: "0.0.10"}
 	resp := &http.Response{
@@ -405,23 +405,14 @@ func TestCheckMinVersion_WarnsWhenOutdated(t *testing.T) {
 	}
 	rt.checkMinVersion(resp)
 
-	output := buf.String()
-	if !strings.Contains(output, "older than the minimum required") {
-		t.Errorf("expected outdated warning, got: %q", output)
-	}
-	if !strings.Contains(output, "0.0.10") || !strings.Contains(output, "0.0.12") {
-		t.Errorf("warning should mention both versions, got: %q", output)
+	if got := DetectedMinVersion(); got != "0.0.12" {
+		t.Errorf("DetectedMinVersion() = %q, want %q", got, "0.0.12")
 	}
 }
 
-func TestCheckMinVersion_SilentWhenCurrent(t *testing.T) {
-	versionWarningOnce = sync.Once{}
-	var buf strings.Builder
-	versionWarningWriter = &buf
-	t.Cleanup(func() {
-		versionWarningOnce = sync.Once{}
-		versionWarningWriter = nil
-	})
+func TestCheckMinVersion_EmptyWhenCurrent(t *testing.T) {
+	resetDetectOnce()
+	t.Cleanup(resetDetectOnce)
 
 	rt := &resilientTransport{version: "0.0.12"}
 	resp := &http.Response{
@@ -429,37 +420,27 @@ func TestCheckMinVersion_SilentWhenCurrent(t *testing.T) {
 	}
 	rt.checkMinVersion(resp)
 
-	if buf.Len() > 0 {
-		t.Errorf("expected no output for current version, got: %q", buf.String())
+	if got := DetectedMinVersion(); got != "" {
+		t.Errorf("DetectedMinVersion() = %q, want empty", got)
 	}
 }
 
-func TestCheckMinVersion_SilentWhenNoHeader(t *testing.T) {
-	versionWarningOnce = sync.Once{}
-	var buf strings.Builder
-	versionWarningWriter = &buf
-	t.Cleanup(func() {
-		versionWarningOnce = sync.Once{}
-		versionWarningWriter = nil
-	})
+func TestCheckMinVersion_EmptyWhenNoHeader(t *testing.T) {
+	resetDetectOnce()
+	t.Cleanup(resetDetectOnce)
 
 	rt := &resilientTransport{version: "0.0.10"}
 	resp := &http.Response{Header: http.Header{}}
 	rt.checkMinVersion(resp)
 
-	if buf.Len() > 0 {
-		t.Errorf("expected no output without header, got: %q", buf.String())
+	if got := DetectedMinVersion(); got != "" {
+		t.Errorf("DetectedMinVersion() = %q, want empty", got)
 	}
 }
 
-func TestCheckMinVersion_SkipsDevVersion(t *testing.T) {
-	versionWarningOnce = sync.Once{}
-	var buf strings.Builder
-	versionWarningWriter = &buf
-	t.Cleanup(func() {
-		versionWarningOnce = sync.Once{}
-		versionWarningWriter = nil
-	})
+func TestCheckMinVersion_EmptyForDevVersion(t *testing.T) {
+	resetDetectOnce()
+	t.Cleanup(resetDetectOnce)
 
 	rt := &resilientTransport{version: "dev"}
 	resp := &http.Response{
@@ -467,8 +448,8 @@ func TestCheckMinVersion_SkipsDevVersion(t *testing.T) {
 	}
 	rt.checkMinVersion(resp)
 
-	if buf.Len() > 0 {
-		t.Errorf("expected no output for dev version, got: %q", buf.String())
+	if got := DetectedMinVersion(); got != "" {
+		t.Errorf("DetectedMinVersion() = %q, want empty", got)
 	}
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -54,8 +54,15 @@ func Execute() {
 
 	err := rootCmd.Execute()
 
-	// Show update notification after command output
-	if checker != nil {
+	// If the API told us our CLI is too old, prompt to upgrade (takes priority)
+	if minVer := api.DetectedMinVersion(); minVer != "" {
+		update.PrintUpdateNotification(&update.Result{
+			CurrentVersion:  Version,
+			LatestVersion:   minVer,
+			UpdateAvailable: true,
+		}, os.Stderr, os.Stdin, yesFlag, IsJSONOutput(), noColor)
+	} else if checker != nil {
+		// Otherwise fall back to the GitHub-based update check
 		if result := checker.GetResult(); result != nil {
 			update.PrintUpdateNotification(result, os.Stderr, os.Stdin, yesFlag, IsJSONOutput(), noColor)
 		}


### PR DESCRIPTION
## Summary
- Reads `x-notte-min-cli-version` response header from the API on every request
- If the running CLI version is below the minimum, prints a one-time stderr warning with upgrade instructions
- Prevents the silent data-loss bug where schema mismatches cause empty/null results (e.g. `notte sessions network` returning 0 batches on v0.0.10 after the S3 migration)

Companion API change: the backend sets `x-notte-min-cli-version: 0.0.12` on all responses (separate PR in the monorepo).

## Test plan
- [x] `TestCheckMinVersion_WarnsWhenOutdated` — warning printed when CLI < min
- [x] `TestCheckMinVersion_SilentWhenCurrent` — no output when CLI >= min
- [x] `TestCheckMinVersion_SilentWhenNoHeader` — no output when header absent
- [x] `TestCheckMinVersion_SkipsDevVersion` — no output for dev builds
- [x] Full test suite passes (`go test ./internal/...`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `x-notte-min-cli-version` response-header check to every API request and surfaces a one-time upgrade prompt when the running CLI falls below the API-advertised minimum. The approach — `sync.Once` + package-level globals written in the HTTP transport and read after `rootCmd.Execute()` returns — is correct for single-goroutine CLI invocations and is well-covered by tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge; both findings are P2 edge cases that do not affect the primary upgrade-warning path

No P0/P1 defects. The detectOnce consumed-early concern is a theoretical edge case (requires different API endpoints to return different minimums mid-session) and the changelog-URL issue is a minor UX trade-off explicitly acknowledged in the PR description. All four new tests pass and cover the main behavioural branches.

internal/api/client.go — sync.Once consumption order; internal/cmd/root.go — changelog URL target version

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/api/client.go | Adds package-level sync.Once / detectedMinVersion globals plus checkMinVersion on every RoundTrip; logic and concurrency are sound for single-goroutine CLI usage, but once detectOnce fires "not outdated" it is permanently consumed for the session |
| internal/api/client_test.go | Adds four unit tests with proper resetDetectOnce guards; covers outdated, current, no-header, and dev-version cases |
| internal/cmd/root.go | Routes API-triggered warning before GitHub update check; LatestVersion is set to the min-required version rather than the actual latest release, so changelog URL points to the minimum tag |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ainternal%2Fapi%2Fclient.go%3A176-182%0A**%60detectOnce%60%20consumed%20on%20%22not%20outdated%22%20check**%0A%0A%60detectOnce.Do%60%20is%20called%20the%20first%20time%20any%20response%20carries%20the%20header%20%E2%80%94%20including%20when%20the%20CLI%20is%20already%20current.%20The%20closure%20returns%20early%20without%20setting%20%60detectedMinVersion%60%2C%20but%20%60detectOnce%60%20is%20permanently%20spent%20for%20the%20session.%20If%20a%20subsequent%20request%20returns%20a%20*higher*%20minimum%20version%20%28e.g.%20the%20API%20is%20mid-deploy%20and%20different%20endpoints%20transiently%20return%20different%20minimums%29%2C%20the%20warning%20will%20be%20silently%20skipped.%0A%0AConsider%20moving%20the%20%60IsNewer%60%20call%20outside%20%60Do%60%20so%20the%20once-guard%20is%20only%20consumed%20when%20the%20CLI%20is%20genuinely%20outdated%3A%0A%0A%60%60%60go%0Aoutdated%2C%20err%20%3A%3D%20update.IsNewer%28t.version%2C%20minVersion%29%0Aif%20err%20!%3D%20nil%20%7C%7C%20!outdated%20%7B%0A%20%20%20%20return%0A%7D%0AdetectOnce.Do%28func%28%29%20%7B%0A%20%20%20%20detectedMinVersion%20%3D%20minVersion%0A%7D%29%0A%60%60%60%0A%0AThis%20keeps%20%60detectOnce%60%20unspent%20until%20a%20genuinely%20outdated%20response%20is%20seen%2C%20so%20a%20later%20higher-minimum%20response%20can%20still%20trigger%20the%20warning.%0A%0A%23%23%23%20Issue%202%20of%202%0Ainternal%2Fcmd%2Froot.go%3A58-68%0A**Changelog%20URL%20points%20to%20minimum%20version%2C%20not%20latest%20release**%0A%0AWhen%20the%20API-triggered%20path%20fires%2C%20%60LatestVersion%60%20is%20set%20to%20%60minVer%60%20%28the%20API-required%20minimum%29.%20%60PrintUpdateNotification%60%20constructs%20the%20changelog%20URL%20as%20%60https%3A%2F%2Fgithub.com%2Fnottelabs%2Fnotte-cli%2Freleases%2Ftag%2Fv%3CminVer%3E%60.%20If%20the%20actual%20latest%20release%20is%2C%20say%2C%20%60v0.0.15%60%20while%20%60minVer%60%20is%20%60v0.0.12%60%2C%20the%20user%20is%20directed%20to%20install%20%60v0.0.12%60%20and%20the%20GitHub%20update%20check%20is%20fully%20bypassed%20%E2%80%94%20so%20they%20never%20learn%20about%20%60v0.0.15%60.%0A%0AIf%20informing%20users%20about%20the%20true%20latest%20release%20matters%20here%2C%20consider%20combining%20both%3A%20use%20%60minVer%60%20for%20the%20warning%20message%20but%20still%20check%20%60checker.GetResult%28%29%60%20and%20surface%20the%20actual%20latest%20in%20the%20changelog%20URL.%0A%0A&repo=nottelabs%2Fnotte-cli"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/api/client.go
Line: 176-182

Comment:
**`detectOnce` consumed on "not outdated" check**

`detectOnce.Do` is called the first time any response carries the header — including when the CLI is already current. The closure returns early without setting `detectedMinVersion`, but `detectOnce` is permanently spent for the session. If a subsequent request returns a *higher* minimum version (e.g. the API is mid-deploy and different endpoints transiently return different minimums), the warning will be silently skipped.

Consider moving the `IsNewer` call outside `Do` so the once-guard is only consumed when the CLI is genuinely outdated:

```go
outdated, err := update.IsNewer(t.version, minVersion)
if err != nil || !outdated {
    return
}
detectOnce.Do(func() {
    detectedMinVersion = minVersion
})
```

This keeps `detectOnce` unspent until a genuinely outdated response is seen, so a later higher-minimum response can still trigger the warning.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/cmd/root.go
Line: 58-68

Comment:
**Changelog URL points to minimum version, not latest release**

When the API-triggered path fires, `LatestVersion` is set to `minVer` (the API-required minimum). `PrintUpdateNotification` constructs the changelog URL as `https://github.com/nottelabs/notte-cli/releases/tag/v<minVer>`. If the actual latest release is, say, `v0.0.15` while `minVer` is `v0.0.12`, the user is directed to install `v0.0.12` and the GitHub update check is fully bypassed — so they never learn about `v0.0.15`.

If informing users about the true latest release matters here, consider combining both: use `minVer` for the warning message but still check `checker.GetResult()` and surface the actual latest in the changelog URL.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["prompt upgrade instead of just warning o..."](https://github.com/nottelabs/notte-cli/commit/1813267d1924932fbd1584b488c0741fdf8a5686) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=21127591)</sub>

<!-- /greptile_comment -->