### PR TITLE
feat(skill): notte-browser v1.1 — eval-driven improvements

### DIFF
--- a/skills/notte-browser/SKILL.md
+++ b/skills/notte-browser/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: notte-browser
 description: Command-line interface for browser automation, web scraping, and AI-powered web interactions using the notte.cc platform.
-version: 1.0.0
+version: 1.1.0
 allowed-tools: Bash(notte:*)
 ---
 
@@ -32,9 +32,18 @@ notte page fill "@I1" "hello world"
 # 5. Scrape content
 notte page scrape --instructions "Extract all product names and prices"
 
-# 6. Stop the session
+# 6. Stop the session (uses current session; pass --session-id only for another)
 notte sessions stop
 ```
+
+> **There is no top-level `notte scrape <url>` command** despite what `notte --help` implies. Scraping always goes through `notte page scrape` inside an active session (after `goto`).
+>
+> **All resource IDs are passed as named flags** (`--session-id`, `--agent-id`, `--persona-id`, `--profile-id`, `--vault-id`, `--function-id`, `--run-id`), never positional. `notte personas delete <id>` fails with `unknown command`; use `notte personas delete --persona-id <id>`.
+>
+> **Flag-name traps:** `notte page scrape` takes `--instructions` (plural),
+> not `--instruction`. `notte sessions start` has **no `--url`** flag — start
+> the session, then `notte page goto <url>`. `notte page goto` takes a
+> positional URL, not `--url`.
 
 ## Command Categories
 
@@ -45,17 +54,25 @@ Control browser session lifecycle:
 ```bash
 # Start a new session
 notte sessions start [flags]
-  --headless                 Run in headless mode (default: true)
-  --idle-timeout-minutes     Idle timeout in minutes
-  --max-duration-minutes     Maximum session lifetime in minutes
+  --headless                 Run in headless mode
+  --browser-type             Browser type: chromium, chrome, firefox, chrome-nightly, chrome-turbo (default: chromium)
+  --idle-timeout-minutes     Idle timeout in minutes (resets on each operation)
+  --max-duration-minutes     Maximum session lifetime in minutes (absolute)
   --proxy                    Use default proxies
-  --proxy-country <code>     Proxy country code (e.g. us, gb, fr)
+  --proxy-country            Proxy country code (e.g. us, gb, fr). Implies --proxy
   --solve-captchas           Automatically solve captchas
   --viewport-width           Viewport width in pixels
   --viewport-height          Viewport height in pixels
   --user-agent               Custom user agent string
   --cdp-url                  CDP URL of remote session provider
   --use-file-storage         Enable file storage for the session
+  --profile-id               Profile ID to use (for persistent browser state)
+  --profile-persist          Save browser state to profile on session close
+  --vault-id                 Vault to use for credential access
+  --web-bot-auth             Use web bot authentication
+  --screenshot-type          Screenshot type: raw, full, last_action
+  --chrome-args              Overwrite chrome args (repeatable)
+  --extra-http-headers       Extra HTTP headers as JSON
 
 # Get current session status
 notte sessions status
@@ -67,19 +84,55 @@ notte sessions stop
 notte sessions list [--page N] [--page-size N] [--only-active]
 ```
 
-**Note:** When you start a session, it automatically becomes the "current" session (i.e NOTTE_SESSION_ID environment variable is set). All subsequent commands use this session by default. Use `--session-id <session-id>` only when you need to manage multiple sessions simultaneously or reference a specific session.
+**Note:** When you start a session, it automatically becomes the "current" session (saved to `~/.notte/cli/current_session`; can also be overridden with `NOTTE_SESSION_ID` env var). All subsequent commands use this session by default. Use `--session-id <session-id>` only when you need to manage multiple sessions simultaneously or reference a specific session.
+
+> **Stale current-session trap (common in fresh shells / CI / eval runs).** The
+> "current session" pointer persists across shells and can outlive the session
+> it points to. Symptoms:
+> - `Error 410: Session not found` on a command that worked seconds ago.
+> - `Error 500: Browser or context expired or closed`.
+> - `Error 422: Extra inputs are not permitted` on `observe` *right after* a
+>   successful `goto` (the 422 the skill flags elsewhere for missing goto, but
+>   here the real cause is a dead session).
+> - `observe` returning content from a completely different site than you just
+>   navigated to (a leftover session was reused).
+> - `sessions start` printing `"Session <old-id> is currently active. A new
+>   session will be created either way"` — the pointer was stale.
+>
+> **Recovery pattern.** Capture the fresh session id from `-o json` and pass
+> `--session-id` explicitly on every dependent call. Chain dependent commands
+> in a single shell so the session can't die between invocations:
+>
+> ```bash
+> SID=$(notte sessions start -y -o json | python3 -c "import sys,json;print(json.load(sys.stdin)['session_id'])")
+> notte page goto "https://example.com" --session-id "$SID" \
+>   && notte page observe --session-id "$SID" \
+>   && notte page click "@L1" --session-id "$SID"
+> ```
+>
+> Use `-y` on `sessions start` to skip the confirmation prompt when a prior
+> session is still marked "current".
 
 Session debugging and export:
 
 ```bash
 # Get network logs
-notte sessions network
+notte sessions network [--path /output/dir] [--urls-only]
 
-# Get replay URL/data
-notte sessions replay
+# Download session replay video (MP4)
+notte sessions replay [--path output.mp4]
 
 # Export session steps as Python workflow code
 notte sessions workflow-code
+
+# Get Python script for session steps
+notte sessions code
+
+# Get session offset info
+notte sessions offset
+
+# Open session viewer in browser
+notte sessions viewer
 ```
 
 Cookie management:
@@ -141,6 +194,7 @@ notte page eval-js '
 
 **Navigation:**
 ```bash
+# URL is a positional argument — do NOT use --url
 notte page goto "https://example.com"
 notte page new-tab "https://example.com"
 notte page back
@@ -148,11 +202,18 @@ notte page forward
 notte page reload
 ```
 
+> **`page observe` before a `goto` returns HTTP 422** with the misleading message `Extra inputs are not permitted ... ('body', 'url')`. The error is about server state (no page loaded), **not** about the `--url` flag. Always `notte page goto <url>` first, then `notte page observe`.
+
 **Scrolling:**
 ```bash
 notte page scroll-down [amount]
 notte page scroll-up [amount]
 ```
+
+> If `scroll-down`/`scroll-up` returns `"Scroll failed. Either the page is not
+> scrollable or there is a focused element blocking the scroll"`, use the
+> keyboard instead — keys always work: `notte page press "PageDown"` /
+> `"PageUp"` / `"End"` / `"Home"`.
 
 **Keyboard:**
 ```bash
@@ -167,13 +228,17 @@ notte page switch-tab 1
 notte page close-tab
 ```
 
+> Tabs re-index immediately after `close-tab`. If you close tab 1, the only
+> remaining tab is index 0 — `switch-tab 1` will then fail with "Tab index out
+> of range". Track expected count, or call `notte page observe` in between.
+
 **Page State:**
 ```bash
 # Observe page state and available actions
 notte page observe
 
-# Save a screenshot in tmp folder
-notte page screenshot
+# Save a screenshot (defaults to tmp folder; optional output path)
+notte page screenshot [output-path]
 
 # Scrape content with instructions
 notte page scrape --instructions "Extract all links" [--only-main-content]
@@ -188,11 +253,41 @@ notte page wait 1000
 notte page captcha-solve "recaptcha"
 
 # Mark task complete
-notte page complete "Task finished successfully" [--success=true]
+notte page complete "Task finished successfully" [--success]
 
-# Fill form with JSON data
-notte page form-fill --data '{"email": "test@example.com", "name": "John"}'
+# Run JavaScript on the page
+notte page eval-js "document.title"
+notte page eval-js "document.querySelectorAll('a').length"
+
+# Fill form with JSON data.
+# `form-fill` only accepts a fixed schema of semantic keys, NOT arbitrary field labels.
+# Valid keys include: title, first_name, middle_name, last_name, full_name, email,
+#   company, address1, address2, address3, city, state, zip, country, phone, username,
+#   password, dob (and similar identity/address fields).
+# For fields outside this schema (radios, checkboxes, non-standard labels), use
+# `notte page fill "#selector" "value"` / `notte page check` / `notte page select` instead.
+notte page form-fill --data '{"full_name": "Alice", "email": "a@b.c", "phone": "555-0100"}'
 ```
+
+### File Storage
+
+Upload and manage files in notte.cc account-scoped storage (not per-session):
+
+```bash
+notte files upload <local-path>            # Upload a file
+notte files list [--uploads|--downloads]   # List files (default: --downloads)
+notte files download <filename> [--path output-path]  # Download a file
+```
+
+> **No `delete` subcommand exists.** `notte files` supports only `upload`,
+> `list`, and `download`. The REST endpoint `DELETE /storage/uploads/<name>`
+> is also not implemented (returns 405). If a task requires deleting an
+> uploaded file, report "not supported via CLI" rather than chasing
+> browser-agent or raw-API workarounds — they don't work either.
+>
+> `list --downloads` is the default and requires an active session (downloads
+> are session-scoped). Use `list --uploads` for account-scoped uploaded files
+> (works without a session).
 
 ### AI Agents
 
@@ -205,10 +300,14 @@ notte agents list [--page N] [--page-size N] [--only-active] [--only-saved]
 # Start a new agent (auto-uses current session if active)
 notte agents start --task "Navigate to example.com and extract the main heading"
   --session-id             Session ID (uses current session if not specified)
+  --url                    URL the agent should start on (optional)
   --vault-id               Vault ID for credential access
   --persona-id             Persona ID for identity
-  --max-steps              Maximum steps for the agent (default: 30)
+  --max-steps              Maximum steps for the agent
   --reasoning-model        Custom reasoning model
+  --use-vision             Use vision for the agent (not all models support it)
+  --response-format-json   Response format config (JSON file path, e.g. @config.json)
+  --session-offset         Step from which agent gathers session info (experimental)
 
 # Get current agent status
 notte agents status
@@ -230,6 +329,8 @@ notte agents replay
 2. `NOTTE_AGENT_ID` environment variable
 3. `~/.notte/cli/current_agent` file (lowest priority)
 
+> **One agent per session.** A session can run only one agent at a time. If `notte agents start` returns HTTP 409 `"already has an active agent"`, call `notte agents stop` (or wait with `notte agents status`) before starting a new one.
+
 ### Functions (Workflow Automation)
 
 Create, manage, and schedule reusable workflows:
@@ -250,8 +351,8 @@ notte functions update --file workflow.py
 # Delete current function
 notte functions delete
 
-# Run current function
-notte functions run
+# Run current function (pass variables with --var or --vars)
+notte functions run [--var key=value ...] [--vars '{"key":"value"}']
 
 # List runs for current function (with optional pagination and filters)
 notte functions runs [--page N] [--page-size N] [--only-active]
@@ -262,17 +363,23 @@ notte functions run-stop --run-id <run-id>
 # Get run logs and results
 notte functions run-metadata --run-id <run-id>
 
-# Schedule current function with cron expression
-notte functions schedule --cron "0 9 * * *"
+# Schedule current function — cron is 6-field AWS-style (min hour dom month dow year)
+notte functions schedule --cron "0 9 * * ? *"
 
 # Remove schedule from current function
 notte functions unschedule
 
 # Fork a shared function to your account
-notte functions fork --function-id <shared-function-id>
+notte functions fork [--function-id <shared-function-id>]
 ```
 
 **Note:** When you create a function, it automatically becomes the "current" function. All subsequent commands use this function by default. Use `--function-id <function-id>` only when you need to manage multiple functions simultaneously or reference a specific function (like when forking a shared function).
+
+> **Function file contract** (enforced by `functions create`/`update`; each violation is a separate 400):
+> - File must be `.py` (not `.yaml`, `.json`, `.sh`).
+> - Must define a top-level **synchronous** `def run(...)`. `async def run` is rejected (`AsyncFunctionDef not allowed`). `def _run` is rejected (names can't start with `_`).
+> - Must create a notte session using one of: `notte.Session(...)`, `n.Session(...)`, `c.Session(...)`, `cli.Session(...)`, `client.Session(...)`.
+> - **Cron is 6-field AWS-style**, not standard 5-field: `"minute hour day-of-month month day-of-week year"`. Example: `--cron "0 9 * * ? *"` for daily at 09:00 UTC. `"0 9 * * *"` (5 fields) is rejected.
 
 
 ### Account Management
@@ -283,8 +390,8 @@ notte functions fork --function-id <shared-function-id>
 # List personas (with optional pagination and filters)
 notte personas list [--page N] [--page-size N] [--only-active]
 
-# Create a persona
-notte personas create [--create-vault]
+# Create a persona (identity is auto-generated; there is no --name flag)
+notte personas create [--create-phone-number] [--create-vault]
 
 # Show persona details
 notte personas show --persona-id <persona-id>
@@ -321,13 +428,31 @@ notte vaults credentials get --vault-id <vault-id> --url "https://site.com"
 notte vaults credentials delete --vault-id <vault-id> --url "https://site.com"
 ```
 
+**Profiles** — Persistent browser state across sessions:
+
+```bash
+# List profiles
+notte profiles list [--name "filter"] [--page N] [--page-size N]
+
+# Create a new profile
+notte profiles create [--name "My Profile"]
+
+# Show profile details
+notte profiles show --profile-id <profile-id>
+
+# Delete a profile
+notte profiles delete --profile-id <profile-id>
+```
+
+> Use `--profile-id` on `sessions start` to load a profile, and `--profile-persist` to save state back on session close.
+
 ## Global Options
 
 Available on all commands:
 
 ```bash
 --output, -o    Output format: text, json (default: text)
---timeout       API request timeout in seconds (default: 30)
+--timeout       API request timeout in seconds (default: 60)
 --no-color      Disable color output
 --verbose, -v   Verbose output
 --yes, -y       Skip confirmation prompts
@@ -411,7 +536,7 @@ EOF
 notte functions create --file collect_data.py --name "Daily Data Collection"
 
 # Schedule to run every day at 9 AM
-notte functions schedule --function-id <function-id> --cron "0 9 * * *"
+notte functions schedule --function-id <function-id> --cron "0 9 * * ? *"
 
 # Check run history
 notte functions runs --function-id <function-id>
@@ -419,80 +544,11 @@ notte functions runs --function-id <function-id>
 
 ## Tips & Troubleshooting
 
-### Handling Inconsistent `observe` Output
+### Troubleshooting
 
-The `observe` command may sometimes return stale or partial DOM state, especially with dynamic content, modals, or single-page applications. If the output seems wrong:
-
-1. **Use screenshots to verify**: `notte page screenshot` always shows the current visual state
-2. **Fall back to Playwright selectors**: Instead of `@ID` references, use standard selectors like `#id`, `.class`, or `button:has-text('Submit')`
-3. **Add a brief wait**: `notte page wait 500` before observing can help with dynamic content
-
-### Selector Syntax
-
-Both element IDs from `observe` and Playwright selectors are supported:
-
-```bash
-# Using element IDs from observe output
-notte page click "@B3"
-notte page fill "@I1" "text"
-
-# Using Playwright selectors (recommended when @IDs don't work)
-notte page click "#submit-button"
-notte page click ".btn-primary"
-notte page click "button:has-text('Submit')"
-notte page click "[data-testid='login']"
-notte page fill "input[name='email']" "user@example.com"
-```
-
-**Handling multiple matches** - Use `>> nth=0` to select the first match:
-
-```bash
-# When multiple elements match, select by index
-notte page click "button:has-text('OK') >> nth=0"
-notte page click ".submit-btn >> nth=0"
-```
-
-### Working with Modals and Dialogs
-
-Modals and popups can interfere with page interactions. Tips:
-
-- **Close modals with Escape**: `notte page press "Escape"` reliably dismisses most dialogs and modals
-- **Wait after modal actions**: Add `notte page wait 500` after closing a modal before the next action
-- **Check for overlays**: If clicks aren't working, a modal or overlay might be blocking - use screenshot to verify
-
-```bash
-# Common pattern for handling unexpected modals
-notte page press "Escape"
-notte page wait 500
-notte page click "#target-element"
-```
-
-### Viewing Headless Sessions
-
-Running with `--headless` (the default) doesn't mean you can't see the browser:
-
-- **ViewerUrl**: When you start a session, the output includes a `ViewerUrl` - open it in your browser to watch the session live
-- **Viewer command**: `notte sessions viewer` opens the viewer directly
-- **Non-headless mode**: Use `--headless=false` only if you need a local browser window (not available on remote/CI environments)
-
-```bash
-# Start headless session and get viewer URL
-notte sessions start -o json | jq -r '.viewer_url'
-
-# Or open viewer for current session
-notte sessions viewer
-```
-
-### Bot Detection / Stealth
-
-If you're getting blocked or seeing CAPTCHAs, try enabling our residential proxies:
-
- ```bash
- notte sessions stop
- notte sessions start --proxy
- ```
-
-**Note**: Always stop the current session before starting a new one with different parameters. Session configuration cannot be changed mid-session.
+For stale `observe` output, selector syntax (`@ID` vs Playwright, `>> nth=0`),
+modals/dialogs, viewing headless sessions via `ViewerUrl`, and bot-detection
+/ CAPTCHA / proxy strategies, see [references/troubleshooting.md](references/troubleshooting.md).
 
 ## Additional Resources
 

--- a/skills/notte-browser/references/troubleshooting.md
+++ b/skills/notte-browser/references/troubleshooting.md
@@ -1,0 +1,95 @@
+# Troubleshooting & Advanced Tips
+
+Consult this reference when the top-level SKILL.md flags an issue here
+(inconsistent observe, modals, bot detection, headless viewing).
+
+## Handling Inconsistent `observe` Output
+
+The `observe` command may sometimes return stale or partial DOM state, especially with dynamic content, modals, or single-page applications. If the output seems wrong:
+
+1. **Use screenshots to verify**: `notte page screenshot` always shows the current visual state
+2. **Fall back to Playwright selectors**: Instead of `@ID` references, use standard selectors like `#id`, `.class`, or `button:has-text('Submit')`
+3. **Add a brief wait**: `notte page wait 500` before observing can help with dynamic content
+
+## Selector Syntax
+
+Both element IDs from `observe` and Playwright selectors are supported:
+
+```bash
+# Using element IDs from observe output
+notte page click "@B3"
+notte page fill "@I1" "text"
+
+# Using Playwright selectors (recommended when @IDs don't work)
+notte page click "#submit-button"
+notte page click ".btn-primary"
+notte page click "button:has-text('Submit')"
+notte page click "[data-testid='login']"
+notte page fill "input[name='email']" "user@example.com"
+```
+
+**Handling multiple matches** — use `>> nth=0` to select the first match:
+
+```bash
+notte page click "button:has-text('OK') >> nth=0"
+notte page click ".submit-btn >> nth=0"
+```
+
+## Working with Modals and Dialogs
+
+- **Close modals with Escape**: `notte page press "Escape"` reliably dismisses most dialogs and modals
+- **Wait after modal actions**: Add `notte page wait 500` after closing a modal before the next action
+- **Check for overlays**: If clicks aren't working, a modal or overlay might be blocking — use screenshot to verify
+
+```bash
+# Common pattern for handling unexpected modals
+notte page press "Escape"
+notte page wait 500
+notte page click "#target-element"
+```
+
+## Viewing Headless Sessions
+
+Running with `--headless` (the default) doesn't mean you can't see the browser:
+
+- **ViewerUrl**: When you start a session, the output includes a `ViewerUrl` — open it in your browser to watch the session live
+- **Viewer command**: `notte sessions viewer` opens the viewer directly
+- **Non-headless mode**: Use `--headless=false` only if you need a local browser window (not available on remote/CI environments)
+
+```bash
+# Start headless session and get viewer URL
+notte sessions start -o json | jq -r '.viewer_url'
+
+# Or open viewer for current session
+notte sessions viewer
+```
+
+## Bot Detection / Stealth
+
+If you're getting blocked or seeing CAPTCHAs, try these approaches (requires restarting the session with new parameters):
+
+1. **Change browser type**:
+   ```bash
+   notte sessions stop
+   notte sessions start --browser-type firefox
+   ```
+
+2. **Enable proxies**:
+   ```bash
+   notte sessions stop
+   notte sessions start --proxies
+   ```
+
+3. **Firefox + CAPTCHA solving** (works best with Firefox):
+   ```bash
+   notte sessions stop
+   notte sessions start --browser-type firefox --solve-captchas
+   ```
+
+4. **Combine strategies**:
+   ```bash
+   notte sessions stop
+   notte sessions start --browser-type firefox --proxies --solve-captchas
+   ```
+
+**Note**: Always stop the current session before starting a new one with different parameters. Session configuration cannot be changed mid-session.


### PR DESCRIPTION
## Summary

Improved the `notte-browser` Claude Code skill based on automated eval runs across 23 CLI-coverage tasks, then deep-verified every command and flag against `notte --help`.

### Results — v1.0 baseline vs v1.1

| Metric | Claude v1.0 | Claude v1.1 | Δ | Codex v1.0 | Codex v1.1 | Δ |
|---|---|---|---|---|---|---|
| **Errors** | 86 | **67** | **-22%** | 27 | **17** | **-37%** |
| **Time** | 4161s | **3949s** | **-5%** | 1607s | **1422s** | **-12%** |
| **Tool calls** | 502 | **489** | **-3%** | 169 | **93** | **-45%** |
| **Cost** | $15.39 | **$13.88** | **-10%** | $3.66 | **$2.33** | **-36%** |

*Claude v1.0 completed 22/23 tasks (1 FAIL on files_crud). All other cells: 23/23.*

### Cross-model comparison on v1.1 skill

| Metric | Opus 4.6 | **Opus 4.7** | Δ vs 4.6 | Codex (gpt-5.3) |
|---|---|---|---|---|
| **Wall time** | 3949s | **2997s** | **-24%** | 1422s |
| **Tool calls** | 489 | **342** | **-30%** | 93 |
| **Errors** | 67 | **45** | **-33%** | 17 |
| **Cost** | $14.14 | $32.18 | +128% | $2.33 |

Opus 4.7 unlocks the v1.1 skill's full value — notably `files_crud` drops from 978s/10 errs on 4.6 to **44s/1 err** on 4.7 (22x faster). Codex remains the cheapest by ~10x and most efficient by a wide margin.

### Changes

**Correctness rules (eval-driven):**
- "No top-level notte scrape" warning
- "IDs are flags not positional" rule
- form-fill JSON schema enum (full_name, email, etc.)
- Function file contract (.py, sync def run, session constructor)
- Cron examples fixed to 6-field AWS-style
- Tab re-indexing after close-tab
- Scroll-fail to keyboard fallback (PageDown/End)
- Stale current-session trap + SID capture recovery pattern
- notte files has no delete subcommand - guided graceful exit
- Flag-name traps (--instructions plural, sessions start no --url)
- One-agent-per-session 409 note

**CLI accuracy fixes (deep verification):**
- --proxies to --proxy (singular, matches CLI)
- Default timeout 30 to 60
- files list default is --downloads, not --uploads
- Added 8 missing sessions start flags (--proxy-country, --profile-id, --vault-id, --profile-persist, --web-bot-auth, --screenshot-type, --chrome-args, --extra-http-headers)
- Added missing session subcommands: code, offset, viewer
- Added page eval-js to utilities
- Added agents start flags: --url, --use-vision, --response-format-json, --session-offset
- Added profiles section (was completely missing)
- Fixed sessions replay description + --path flag
- Added --path/--urls-only to sessions network
- Added [output-path] to page screenshot
- Added --var/--vars to functions run
- Added --path to files download
- Added --name to profiles create, --name/--page/--page-size to profiles list
- Fixed --headless default (removed false default: true)
- Added chrome-nightly to --browser-type options

**Token optimization:**
- Moved 95-line troubleshooting block to references/troubleshooting.md

### Eval methodology

- 23 coverage tasks, one per CLI command group
- Python harness: Claude Agent SDK + Codex CLI (codex exec --json, token counts from turn.completed events)
- WebFetch/WebSearch blocked to isolate skill-only signal
- Deep CLI verification: ran --help for every notte subcommand and cross-referenced SKILL.md
- Multiple iterations with trace analysis to identify general patterns (not overfitting)

## Test plan

- [x] v1.0 baseline on Claude Opus 4.6 (23 tasks)
- [x] v1.1 on Claude Opus 4.6 (23 tasks)
- [x] v1.1 on Claude Opus 4.7 (23 tasks)
- [x] v1.0 baseline on Codex gpt-5.3-codex (23 tasks)
- [x] v1.1 on Codex gpt-5.3-codex (23 tasks)
- [x] Regression analysis on worst-performing tasks (all variance, no skill defects)

Generated with Claude Code