### PR TITLE
Add `make check` target to verify generated code is up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean test test-integration test-all lint fmt generate setup help
+.PHONY: build install clean test test-integration test-all lint fmt generate check setup help
 
 VERSION ?= dev
 LDFLAGS := -ldflags "-X main.version=$(VERSION)"
@@ -71,5 +71,16 @@ fmt: ## Format code
 
 generate: ## Generate code (API client, etc.)
 	./scripts/generate.sh
+
+check: ## Verify generated code is up to date (fails if `make generate` would produce a diff)
+	@echo "Checking for local changes in generated files..."
+	@git diff --quiet -- internal/api/client.gen.go internal/api/property_names.gen.go 'internal/cmd/*_flags.gen.go' || \
+		(echo "Error: generated files have uncommitted local changes. Commit or stash them before running 'make check'." && exit 2)
+	@echo "Running code generation..."
+	@./scripts/generate.sh >/dev/null
+	@echo "Checking for diffs in generated files..."
+	@git diff --exit-code -- internal/api/client.gen.go internal/api/property_names.gen.go 'internal/cmd/*_flags.gen.go' || \
+		(echo "Generated code is out of date. Run 'make generate' and commit the changes." && exit 1)
+	@echo "✓ Generated code is up to date"
 
 .DEFAULT_GOAL := build

--- a/Makefile
+++ b/Makefile
@@ -74,13 +74,13 @@ generate: ## Generate code (API client, etc.)
 
 check: ## Verify generated code is up to date (fails if `make generate` would produce a diff)
 	@echo "Checking for local changes in generated files..."
-	@git diff --quiet -- internal/api/client.gen.go internal/api/property_names.gen.go 'internal/cmd/*_flags.gen.go' || \
-		(echo "Error: generated files have uncommitted local changes. Commit or stash them before running 'make check'." && exit 2)
+	@[ -z "$$(git status --porcelain -- internal/api/client.gen.go internal/api/property_names.gen.go 'internal/cmd/*_flags.gen.go')" ] || \
+		(echo "Error: generated files have uncommitted local changes (including staged or untracked). Commit or stash them before running 'make check'." && exit 2)
 	@echo "Running code generation..."
 	@./scripts/generate.sh >/dev/null
 	@echo "Checking for diffs in generated files..."
-	@git diff --exit-code -- internal/api/client.gen.go internal/api/property_names.gen.go 'internal/cmd/*_flags.gen.go' || \
-		(echo "Generated code is out of date. Run 'make generate' and commit the changes." && exit 1)
+	@[ -z "$$(git status --porcelain -- internal/api/client.gen.go internal/api/property_names.gen.go 'internal/cmd/*_flags.gen.go')" ] || \
+		(echo "Generated code is out of date. Run 'make generate' and commit the changes." && git status --short -- internal/api/client.gen.go internal/api/property_names.gen.go 'internal/cmd/*_flags.gen.go' && exit 1)
 	@echo "✓ Generated code is up to date"
 
 .DEFAULT_GOAL := build


### PR DESCRIPTION
## Summary
- Adds a `make check` target that runs `./scripts/generate.sh` and fails with exit 1 if it produces a diff in the generated files (`internal/api/client.gen.go`, `internal/api/property_names.gen.go`, `internal/cmd/*_flags.gen.go`).
- Pre-checks the working tree first: if those generated files already have uncommitted local changes, it exits 2 with a distinct message so a dirty tree isn't misreported as generator drift.

Not a true dry run — `generate.sh` writes to disk, so `make check` will overwrite the files and rely on `git diff` to detect drift. A pure dry-run would require refactoring the script to write to a temp dir.

## Test plan
- [ ] On a clean tree with up-to-date generated files, `make check` exits 0.
- [ ] After manually editing `internal/api/client.gen.go`, `make check` exits 2 with the "uncommitted local changes" message.
- [ ] After a spec change that would regenerate output, `make check` exits 1 with the "out of date" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `check` Make target that pre-checks for uncommitted local changes in generated files (exiting 2), runs `generate.sh`, then checks `git status --porcelain` to detect drift (exiting 1). The use of `git status --porcelain` correctly captures both staged and working-tree changes relative to HEAD, resolving the previous concern about `git diff --quiet` comparing against the index.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only a minor UX nit in an error message remains.

The implementation is logically sound: `git status --porcelain` correctly detects staged, unstaged, and untracked changes relative to HEAD. The only remaining finding is a P2 wording improvement in the post-drift error message.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Makefile | Adds a `check` target using `git status --porcelain` to pre-check for dirty generated files and post-check for generator drift; logic is correct, one minor UX nit in the post-drift error message. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AMakefile%3A83%0A**Misleading%20post-drift%20message**%0A%0ABy%20the%20time%20this%20line%20is%20reached%2C%20%60.%2Fscripts%2Fgenerate.sh%60%20has%20already%20run%20%28line%2080%29%20and%20the%20files%20have%20already%20been%20updated%20on%20disk.%20Telling%20the%20user%20to%20%22Run%20'make%20generate'%22%20is%20redundant%20and%20potentially%20confusing%20%E2%80%94%20they%20only%20need%20to%20commit%20the%20files%20that%20were%20just%20regenerated.%0A%0A%60%60%60suggestion%0A%09%09%28echo%20%22Generated%20code%20is%20out%20of%20date.%20Run%20'git%20add'%20and%20commit%20the%20regenerated%20files%20above.%22%20%26%26%20git%20status%20--short%20--%20internal%2Fapi%2Fclient.gen.go%20internal%2Fapi%2Fproperty_names.gen.go%20'internal%2Fcmd%2F*_flags.gen.go'%20%26%26%20exit%201%29%0A%60%60%60%0A%0A&repo=nottelabs%2Fnotte-cli"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Makefile
Line: 83

Comment:
**Misleading post-drift message**

By the time this line is reached, `./scripts/generate.sh` has already run (line 80) and the files have already been updated on disk. Telling the user to "Run 'make generate'" is redundant and potentially confusing — they only need to commit the files that were just regenerated.

```suggestion
		(echo "Generated code is out of date. Run 'git add' and commit the regenerated files above." && git status --short -- internal/api/client.gen.go internal/api/property_names.gen.go 'internal/cmd/*_flags.gen.go' && exit 1)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["Address PR review: detect staged changes..."](https://github.com/nottelabs/notte-cli/commit/37e7c8cd608ab40632d51e802ac4a2a6a17e9acc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=21141666)</sub>

<!-- /greptile_comment -->