### PR TITLE
ci: fix reflect.Ptr lint break and pin golangci-lint version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # Pinned (rather than `latest`) so new linter releases can't silently
+          # break CI by enabling new analyzers. Bump intentionally.
+          version: v2.12.0
 
       - name: Build
         run: go build -v ./...

--- a/internal/cmd/output_helpers.go
+++ b/internal/cmd/output_helpers.go
@@ -159,14 +159,14 @@ func printSessionStatus(resp *api.SessionResponse) error {
 
 		// Skip nil pointers, nil slices, nil maps, and nil interfaces
 		switch fieldValue.Kind() {
-		case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface:
+		case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Interface:
 			if fieldValue.IsNil() {
 				continue
 			}
 		}
 
 		var displayValue any
-		if fieldValue.Kind() == reflect.Ptr {
+		if fieldValue.Kind() == reflect.Pointer {
 			displayValue = fieldValue.Elem().Interface()
 		} else {
 			displayValue = fieldValue.Interface()

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -25,7 +25,7 @@ func (f *TextFormatter) Print(data any) error {
 	v := reflect.ValueOf(data)
 
 	// Handle pointers by dereferencing
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			_, err := fmt.Fprintln(f.Writer, "<nil>")
 			return err
@@ -85,7 +85,7 @@ func (f *TextFormatter) printStructWithIndent(data any, indent string) error {
 
 		// Skip nil pointers, nil slices, nil maps, and nil interfaces
 		switch fieldValue.Kind() {
-		case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface:
+		case reflect.Pointer, reflect.Slice, reflect.Map, reflect.Interface:
 			if fieldValue.IsNil() {
 				continue
 			}
@@ -94,7 +94,7 @@ func (f *TextFormatter) printStructWithIndent(data any, indent string) error {
 		label := f.colorize(indent+field.Name+":", termenv.ANSICyan)
 
 		// Handle pointer fields by dereferencing
-		if fieldValue.Kind() == reflect.Ptr {
+		if fieldValue.Kind() == reflect.Pointer {
 			fieldValue = fieldValue.Elem()
 		}
 
@@ -133,7 +133,7 @@ func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent st
 
 	// Check if it's a slice of structs
 	elemType := v.Type().Elem()
-	if elemType.Kind() == reflect.Ptr {
+	if elemType.Kind() == reflect.Pointer {
 		elemType = elemType.Elem()
 	}
 	if elemType.Kind() == reflect.Struct {
@@ -142,7 +142,7 @@ func (f *TextFormatter) printSliceField(v reflect.Value, label string, indent st
 		}
 		for i := 0; i < v.Len(); i++ {
 			elem := v.Index(i)
-			if elem.Kind() == reflect.Ptr {
+			if elem.Kind() == reflect.Pointer {
 				elem = elem.Elem()
 			}
 			if i > 0 {


### PR DESCRIPTION
## Summary

Unblocks CI on `main` and every open PR. CI has been red since the v0.0.14 brew bump (commit `def75ad`) because the workflow uses `golangci-lint-action` with `version: latest`. Latest is currently `v2.12.0`, which enabled the `govet` "inline" analyzer; that analyzer flags `reflect.Ptr` (deprecated in Go 1.18 in favour of `reflect.Pointer`).

Two related changes in one PR:

1. **`reflect.Ptr` → `reflect.Pointer`** across `internal/cmd/output_helpers.go` and `internal/output/text.go` (7 sites). The lint output only named 3 of the 7, but the deprecation is identical across all of them; doing them consistently avoids leaving partial cleanup behind.
2. **Pin `golangci-lint-action` to `v2.12.0`** in `.github/workflows/ci.yml` instead of `latest`. Future bumps become intentional commits, and a new linter release can't silently re-break CI by enabling another analyzer.

## Test plan

- [x] `go build ./...` passes locally
- [x] No `reflect.Ptr` usages remain (`grep -rn 'reflect\.Ptr\b' . --include='*.go'` returns nothing)
- [ ] CI `Lint` job passes on this PR (the proof point)

## Notes

- Behaviour is unchanged: `reflect.Pointer` and `reflect.Ptr` are the same constant; the rename is purely a deprecation alias.
- Pinning at `v2.12.0` matches what CI is *already* running, so the pin doesn't change current behaviour — it just freezes future drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)