### PR TITLE
docs: align README theme with main notte repo + add notte.cc backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Browser automation in your terminal
+# Notte CLI - Browser automation in your terminal
 
 <div align="center">
   <p>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
-# Notte CLI
+# Browser automation in your terminal
 
-Browser automation in your terminal.
+<div align="center">
+  <p>
+    Control browser sessions, AI agents, and web scraping through intuitive <strong>resource-based commands</strong> <br/>
+    → Read more at: <a href="https://notte.cc?ref=github" target="_blank" rel="noopener noreferrer">Landing</a> • <a href="https://console.notte.cc/?ref=github" target="_blank" rel="noopener noreferrer">Console</a> • <a href="https://docs.notte.cc?ref=github" target="_blank" rel="noopener noreferrer">Docs</a> • <a href="https://x.com/nottecore?ref=github" target="_blank" rel="noopener noreferrer">X</a> • <a href="https://www.linkedin.com/company/nottelabsinc/?ref=github" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+  </p>
+</div>
 
-Control browser sessions, AI agents, and web scraping through intuitive resource-based commands.
+[![GitHub stars](https://img.shields.io/github/stars/nottelabs/notte-cli?style=social)](https://github.com/nottelabs/notte-cli/stargazers)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Go 1.25+](https://img.shields.io/badge/go-1.25+-blue.svg)](https://go.dev/)
+[![Homebrew](https://img.shields.io/badge/homebrew-nottelabs%2Fnotte--cli-blue.svg)](https://github.com/nottelabs/notte-cli)
+
+---
+
+# What is Notte CLI?
+
+The Notte CLI brings the full power of [notte.cc](https://notte.cc?ref=github) to your terminal — letting you drive browser sessions, AI agents, and web scraping pipelines from the command line. Pair it with shell scripts, CI/CD pipelines, or AI coding assistants for repeatable, scriptable web automation.
 
 ## Features
 
@@ -444,8 +458,13 @@ This installs [lefthook](https://github.com/evilmartians/lefthook) pre-commit an
 
 ## License
 
-MIT
+This project is licensed under the MIT License.
 
 ## Links
 
-- [Notte API Documentation](https://notte.cc/docs)
+- [Landing](https://notte.cc?ref=github)
+- [Console](https://console.notte.cc/?ref=github)
+- [Documentation](https://docs.notte.cc?ref=github)
+- [Main repository (nottelabs/notte)](https://github.com/nottelabs/notte)
+
+Copyright © 2025 Notte Labs, Inc.


### PR DESCRIPTION
## Summary
- Restyle the README header to match `nottelabs/notte`: title-as-tagline, centered nav row with **Landing / Console / Docs / X / LinkedIn**, badge row, and a `What is Notte CLI?` intro section.
- Add explicit back-links to **notte.cc** (Landing) in the header, intro paragraph, and Links footer.
- Update the footer to mirror the main repo: license blurb, Links list (Landing, Console, Docs, main repo), and `Copyright © 2025 Notte Labs, Inc.`
- All existing sections (Installation, Quick Start, Commands, Examples, etc.) remain unchanged.

## Test plan
- [ ] Render `README.md` on GitHub and confirm the centered nav, badges, separator, and footer display correctly.
- [ ] Click each link (notte.cc, console, docs, X, LinkedIn, main repo) and verify they resolve.
- [ ] Confirm badges (stars, license, Go version, Homebrew) load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)