### PR TITLE
Add function secrets commands

### DIFF
--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -33,6 +33,7 @@ var (
 	functionCronExpression   string
 	functionRunVariables     []string // Variables as key=value pairs
 	functionRunVariablesJSON string   // Variables as JSON string
+	functionSecretValue      string
 )
 
 // GetCurrentFunctionID returns the function ID from flag, env var, or file (in priority order)
@@ -95,9 +96,10 @@ func RequireFunctionID() error {
 }
 
 var functionsCmd = &cobra.Command{
-	Use:   "functions",
-	Short: "Manage functions",
-	Long:  "List, create, and operate on functions.",
+	Use:     "functions",
+	Aliases: []string{"function"},
+	Short:   "Manage functions",
+	Long:    "List, create, and operate on functions.",
 }
 
 var functionsListCmd = &cobra.Command{
@@ -198,6 +200,40 @@ var functionsUnscheduleCmd = &cobra.Command{
 	RunE:  runFunctionUnschedule,
 }
 
+var functionSecretsCmd = &cobra.Command{
+	Use:   "secrets",
+	Short: "Manage function environment secrets",
+}
+
+var functionSecretsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List function environment secrets",
+	Args:  cobra.NoArgs,
+	RunE:  runFunctionSecretsList,
+}
+
+var functionSecretsGetCmd = &cobra.Command{
+	Use:   "get <name>",
+	Short: "Get a function environment secret value",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFunctionSecretsGet,
+}
+
+var functionSecretsSetCmd = &cobra.Command{
+	Use:   "set <name> [value]",
+	Short: "Set a function environment secret",
+	Args:  cobra.RangeArgs(1, 2),
+	RunE:  runFunctionSecretsSet,
+}
+
+var functionSecretsDeleteCmd = &cobra.Command{
+	Use:     "delete <secret-id>",
+	Aliases: []string{"rm"},
+	Short:   "Delete a function environment secret",
+	Args:    cobra.ExactArgs(1),
+	RunE:    runFunctionSecretsDelete,
+}
+
 func init() {
 	rootCmd.AddCommand(functionsCmd)
 	functionsCmd.AddCommand(functionsListCmd)
@@ -219,6 +255,11 @@ func init() {
 	functionsCmd.AddCommand(functionsRunMetadataUpdateCmd)
 	functionsCmd.AddCommand(functionsScheduleCmd)
 	functionsCmd.AddCommand(functionsUnscheduleCmd)
+	functionsCmd.AddCommand(functionSecretsCmd)
+	functionSecretsCmd.AddCommand(functionSecretsListCmd)
+	functionSecretsCmd.AddCommand(functionSecretsGetCmd)
+	functionSecretsCmd.AddCommand(functionSecretsSetCmd)
+	functionSecretsCmd.AddCommand(functionSecretsDeleteCmd)
 
 	// Create command flags
 	functionsCreateCmd.Flags().StringVar(&functionsCreateFile, "file", "", "Path to function file (required)")
@@ -272,6 +313,9 @@ func init() {
 
 	// Unschedule command flags
 	functionsUnscheduleCmd.Flags().StringVar(&functionID, "function-id", "", "Function ID (uses current function if not specified)")
+
+	// Function secrets command flags
+	functionSecretsSetCmd.Flags().StringVar(&functionSecretValue, "value", "", "Secret value")
 }
 
 func runFunctionsList(cmd *cobra.Command, args []string) error {
@@ -827,5 +871,134 @@ func runFunctionUnschedule(cmd *cobra.Command, args []string) error {
 	return PrintResult(fmt.Sprintf("Function %s schedule removed.", functionID), map[string]any{
 		"id":     functionID,
 		"status": "unscheduled",
+	})
+}
+
+func functionSecretsNamespace() api.SecretNamespace {
+	return api.FunctionEnv
+}
+
+func runFunctionSecretsList(cmd *cobra.Command, args []string) error {
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := GetContextWithTimeout(cmd.Context())
+	defer cancel()
+
+	namespace := functionSecretsNamespace()
+	params := &api.ListSecretsParams{Namespace: &namespace}
+	resp, err := client.Client().ListSecretsWithResponse(ctx, params)
+	if err != nil {
+		return fmt.Errorf("API request failed: %w", err)
+	}
+
+	if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return err
+	}
+
+	var items []api.SecretMetadata
+	if resp.JSON200 != nil {
+		items = resp.JSON200.Items
+	}
+	if printed, err := PrintListOrEmpty(items, "No function environment secrets found."); err != nil {
+		return err
+	} else if printed {
+		return nil
+	}
+
+	return GetFormatter().Print(items)
+}
+
+func runFunctionSecretsGet(cmd *cobra.Command, args []string) error {
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := GetContextWithTimeout(cmd.Context())
+	defer cancel()
+
+	params := &api.GetSecretParams{Namespace: functionSecretsNamespace()}
+	resp, err := client.Client().GetSecretWithResponse(ctx, args[0], params)
+	if err != nil {
+		return fmt.Errorf("API request failed: %w", err)
+	}
+
+	if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return err
+	}
+
+	return GetFormatter().Print(resp.JSON200)
+}
+
+func runFunctionSecretsSet(cmd *cobra.Command, args []string) error {
+	value := functionSecretValue
+	if len(args) == 2 {
+		value = args[1]
+	}
+	if value == "" && !cmd.Flags().Changed("value") {
+		return fmt.Errorf("secret value required: pass it as an argument or with --value")
+	}
+
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := GetContextWithTimeout(cmd.Context())
+	defer cancel()
+
+	body := api.StoreSecretJSONRequestBody{
+		Name:      args[0],
+		Namespace: functionSecretsNamespace(),
+		Value:     value,
+	}
+	params := &api.StoreSecretParams{}
+	resp, err := client.Client().StoreSecretWithResponse(ctx, params, body)
+	if err != nil {
+		return fmt.Errorf("API request failed: %w", err)
+	}
+
+	if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return err
+	}
+
+	return GetFormatter().Print(resp.JSON201)
+}
+
+func runFunctionSecretsDelete(cmd *cobra.Command, args []string) error {
+	secretID := args[0]
+
+	confirmed, err := ConfirmAction("function environment secret", secretID)
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		return PrintResult("Cancelled.", map[string]any{"cancelled": true})
+	}
+
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := GetContextWithTimeout(cmd.Context())
+	defer cancel()
+
+	params := &api.DeleteSecretParams{}
+	resp, err := client.Client().DeleteSecretWithResponse(ctx, secretID, params)
+	if err != nil {
+		return fmt.Errorf("API request failed: %w", err)
+	}
+
+	if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return err
+	}
+
+	return PrintResult(fmt.Sprintf("Function environment secret %s deleted.", secretID), map[string]any{
+		"id":     secretID,
+		"status": "deleted",
 	})
 }

--- a/internal/cmd/functions_test.go
+++ b/internal/cmd/functions_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,11 +30,14 @@ func setupFunctionTest(t *testing.T) *testutil.MockServer {
 
 	origFunctionID := functionID
 	origRunID := functionRunID
+	origSecretValue := functionSecretValue
 	functionID = functionIDTest
 	functionRunID = functionRunIDTest
+	functionSecretValue = ""
 	t.Cleanup(func() {
 		functionID = origFunctionID
 		functionRunID = origRunID
+		functionSecretValue = origSecretValue
 	})
 
 	return server
@@ -53,6 +57,10 @@ func functionRunJSON() string {
 
 func updateFunctionRunJSON() string {
 	return `{"function_id":"` + functionIDTest + `","function_run_id":"` + functionRunIDTest + `","updated_at":"2020-01-01T00:00:00Z","status":"STOPPED"}`
+}
+
+func secretMetadataJSON() string {
+	return `{"id":"sec_123","name":"API_KEY","namespace":"function_env","key_hint":"API***","created_at":"2020-01-01T00:00:00Z"}`
 }
 
 func TestRunFunctionsList_Success(t *testing.T) {
@@ -110,6 +118,149 @@ func TestRunFunctionsList_Empty(t *testing.T) {
 
 	if !strings.Contains(stdout, "No functions found.") {
 		t.Errorf("expected empty message, got %q", stdout)
+	}
+}
+
+func TestRunFunctionSecretsList_Success(t *testing.T) {
+	server := setupFunctionTest(t)
+	server.AddResponse("/secrets", 200, `{"items":[`+secretMetadataJSON()+`]}`)
+
+	origFormat := outputFormat
+	outputFormat = "json"
+	t.Cleanup(func() { outputFormat = origFormat })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	stdout, _ := testutil.CaptureOutput(func() {
+		err := runFunctionSecretsList(cmd, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, `"namespace":"function_env"`) {
+		t.Errorf("expected function_env secret in output, got %q", stdout)
+	}
+
+	requests := server.Requests("/secrets")
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+	if requests[0].Method != "GET" {
+		t.Errorf("method = %q, want GET", requests[0].Method)
+	}
+	if !strings.Contains(requests[0].Query, "namespace=function_env") {
+		t.Errorf("query = %q, want namespace=function_env", requests[0].Query)
+	}
+}
+
+func TestRunFunctionSecretsGet_Success(t *testing.T) {
+	server := setupFunctionTest(t)
+	server.AddResponse("/secrets/API_KEY", 200, `{"value":"secret-value"}`)
+
+	origFormat := outputFormat
+	outputFormat = "json"
+	t.Cleanup(func() { outputFormat = origFormat })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	stdout, _ := testutil.CaptureOutput(func() {
+		err := runFunctionSecretsGet(cmd, []string{"API_KEY"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, `"value":"secret-value"`) {
+		t.Errorf("expected secret value in output, got %q", stdout)
+	}
+
+	requests := server.Requests("/secrets/API_KEY")
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+	if requests[0].Method != "GET" {
+		t.Errorf("method = %q, want GET", requests[0].Method)
+	}
+	if !strings.Contains(requests[0].Query, "namespace=function_env") {
+		t.Errorf("query = %q, want namespace=function_env", requests[0].Query)
+	}
+}
+
+func TestRunFunctionSecretsSet_Success(t *testing.T) {
+	server := setupFunctionTest(t)
+	server.AddResponse("/secrets", 201, secretMetadataJSON())
+
+	origFormat := outputFormat
+	outputFormat = "json"
+	t.Cleanup(func() { outputFormat = origFormat })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	stdout, _ := testutil.CaptureOutput(func() {
+		err := runFunctionSecretsSet(cmd, []string{"API_KEY", "secret-value"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, `"id":"sec_123"`) {
+		t.Errorf("expected secret metadata in output, got %q", stdout)
+	}
+
+	requests := server.Requests("/secrets")
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+	if requests[0].Method != "POST" {
+		t.Errorf("method = %q, want POST", requests[0].Method)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal([]byte(requests[0].Body), &body); err != nil {
+		t.Fatalf("failed to parse request body: %v", err)
+	}
+	if body["namespace"] != "function_env" {
+		t.Errorf("namespace = %q, want function_env", body["namespace"])
+	}
+	if body["name"] != "API_KEY" || body["value"] != "secret-value" {
+		t.Errorf("unexpected request body: %#v", body)
+	}
+}
+
+func TestRunFunctionSecretsDelete_Success(t *testing.T) {
+	server := setupFunctionTest(t)
+	server.AddResponse("/secrets/sec_123", 204, ``)
+	SetSkipConfirmation(true)
+	t.Cleanup(func() { SetSkipConfirmation(false) })
+
+	origFormat := outputFormat
+	outputFormat = "json"
+	t.Cleanup(func() { outputFormat = origFormat })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	stdout, _ := testutil.CaptureOutput(func() {
+		err := runFunctionSecretsDelete(cmd, []string{"sec_123"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, `"status":"deleted"`) {
+		t.Errorf("expected deleted status in output, got %q", stdout)
+	}
+
+	requests := server.Requests("/secrets/sec_123")
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(requests))
+	}
+	if requests[0].Method != "DELETE" {
+		t.Errorf("method = %q, want DELETE", requests[0].Method)
 	}
 }
 

--- a/internal/testutil/httpserver.go
+++ b/internal/testutil/httpserver.go
@@ -2,6 +2,8 @@
 package testutil
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -18,6 +20,7 @@ type MockResponse struct {
 type RecordedRequest struct {
 	Method  string
 	Path    string
+	Query   string
 	Headers http.Header
 	Body    string
 }
@@ -61,13 +64,22 @@ func NewMockServer() *MockServer {
 }
 
 func (ms *MockServer) recordRequest(r *http.Request) {
+	var body []byte
+	if r.Body != nil {
+		body, _ = io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		r.Body = io.NopCloser(bytes.NewReader(body))
+	}
+
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
 	rec := RecordedRequest{
 		Method:  r.Method,
 		Path:    r.URL.Path,
+		Query:   r.URL.RawQuery,
 		Headers: r.Header.Clone(),
+		Body:    string(body),
 	}
 
 	ms.requests[r.URL.Path] = append(ms.requests[r.URL.Path], rec)

--- a/tests/integration/functions_test.go
+++ b/tests/integration/functions_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -109,6 +110,64 @@ func TestFunctionsCreateThenDelete(t *testing.T) {
 	t.Logf("Created function: %s (version: %s)", functionID, createResp.LatestVersion)
 
 	t.Log("Function create then delete test completed successfully")
+}
+
+func TestFunctionSecretsLifecycle(t *testing.T) {
+	secretName := "INTEGRATION_SECRET_" + strings.NewReplacer("-", "_", ":", "_", ".", "_").Replace(time.Now().UTC().Format(time.RFC3339Nano))
+	secretValue := "integration-secret-value"
+
+	result := runCLI(t, "function", "secrets", "set", secretName, secretValue)
+	requireSuccess(t, result)
+
+	var setResp struct {
+		ID        string `json:"id"`
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &setResp); err != nil {
+		t.Fatalf("Failed to parse secret set response: %v", err)
+	}
+	if setResp.ID == "" {
+		t.Fatal("No secret ID returned from set command")
+	}
+	if setResp.Name != secretName {
+		t.Errorf("Expected secret name %q, got %q", secretName, setResp.Name)
+	}
+	if setResp.Namespace != "function_env" {
+		t.Errorf("Expected namespace function_env, got %q", setResp.Namespace)
+	}
+	deleted := false
+	defer func() {
+		if !deleted {
+			result := runCLI(t, "function", "secrets", "delete", setResp.ID)
+			if result.ExitCode != 0 {
+				t.Logf("Warning: failed to cleanup function secret %s: %s", setResp.ID, result.Stderr)
+			}
+		}
+	}()
+
+	result = runCLI(t, "function", "secrets", "get", secretName)
+	requireSuccess(t, result)
+	var getResp struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &getResp); err != nil {
+		t.Fatalf("Failed to parse secret get response: %v", err)
+	}
+	if getResp.Value != secretValue {
+		t.Errorf("Expected secret value %q, got %q", secretValue, getResp.Value)
+	}
+
+	result = runCLI(t, "function", "secrets", "list")
+	requireSuccess(t, result)
+	if !containsString(result.Stdout, secretName) {
+		t.Errorf("Function secrets list did not contain %q", secretName)
+	}
+
+	result = runCLI(t, "function", "secrets", "delete", setResp.ID)
+	requireSuccess(t, result)
+	deleted = true
+	t.Log("Function secrets lifecycle test completed successfully")
 }
 
 func TestFunctionsLifecycle(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `notte function secrets` / `notte functions secrets` commands for list, get, set, and delete
- wire function secrets to `/secrets` with `function_env` namespace
- add unit coverage for request methods, query params, and request body namespace
- add integration lifecycle coverage for set/get/list/delete

## Tests
- `go test ./internal/cmd ./internal/testutil`
- `go test ./...`
- `NOTTE_API_KEY=dummy go test -tags integration ./tests/integration -run '^$'`\n- `go run ./cmd/notte function secrets --help`\n\nNote: live integration test was not run locally because no real `NOTTE_API_KEY` was available in this shell.