### PR TITLE
fix: don't kill sibling sessions when `sessions start` runs without a TTY

### DIFF
--- a/internal/cmd/agents.go
+++ b/internal/cmd/agents.go
@@ -266,8 +266,10 @@ func runAgentsStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Save agent ID as current agent
-	if resp.JSON200 != nil {
+	// Save agent ID as current agent, but only when running interactively.
+	// In non-TTY contexts (scripts, CI, parallel workers) writing to the shared
+	// ~/.notte/cli/current_agent file races with sibling processes.
+	if resp.JSON200 != nil && isInteractiveStdin() {
 		if err := setCurrentAgent(resp.JSON200.AgentId); err != nil {
 			PrintInfo(fmt.Sprintf("Warning: could not save current agent: %v", err))
 		}

--- a/internal/cmd/agents_test.go
+++ b/internal/cmd/agents_test.go
@@ -546,6 +546,8 @@ func TestRequireAgentID_FromFile(t *testing.T) {
 }
 
 func TestAgentsStart_SetsCurrentAgent(t *testing.T) {
+	withInteractiveStdinForTest(t)
+
 	env := testutil.SetupTestEnv(t)
 	env.SetEnv("NOTTE_API_KEY", "test-key")
 

--- a/internal/cmd/confirm.go
+++ b/internal/cmd/confirm.go
@@ -7,10 +7,18 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"golang.org/x/term"
 )
 
 // skipConfirmation is set by --yes flag to skip prompts
 var skipConfirmation bool
+
+// isInteractiveStdin reports whether stdin is connected to a terminal.
+// Indirected through a variable so tests can override it.
+var isInteractiveStdin = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
 
 // ConfirmAction prompts the user to confirm a destructive action.
 // Returns true if confirmed, false otherwise.
@@ -38,10 +46,14 @@ func ConfirmActionWithIO(in io.Reader, out io.Writer, resource, id string) (bool
 }
 
 // confirmReplaceSession prompts the user to confirm stopping an existing session before starting a new one.
-// Defaults to "yes" if user just presses Enter.
+// Defaults to "yes" if the user just presses Enter on an interactive terminal.
+// Returns false (do nothing destructive) when stdin is not a terminal, unless --yes was passed.
 func confirmReplaceSession(id string) (bool, error) {
 	if skipConfirmation {
 		return true, nil
+	}
+	if !isInteractiveStdin() {
+		return false, nil
 	}
 	return confirmReplaceSessionWithIO(os.Stdin, os.Stderr, id)
 }
@@ -63,10 +75,14 @@ func confirmReplaceSessionWithIO(in io.Reader, out io.Writer, id string) (bool, 
 }
 
 // confirmReplaceAgent prompts the user to confirm stopping an existing agent before starting a new one.
-// Defaults to "yes" if user just presses Enter.
+// Defaults to "yes" if the user just presses Enter on an interactive terminal.
+// Returns false (do nothing destructive) when stdin is not a terminal, unless --yes was passed.
 func confirmReplaceAgent(id string) (bool, error) {
 	if skipConfirmation {
 		return true, nil
+	}
+	if !isInteractiveStdin() {
+		return false, nil
 	}
 	return confirmReplaceAgentWithIO(os.Stdin, os.Stderr, id)
 }
@@ -93,11 +109,14 @@ func SetSkipConfirmation(skip bool) {
 }
 
 // ConfirmStop prompts the user to confirm stopping a resource.
-// Defaults to "yes" if user just presses Enter.
-// Returns true if confirmed, false otherwise.
+// Defaults to "yes" if the user just presses Enter on an interactive terminal.
+// Returns false (do nothing destructive) when stdin is not a terminal, unless --yes was passed.
 func ConfirmStop(resource, id string) (bool, error) {
 	if skipConfirmation {
 		return true, nil
+	}
+	if !isInteractiveStdin() {
+		return false, nil
 	}
 	return ConfirmStopWithIO(os.Stdin, os.Stderr, resource, id)
 }

--- a/internal/cmd/confirm_test.go
+++ b/internal/cmd/confirm_test.go
@@ -181,3 +181,89 @@ func TestConfirmReplaceAgentWithIO_Errors(t *testing.T) {
 		t.Fatal("expected read error")
 	}
 }
+
+// withNonInteractiveStdin temporarily overrides isInteractiveStdin to report false.
+func withNonInteractiveStdin(t *testing.T) {
+	t.Helper()
+	prev := isInteractiveStdin
+	isInteractiveStdin = func() bool { return false }
+	t.Cleanup(func() { isInteractiveStdin = prev })
+}
+
+func TestConfirmReplaceSession_NonTTYDefaultsToFalse(t *testing.T) {
+	withNonInteractiveStdin(t)
+
+	ok, err := confirmReplaceSession("sess_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected non-TTY confirm to default to false")
+	}
+}
+
+func TestConfirmReplaceSession_NonTTYSkipConfirmationStillReturnsTrue(t *testing.T) {
+	withNonInteractiveStdin(t)
+	SetSkipConfirmation(true)
+	t.Cleanup(func() { SetSkipConfirmation(false) })
+
+	ok, err := confirmReplaceSession("sess_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected --yes to still return true even on non-TTY stdin")
+	}
+}
+
+func TestConfirmReplaceAgent_NonTTYDefaultsToFalse(t *testing.T) {
+	withNonInteractiveStdin(t)
+
+	ok, err := confirmReplaceAgent("agent_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected non-TTY confirm to default to false")
+	}
+}
+
+func TestConfirmReplaceAgent_NonTTYSkipConfirmationStillReturnsTrue(t *testing.T) {
+	withNonInteractiveStdin(t)
+	SetSkipConfirmation(true)
+	t.Cleanup(func() { SetSkipConfirmation(false) })
+
+	ok, err := confirmReplaceAgent("agent_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected --yes to still return true even on non-TTY stdin")
+	}
+}
+
+func TestConfirmStop_NonTTYDefaultsToFalse(t *testing.T) {
+	withNonInteractiveStdin(t)
+
+	ok, err := ConfirmStop("session", "sess_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected non-TTY confirm to default to false")
+	}
+}
+
+func TestConfirmStop_NonTTYSkipConfirmationStillReturnsTrue(t *testing.T) {
+	withNonInteractiveStdin(t)
+	SetSkipConfirmation(true)
+	t.Cleanup(func() { SetSkipConfirmation(false) })
+
+	ok, err := ConfirmStop("session", "sess_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected --yes to still return true even on non-TTY stdin")
+	}
+}

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -588,8 +588,12 @@ func runSessionsStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Save session ID as current session
-	if resp.JSON200 != nil {
+	// Save session ID as current session, but only when running interactively.
+	// In non-TTY contexts (scripts, CI, parallel workers) writing to the shared
+	// ~/.notte/cli/current_session file is the root of a race where sibling
+	// processes can read each other's IDs and stop them. Scripted callers should
+	// thread the session ID explicitly via --session-id or NOTTE_SESSION_ID.
+	if resp.JSON200 != nil && isInteractiveStdin() {
 		if err := setCurrentSession(resp.JSON200.SessionId); err != nil {
 			PrintInfo(fmt.Sprintf("Warning: could not save current session: %v", err))
 		}

--- a/internal/cmd/sessions_test.go
+++ b/internal/cmd/sessions_test.go
@@ -819,6 +819,132 @@ func TestRunSessionWorkflowCode(t *testing.T) {
 	}
 }
 
+// withNonInteractiveStdinForTest forces isInteractiveStdin to report non-TTY for the test duration.
+func withNonInteractiveStdinForTest(t *testing.T) {
+	t.Helper()
+	prev := isInteractiveStdin
+	isInteractiveStdin = func() bool { return false }
+	t.Cleanup(func() { isInteractiveStdin = prev })
+}
+
+// withInteractiveStdinForTest forces isInteractiveStdin to report TTY for the test duration.
+// Use when verifying behaviors that are gated on interactive mode (e.g. writing to
+// the global current_session/current_agent file).
+func withInteractiveStdinForTest(t *testing.T) {
+	t.Helper()
+	prev := isInteractiveStdin
+	isInteractiveStdin = func() bool { return true }
+	t.Cleanup(func() { isInteractiveStdin = prev })
+}
+
+// TestRunSessionsStart_NonTTYDoesNotStopExistingSession verifies the core bug fix:
+// when stdin is not a terminal, runSessionsStart must not stop the session
+// referenced by ~/.notte/cli/current_session, since that ID may belong to a
+// concurrent worker process. Without the fix, the EOF stdin causes the
+// confirmation prompt to default to "yes" and issues a DELETE on a sibling
+// process's live session.
+func TestRunSessionsStart_NonTTYDoesNotStopExistingSession(t *testing.T) {
+	env := testutil.SetupTestEnv(t)
+	env.SetEnv("NOTTE_API_KEY", "test-key")
+
+	server := testutil.NewMockServer()
+	defer server.Close()
+	env.SetEnv("NOTTE_API_URL", server.URL())
+
+	server.AddResponse("/sessions/start", 200, `{"session_id":"sess_new","status":"ACTIVE","created_at":"2020-01-01T00:00:00Z","last_accessed_at":"2020-01-01T00:00:00Z","timeout_minutes":5}`)
+	// If the bug regresses, the CLI will call this endpoint with sess_existing.
+	server.AddResponse("/sessions/sess_existing/stop", 200, `{"session_id":"sess_existing","status":"CLOSED","created_at":"2020-01-01T00:00:00Z","last_accessed_at":"2020-01-01T00:00:00Z","timeout_minutes":0}`)
+
+	tmpDir := setupSessionFileTest(t)
+	configDir := filepath.Join(tmpDir, config.ConfigDirName)
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	sessionFile := filepath.Join(configDir, config.CurrentSessionFile)
+	if err := os.WriteFile(sessionFile, []byte("sess_existing"), 0o600); err != nil {
+		t.Fatalf("failed to seed current_session: %v", err)
+	}
+
+	withNonInteractiveStdinForTest(t)
+
+	origID := sessionID
+	sessionID = ""
+	t.Cleanup(func() { sessionID = origID })
+
+	origFormat := outputFormat
+	outputFormat = "json"
+	t.Cleanup(func() { outputFormat = origFormat })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	var runErr error
+	_, _ = testutil.CaptureOutput(func() {
+		runErr = runSessionsStart(cmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+
+	if reqs := server.Requests("/sessions/sess_existing/stop"); len(reqs) > 0 {
+		t.Fatalf("non-TTY runSessionsStart must not stop the existing session, but called %d times", len(reqs))
+	}
+
+	// Current-session file should NOT have been overwritten with the new ID,
+	// otherwise a concurrent sibling process could later read it and target sess_new.
+	data, err := os.ReadFile(sessionFile)
+	if err != nil {
+		t.Fatalf("failed to read current_session file: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "sess_existing" {
+		t.Fatalf("non-TTY runSessionsStart must not overwrite current_session; got %q, want %q", got, "sess_existing")
+	}
+}
+
+// TestRunSessionsStart_NonTTYNewSessionDoesNotWriteFile verifies that on a clean
+// machine (no current_session) a non-TTY runSessionsStart does not write the
+// global state file - so a sibling process in a separate worker doesn't later
+// pick up the ID and stop it.
+func TestRunSessionsStart_NonTTYNewSessionDoesNotWriteFile(t *testing.T) {
+	env := testutil.SetupTestEnv(t)
+	env.SetEnv("NOTTE_API_KEY", "test-key")
+
+	server := testutil.NewMockServer()
+	defer server.Close()
+	env.SetEnv("NOTTE_API_URL", server.URL())
+
+	server.AddResponse("/sessions/start", 200, `{"session_id":"sess_new","status":"ACTIVE","created_at":"2020-01-01T00:00:00Z","last_accessed_at":"2020-01-01T00:00:00Z","timeout_minutes":5}`)
+
+	tmpDir := setupSessionFileTest(t)
+	configDir := filepath.Join(tmpDir, config.ConfigDirName)
+	sessionFile := filepath.Join(configDir, config.CurrentSessionFile)
+
+	withNonInteractiveStdinForTest(t)
+
+	origID := sessionID
+	sessionID = ""
+	t.Cleanup(func() { sessionID = origID })
+
+	origFormat := outputFormat
+	outputFormat = "json"
+	t.Cleanup(func() { outputFormat = origFormat })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	var runErr error
+	_, _ = testutil.CaptureOutput(func() {
+		runErr = runSessionsStart(cmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("unexpected error: %v", runErr)
+	}
+
+	if _, err := os.Stat(sessionFile); !os.IsNotExist(err) {
+		t.Fatalf("non-TTY runSessionsStart must not write current_session; stat err=%v", err)
+	}
+}
+
 // Tests for session ID resolution (file-based tracking)
 
 func setupSessionFileTest(t *testing.T) string {
@@ -1032,6 +1158,8 @@ func TestRequireSessionID_FromFile(t *testing.T) {
 }
 
 func TestSessionsStart_SetsCurrentSession(t *testing.T) {
+	withInteractiveStdinForTest(t)
+
 	env := testutil.SetupTestEnv(t)
 	env.SetEnv("NOTTE_API_KEY", "test-key")
 
@@ -1238,6 +1366,8 @@ func TestClearCurrentSessionExpiry_NoFile(t *testing.T) {
 }
 
 func TestSessionsStart_SavesExpiry(t *testing.T) {
+	withInteractiveStdinForTest(t)
+
 	env := testutil.SetupTestEnv(t)
 	env.SetEnv("NOTTE_API_KEY", "test-key")
 
@@ -1289,6 +1419,8 @@ func TestSessionsStart_SavesExpiry(t *testing.T) {
 }
 
 func TestSessionsStart_AutoClearsExpiredSession(t *testing.T) {
+	withInteractiveStdinForTest(t)
+
 	env := testutil.SetupTestEnv(t)
 	env.SetEnv("NOTTE_API_KEY", "test-key")
 
@@ -1354,6 +1486,8 @@ func TestSessionsStart_AutoClearsExpiredSession(t *testing.T) {
 }
 
 func TestSessionsStart_DoesNotAutoClearNonExpiredSession(t *testing.T) {
+	withInteractiveStdinForTest(t)
+
 	env := testutil.SetupTestEnv(t)
 	env.SetEnv("NOTTE_API_KEY", "test-key")
 


### PR DESCRIPTION
## Summary

Fixes a correctness bug where `notte sessions start` invoked from a non-TTY context (subprocess, CI, parallel script) silently kills whatever session ID happens to be in `~/.notte/cli/current_session`. In parallel workloads, workers race to overwrite that shared file and then stop each other's live sessions, surfacing later as `NotteApiSessionTimeoutError: Session ... has been closed` on unrelated page calls.

Root cause is three behaviors combined:
- `~/.notte/cli/current_session` is global, file-based, unsynchronized.
- `runSessionsStart` auto-stops whatever ID it finds there, with no ownership check.
- `confirmReplaceSession` reads stdin, gets EOF, swallows the error, and treats empty input as the `[Y/n]` default → YES.

## What's in this PR

1. **`confirm.go`** — `confirmReplaceSession`, `confirmReplaceAgent`, and `ConfirmStop` now return `false` when `stdin` is not a terminal (unless `--yes` was passed). Matches the convention in `apt`, `git`, `gh` of refusing destructive defaults in non-interactive mode. The `*WithIO` helpers are unchanged so existing tests keep their interactive contract.
2. **`sessions.go` / `agents.go`** — `runSessionsStart` and `runAgentsStart` skip writing `current_session` / `current_agent` / `current_session_expiry` / `current_viewer_url` when stdin is not a terminal. This stops scripted invocations from clobbering each other's state and from mutating state the user's interactive shell depends on. Scripted callers should pass `--session-id` or `NOTTE_SESSION_ID` explicitly.

`isInteractiveStdin` is indirected through a package-level `var` so tests can flip it. `golang.org/x/term` is already a dependency (used by `internal/update`).

## Behavior changes

| Context | Before | After |
| --- | --- | --- |
| Interactive TTY, existing session, `[Enter]` | stops existing, starts new (unchanged) | same |
| Interactive TTY, existing session, `n` | starts new without stopping (unchanged) | same |
| Non-TTY (script), existing session | **EOF → "yes" → stops sibling's session** | does not stop; starts new in parallel |
| Non-TTY (script), `--yes` | stops, starts new | same |
| Non-TTY (script), new session | writes shared `current_session` (race) | does not write |
| Interactive TTY, new session | writes `current_session` (unchanged) | same |

Scripts that relied on the auto-stop behavior (unlikely; it was a footgun) need to pass `--yes` explicitly. The README/CHANGELOG should mention this in the next release notes.

## Test plan

- [x] `go test ./...` passes locally
- [x] New `confirm_test.go` tests cover non-TTY default for replace session/agent and stop, plus `--yes` override
- [x] New `sessions_test.go` tests verify (a) non-TTY start does not call `/sessions/{id}/stop` on a pre-populated `current_session`, and (b) non-TTY start does not write `current_session`
- [x] Existing `TestSessionsStart_SetsCurrentSession` / `_SavesExpiry` / `_AutoClearsExpiredSession` / `_DoesNotAutoClearNonExpiredSession` / `TestAgentsStart_SetsCurrentAgent` now opt into `withInteractiveStdinForTest` (they were always testing the interactive contract; `go test` runs without a TTY by default)
- [ ] Manual repro from the PRD on a built binary:
  ```
  notte sessions start &
  notte sessions start &
  notte sessions start &
  wait
  NOTTE_API_KEY=... notte sessions list --only-active   # expect 3 active sessions
  ```

## Follow-ups (not in this PR)

- Scope `current_session` by API-key hash so different accounts on the same machine never collide interactively. Suggested in the PRD as additional hardening on top of (A) + skip-write-if-not-TTY.
- Consider a release-note line so users who were silently relying on the auto-stop behavior know to pass `-y`.