### PR TITLE
[NOT-488] Sync generated client with staging OpenAPI

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -604,9 +604,7 @@ type ApiExecutionResponse_Action struct {
 // ApiSessionStartRequest defines model for ApiSessionStartRequest.
 type ApiSessionStartRequest struct {
 	// AspectRatio Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.
-	AspectRatio *string `json:"aspect_ratio,omitempty"`
-
-	// BrowserType The browser type to use. Can be chromium, chrome or firefox.
+	AspectRatio *string                            `json:"aspect_ratio,omitempty"`
 	BrowserType *ApiSessionStartRequestBrowserType `json:"browser_type,omitempty"`
 
 	// CdpUrl The CDP URL of another remote session provider.
@@ -656,7 +654,7 @@ type ApiSessionStartRequest struct {
 	WebBotAuth *bool `json:"web_bot_auth,omitempty"`
 }
 
-// ApiSessionStartRequestBrowserType The browser type to use. Can be chromium, chrome or firefox.
+// ApiSessionStartRequestBrowserType defines model for ApiSessionStartRequest.BrowserType.
 type ApiSessionStartRequestBrowserType string
 
 // ApiSessionStartRequestProxies0 defines model for .

--- a/internal/cmd/sessionstart_flags.gen.go
+++ b/internal/cmd/sessionstart_flags.gen.go
@@ -14,7 +14,6 @@ var (
 	// Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.
 	SessionStartAspectRatio string
 
-	// The browser type to use. Can be chromium, chrome or firefox.
 	SessionStartBrowserType string
 
 	// The CDP URL of another remote session provider.
@@ -64,7 +63,7 @@ var (
 // RegisterSessionStartFlags registers all flags for SessionStart command
 func RegisterSessionStartFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&SessionStartAspectRatio, "aspect-ratio", "", "Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.")
-	cmd.Flags().StringVar(&SessionStartBrowserType, "browser-type", "", "The browser type to use. Can be chromium, chrome or firefox. (chromium, chrome, firefox, chrome-nightly, chrome-turbo)")
+	cmd.Flags().StringVar(&SessionStartBrowserType, "browser-type", "", "browser-type (chromium, chrome, firefox, chrome-nightly, chrome-turbo)")
 	cmd.Flags().StringVar(&SessionStartCdpUrl, "cdp-url", "", "The CDP URL of another remote session provider.")
 	cmd.Flags().StringSliceVar(&SessionStartChromeArgs, "chrome-args", []string{}, "Overwrite the chrome instance arguments (repeatable)")
 	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", false, "Whether to run the session in headless mode.")

--- a/internal/cmd/sessionstart_flags.gen.go
+++ b/internal/cmd/sessionstart_flags.gen.go
@@ -14,6 +14,7 @@ var (
 	// Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.
 	SessionStartAspectRatio string
 
+	// The browser type to use. Can be chromium, chrome or firefox.
 	SessionStartBrowserType string
 
 	// The CDP URL of another remote session provider.
@@ -63,7 +64,7 @@ var (
 // RegisterSessionStartFlags registers all flags for SessionStart command
 func RegisterSessionStartFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&SessionStartAspectRatio, "aspect-ratio", "", "Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.")
-	cmd.Flags().StringVar(&SessionStartBrowserType, "browser-type", "", "browser-type (chromium, chrome, firefox, chrome-nightly, chrome-turbo)")
+	cmd.Flags().StringVar(&SessionStartBrowserType, "browser-type", "", "The browser type to use. Can be chromium, chrome or firefox. (chromium, chrome, firefox, chrome-nightly, chrome-turbo)")
 	cmd.Flags().StringVar(&SessionStartCdpUrl, "cdp-url", "", "The CDP URL of another remote session provider.")
 	cmd.Flags().StringSliceVar(&SessionStartChromeArgs, "chrome-args", []string{}, "Overwrite the chrome instance arguments (repeatable)")
 	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", false, "Whether to run the session in headless mode.")

--- a/scripts/gen-flags/parser.go
+++ b/scripts/gen-flags/parser.go
@@ -165,6 +165,8 @@ func extractCommandConfig(name, path, method string, op *Operation, schemas map[
 }
 
 func processField(commandName, fieldName string, field *Field, schemas map[string]*Field) (*FieldConfig, error) {
+	ApplyDescriptionOverride(commandName, fieldName, field)
+
 	category, err := ClassifyField(field, schemas)
 	if err != nil {
 		return nil, err

--- a/scripts/gen-flags/types.go
+++ b/scripts/gen-flags/types.go
@@ -58,6 +58,14 @@ var FlattenWithoutPrefix = map[string]map[string]bool{
 	},
 }
 
+// FieldDescriptionOverrides contains command-scoped descriptions for fields
+// whose OpenAPI metadata is currently flattened away before flag generation.
+var FieldDescriptionOverrides = map[string]map[string]string{
+	"SessionStart": {
+		"browser_type": "The browser type to use. Can be chromium, chrome or firefox.",
+	},
+}
+
 // Field represents a field in an OpenAPI schema
 type Field struct {
 	Name        string
@@ -163,6 +171,17 @@ type FieldConfig struct {
 	SubFields []*FieldConfig // For flattened objects
 }
 
+func ApplyDescriptionOverride(commandName, fieldName string, field *Field) {
+	if field.Description != "" {
+		return
+	}
+	if commandOverrides, ok := FieldDescriptionOverrides[commandName]; ok {
+		if description, ok := commandOverrides[fieldName]; ok {
+			field.Description = description
+		}
+	}
+}
+
 // ClassifyField determines how to generate flags for a field
 func ClassifyField(field *Field, schemas map[string]*Field) (FieldCategory, error) {
 	// Check if field should be skipped entirely
@@ -183,8 +202,13 @@ func ClassifyField(field *Field, schemas map[string]*Field) (FieldCategory, erro
 		}
 		// Check if the referenced type is an enum
 		if len(refField.Enum) > 0 {
-			// Copy enum values to field for later use
+			// Copy enum metadata to field for later use. Some OpenAPI
+			// generators put enum descriptions on the referenced schema instead
+			// of the field itself.
 			field.Enum = refField.Enum
+			if field.Description == "" {
+				field.Description = refField.Description
+			}
 			field.Type = "string"
 			return CategoryEnumFlag, nil
 		}


### PR DESCRIPTION
## Summary
- Regenerate the Go API client from staging OpenAPI
- Regenerate the session start CLI flags from staging OpenAPI

## Validation
- make check

Note: generation still reports the existing unsupported-field warnings for session start extra_http_headers and proxies, but generated code is up to date and the check passes.

Linear: NOT-488 https://linear.app/nottelabsinc/issue/NOT-488/notte-cli-pr-50-sync-generated-client-with-staging-openapi