### PR TITLE
[NOT-650] Add profile duplication command

### DIFF
--- a/internal/cmd/profiles.go
+++ b/internal/cmd/profiles.go
@@ -1,7 +1,12 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 
 	"github.com/spf13/cobra"
 
@@ -9,6 +14,7 @@ import (
 )
 
 var profileID string
+var profileDuplicateName string
 
 var profilesCmd = &cobra.Command{
 	Use:   "profiles",
@@ -42,6 +48,13 @@ var profilesDeleteCmd = &cobra.Command{
 	RunE:  runProfileDelete,
 }
 
+var profilesDuplicateCmd = &cobra.Command{
+	Use:   "duplicate",
+	Short: "Duplicate a profile and its persisted browser state",
+	Args:  cobra.NoArgs,
+	RunE:  runProfileDuplicate,
+}
+
 func init() {
 	rootCmd.AddCommand(profilesCmd)
 	profilesCmd.AddCommand(profilesListCmd)
@@ -51,6 +64,7 @@ func init() {
 	profilesCmd.AddCommand(profilesCreateCmd)
 	profilesCmd.AddCommand(profilesShowCmd)
 	profilesCmd.AddCommand(profilesDeleteCmd)
+	profilesCmd.AddCommand(profilesDuplicateCmd)
 
 	// Create command flags (auto-generated)
 	RegisterProfileCreateFlags(profilesCreateCmd)
@@ -62,6 +76,11 @@ func init() {
 	// Delete command flags
 	profilesDeleteCmd.Flags().StringVar(&profileID, "profile-id", "", "Profile ID (required)")
 	_ = profilesDeleteCmd.MarkFlagRequired("profile-id")
+
+	// Duplicate command flags
+	profilesDuplicateCmd.Flags().StringVar(&profileID, "profile-id", "", "Source profile ID (required)")
+	profilesDuplicateCmd.Flags().StringVar(&profileDuplicateName, "name", "", "Optional name for the duplicate")
+	_ = profilesDuplicateCmd.MarkFlagRequired("profile-id")
 }
 
 func runProfilesList(cmd *cobra.Command, args []string) error {
@@ -195,4 +214,50 @@ func runProfileDelete(cmd *cobra.Command, args []string) error {
 		"id":     profileID,
 		"status": "deleted",
 	})
+}
+
+func runProfileDuplicate(cmd *cobra.Command, args []string) error {
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := GetContextWithTimeout(cmd.Context())
+	defer cancel()
+
+	requestBody := map[string]string{}
+	if cmd.Flags().Changed("name") {
+		requestBody["name"] = profileDuplicateName
+	}
+	bodyJSON, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal duplicate request: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/profiles/%s/duplicate", client.BaseURL(), url.PathEscape(profileID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyJSON))
+	if err != nil {
+		return fmt.Errorf("failed to create duplicate request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.HTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("API request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	if err := HandleAPIResponse(resp, body); err != nil {
+		return err
+	}
+
+	var duplicate api.ProfileResponse
+	if err := json.Unmarshal(body, &duplicate); err != nil {
+		return fmt.Errorf("failed to parse duplicate profile: %w", err)
+	}
+	return GetFormatter().Print(duplicate)
 }

--- a/internal/cmd/profiles.go
+++ b/internal/cmd/profiles.go
@@ -13,8 +13,10 @@ import (
 	"github.com/nottelabs/notte-cli/internal/api"
 )
 
-var profileID string
-var profileDuplicateName string
+var (
+	profileID            string
+	profileDuplicateName string
+)
 
 var profilesCmd = &cobra.Command{
 	Use:   "profiles",

--- a/internal/cmd/profiles_test.go
+++ b/internal/cmd/profiles_test.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -169,5 +171,48 @@ func TestRunProfileDelete(t *testing.T) {
 
 	if !strings.Contains(stdout, "deleted") {
 		t.Errorf("expected delete message, got %q", stdout)
+	}
+}
+
+func TestRunProfileDuplicate(t *testing.T) {
+	server := setupProfileTest(t)
+	path := "/profiles/" + profileIDTest + "/duplicate"
+	server.AddResponse(path, http.StatusOK, `{"profile_id":"notte-profile-copy123","name":"Copied Profile","created_at":"2020-01-01T00:00:00Z","updated_at":"2020-01-01T00:00:00Z"}`)
+
+	originalName := profileDuplicateName
+	profileDuplicateName = "Copied Profile"
+	t.Cleanup(func() { profileDuplicateName = originalName })
+
+	originalFormat := outputFormat
+	outputFormat = "json"
+	t.Cleanup(func() { outputFormat = originalFormat })
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("name", "", "")
+	_ = cmd.Flags().Set("name", profileDuplicateName)
+	cmd.SetContext(context.Background())
+
+	stdout, _ := testutil.CaptureOutput(func() {
+		if err := runProfileDuplicate(cmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "notte-profile-copy123") {
+		t.Errorf("expected duplicate profile output, got %q", stdout)
+	}
+	requests := server.Requests(path)
+	if len(requests) != 1 {
+		t.Fatalf("expected one duplicate request, got %d", len(requests))
+	}
+	if requests[0].Method != http.MethodPost {
+		t.Errorf("expected POST, got %s", requests[0].Method)
+	}
+	var body map[string]string
+	if err := json.Unmarshal([]byte(requests[0].Body), &body); err != nil {
+		t.Fatalf("invalid request JSON: %v", err)
+	}
+	if body["name"] != "Copied Profile" {
+		t.Errorf("expected destination name, got %#v", body)
 	}
 }


### PR DESCRIPTION
## Summary

- add `notte profiles duplicate --profile-id <id>`
- accept an optional `--name`
- use the authenticated API client transport
- cover method, path, payload, and output

Companion to nottelabs/monorepo#1918.

Linear: NOT-650 https://linear.app/nottelabsinc/issue/NOT-650/notte-cli-pr-53-add-profile-duplication-command