### PR TITLE
[NOT-678] feat(files): download uploaded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,11 @@ notte profiles delete --profile-id <id>  # Delete a profile
 ### Files
 
 ```bash
-notte files list                     # List uploaded files
-notte files upload <path>            # Upload a file
-notte files download <id>            # Download a file by ID
+notte files upload <path>                                      # Upload a persistent input file
+notte files list --from uploads                                # List persistent input files
+notte files download <filename> --from uploads                 # Download a persistent input file
+notte files list --from session [--session-id <id>]            # List files produced by a session
+notte files download <filename> [--session-id <id>]            # Download a file produced by a session
 ```
 
 ### Utilities

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	notteErrors "github.com/nottelabs/notte-cli/internal/errors"
@@ -219,6 +222,28 @@ func (c *NotteClient) BaseURL() string {
 // APIKey returns the API key used by the client
 func (c *NotteClient) APIKey() string {
 	return c.apiKey
+}
+
+// DownloadUploadedFile requests a temporary download link for a user-uploaded file.
+// This endpoint is kept here until it is available in the generated OpenAPI client.
+func (c *NotteClient) DownloadUploadedFile(ctx context.Context, filename string) (*http.Response, []byte, error) {
+	endpoint := strings.TrimRight(c.baseURL, "/") + "/storage/uploads/" + url.PathEscape(filename)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create uploaded file download request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp, nil, fmt.Errorf("failed to read uploaded file download response: %w", err)
+	}
+	return resp, body, nil
 }
 
 // Context helper for commands

--- a/internal/cmd/files.go
+++ b/internal/cmd/files.go
@@ -105,6 +105,33 @@ func resolveFilesSource(from string, uploads, downloads bool) (string, error) {
 	}
 }
 
+func resolveDownloadOutputPath(outputPath string) (string, error) {
+	resolvedPath := outputPath
+	for range 255 {
+		info, err := os.Lstat(resolvedPath)
+		if os.IsNotExist(err) {
+			return resolvedPath, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("failed to inspect destination: %w", err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			return resolvedPath, nil
+		}
+
+		target, err := os.Readlink(resolvedPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to read destination symlink: %w", err)
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(resolvedPath), target)
+		}
+		resolvedPath = filepath.Clean(target)
+	}
+
+	return "", fmt.Errorf("destination has too many symlink levels")
+}
+
 func downloadFileWithContext(ctx context.Context, fileURL, outputPath string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
 	if err != nil {
@@ -121,8 +148,13 @@ func downloadFileWithContext(ctx context.Context, fileURL, outputPath string) er
 		return fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
 
+	destinationPath, err := resolveDownloadOutputPath(outputPath)
+	if err != nil {
+		return err
+	}
+
 	fileMode := os.FileMode(0o644)
-	if info, statErr := os.Stat(outputPath); statErr == nil {
+	if info, statErr := os.Stat(destinationPath); statErr == nil {
 		if info.IsDir() {
 			return fmt.Errorf("destination path is a directory")
 		}
@@ -131,7 +163,10 @@ func downloadFileWithContext(ctx context.Context, fileURL, outputPath string) er
 		return fmt.Errorf("failed to inspect destination: %w", statErr)
 	}
 
-	tempFile, err := os.CreateTemp(filepath.Dir(outputPath), "."+filepath.Base(outputPath)+".tmp-*")
+	tempFile, err := os.CreateTemp(
+		filepath.Dir(destinationPath),
+		"."+filepath.Base(destinationPath)+".tmp-*",
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create temporary file: %w", err)
 	}
@@ -156,7 +191,7 @@ func downloadFileWithContext(ctx context.Context, fileURL, outputPath string) er
 	if err := tempFile.Close(); err != nil {
 		return fmt.Errorf("failed to close temporary file: %w", err)
 	}
-	if err := os.Rename(tempPath, outputPath); err != nil {
+	if err := os.Rename(tempPath, destinationPath); err != nil {
 		return fmt.Errorf("failed to replace destination: %w", err)
 	}
 	committed = true

--- a/internal/cmd/files.go
+++ b/internal/cmd/files.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -102,6 +103,64 @@ func resolveFilesSource(from string, uploads, downloads bool) (string, error) {
 	default:
 		return "", fmt.Errorf("invalid --from value %q: must be uploads or session", from)
 	}
+}
+
+func downloadFileWithContext(ctx context.Context, fileURL, outputPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fileURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create download request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	fileMode := os.FileMode(0o644)
+	if info, statErr := os.Stat(outputPath); statErr == nil {
+		if info.IsDir() {
+			return fmt.Errorf("destination path is a directory")
+		}
+		fileMode = info.Mode().Perm()
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("failed to inspect destination: %w", statErr)
+	}
+
+	tempFile, err := os.CreateTemp(filepath.Dir(outputPath), "."+filepath.Base(outputPath)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %w", err)
+	}
+	tempPath := tempFile.Name()
+	committed := false
+	defer func() {
+		_ = tempFile.Close()
+		if !committed {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := io.Copy(tempFile, resp.Body); err != nil {
+		return fmt.Errorf("failed to write temporary file: %w", err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		return fmt.Errorf("failed to sync temporary file: %w", err)
+	}
+	if err := tempFile.Chmod(fileMode); err != nil {
+		return fmt.Errorf("failed to set file permissions: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary file: %w", err)
+	}
+	if err := os.Rename(tempPath, outputPath); err != nil {
+		return fmt.Errorf("failed to replace destination: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func runFilesList(cmd *cobra.Command, args []string) error {
@@ -323,33 +382,14 @@ func runFilesDownload(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no download URL in response")
 	}
 
-	// Download the actual file from the presigned URL
-	httpResp, err := http.Get(downloadResp.URL)
-	if err != nil {
-		return fmt.Errorf("failed to download file: %w", err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	if httpResp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download file: HTTP %d", httpResp.StatusCode)
-	}
-
 	// Determine output path
 	outputPath := filesDownloadOutput
 	if outputPath == "" {
 		outputPath = filename
 	}
 
-	// Create the output file
-	outFile, err := os.Create(outputPath)
-	if err != nil {
-		return fmt.Errorf("failed to create file: %w", err)
-	}
-	defer func() { _ = outFile.Close() }()
-
-	// Copy the downloaded content to the file
-	if _, err := io.Copy(outFile, httpResp.Body); err != nil {
-		return fmt.Errorf("failed to write file: %w", err)
+	if err := downloadFileWithContext(ctx, downloadResp.URL, outputPath); err != nil {
+		return fmt.Errorf("failed to download file: %w", err)
 	}
 
 	return PrintResult(fmt.Sprintf("File downloaded successfully: %s", outputPath), map[string]any{

--- a/internal/cmd/files.go
+++ b/internal/cmd/files.go
@@ -18,20 +18,27 @@ import (
 var (
 	filesListUploadsFlag   bool
 	filesListDownloadsFlag bool
+	filesListFrom          string
+	filesDownloadFrom      string
 	filesDownloadOutput    string
+)
+
+const (
+	filesSourceUploads = "uploads"
+	filesSourceSession = "session"
 )
 
 var filesCmd = &cobra.Command{
 	Use:   "files",
-	Short: "Manage uploaded files",
+	Short: "Manage stored files",
 	Long:  "Upload, list, and download files from notte.cc storage.",
 }
 
 var filesListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List uploaded files",
-	Long: `List files in storage. Use --uploads to list uploaded files,
-or --downloads to list downloaded files from a session.`,
+	Short: "List stored files",
+	Long: `List user-uploaded files or files downloaded by a browser session.
+Use --from uploads for user uploads or --from session for session downloads.`,
 	RunE: runFilesList,
 }
 
@@ -46,9 +53,10 @@ var filesUploadCmd = &cobra.Command{
 var filesDownloadCmd = &cobra.Command{
 	Use:   "download <filename>",
 	Short: "Download a file by name",
-	Long:  "Download a file from a session by its filename.",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runFilesDownload,
+	Long: `Download a user-uploaded file or a file produced by a browser session.
+Use --from uploads for user uploads or --from session for session downloads.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runFilesDownload,
 }
 
 func init() {
@@ -59,15 +67,49 @@ func init() {
 
 	// List command flags
 	filesListCmd.Flags().BoolVar(&filesListUploadsFlag, "uploads", false, "List uploaded files")
-	filesListCmd.Flags().BoolVar(&filesListDownloadsFlag, "downloads", true, "List downloaded files from a session")
+	filesListCmd.Flags().BoolVar(&filesListDownloadsFlag, "downloads", false, "List downloaded files from a session")
+	filesListCmd.Flags().StringVar(&filesListFrom, "from", "", "File source: uploads or session (default session)")
 	filesListCmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID (uses current session if not specified)")
+	_ = filesListCmd.Flags().MarkDeprecated("uploads", "use --from uploads instead")
+	_ = filesListCmd.Flags().MarkDeprecated("downloads", "use --from session instead")
 
 	// Download command flags
 	filesDownloadCmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID (uses current session if not specified)")
+	filesDownloadCmd.Flags().StringVar(&filesDownloadFrom, "from", "", "File source: uploads or session (default session)")
 	filesDownloadCmd.Flags().StringVar(&filesDownloadOutput, "path", "", "Output file path (defaults to current directory)")
 }
 
+func resolveFilesSource(from string, uploads, downloads bool) (string, error) {
+	if uploads && downloads {
+		return "", fmt.Errorf("--uploads and --downloads cannot be used together")
+	}
+	if from != "" && (uploads || downloads) {
+		return "", fmt.Errorf("--from cannot be combined with --uploads or --downloads")
+	}
+
+	if uploads {
+		return filesSourceUploads, nil
+	}
+	if downloads {
+		return filesSourceSession, nil
+	}
+
+	switch from {
+	case "", filesSourceSession:
+		return filesSourceSession, nil
+	case filesSourceUploads:
+		return filesSourceUploads, nil
+	default:
+		return "", fmt.Errorf("invalid --from value %q: must be uploads or session", from)
+	}
+}
+
 func runFilesList(cmd *cobra.Command, args []string) error {
+	source, err := resolveFilesSource(filesListFrom, filesListUploadsFlag, filesListDownloadsFlag)
+	if err != nil {
+		return err
+	}
+
 	client, err := GetClient()
 	if err != nil {
 		return err
@@ -75,8 +117,7 @@ func runFilesList(cmd *cobra.Command, args []string) error {
 
 	formatter := GetFormatter()
 
-	// If uploads flag is set, list uploads
-	if filesListUploadsFlag {
+	if source == filesSourceUploads {
 		ctx, cancel := GetContextWithTimeout(cmd.Context())
 		defer cancel()
 
@@ -225,8 +266,15 @@ func runFilesUpload(cmd *cobra.Command, args []string) error {
 func runFilesDownload(cmd *cobra.Command, args []string) error {
 	filename := args[0]
 
-	if err := RequireSessionID(); err != nil {
+	source, err := resolveFilesSource(filesDownloadFrom, false, false)
+	if err != nil {
 		return err
+	}
+
+	if source == filesSourceSession {
+		if err := RequireSessionID(); err != nil {
+			return err
+		}
 	}
 
 	client, err := GetClient()
@@ -237,18 +285,29 @@ func runFilesDownload(cmd *cobra.Command, args []string) error {
 	ctx, cancel := GetContextWithTimeout(cmd.Context())
 	defer cancel()
 
-	params := &api.FileDownloadParams{}
-	resp, err := client.Client().FileDownloadWithResponse(
-		ctx,
-		sessionID,
-		filename,
-		params,
-	)
-	if err != nil {
-		return fmt.Errorf("API request failed: %w", err)
+	var httpResponse *http.Response
+	var responseBody []byte
+	if source == filesSourceUploads {
+		httpResponse, responseBody, err = client.DownloadUploadedFile(ctx, filename)
+		if err != nil {
+			return fmt.Errorf("API request failed: %w", err)
+		}
+	} else {
+		params := &api.FileDownloadParams{}
+		resp, err := client.Client().FileDownloadWithResponse(
+			ctx,
+			sessionID,
+			filename,
+			params,
+		)
+		if err != nil {
+			return fmt.Errorf("API request failed: %w", err)
+		}
+		httpResponse = resp.HTTPResponse
+		responseBody = resp.Body
 	}
 
-	if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
+	if err := HandleAPIResponse(httpResponse, responseBody); err != nil {
 		return err
 	}
 
@@ -256,7 +315,7 @@ func runFilesDownload(cmd *cobra.Command, args []string) error {
 	var downloadResp struct {
 		URL string `json:"url"`
 	}
-	if err := json.Unmarshal(resp.Body, &downloadResp); err != nil {
+	if err := json.Unmarshal(responseBody, &downloadResp); err != nil {
 		return fmt.Errorf("failed to parse download response: %w", err)
 	}
 

--- a/internal/cmd/files_test.go
+++ b/internal/cmd/files_test.go
@@ -24,12 +24,15 @@ func TestRunFilesListUploads(t *testing.T) {
 	server.AddResponse("/storage/uploads", 200, `{"files":[{"name":"a.txt","file_ext":".txt","size":100}]}`)
 
 	origUploadsFlag := filesListUploadsFlag
+	origFrom := filesListFrom
 	origSession := sessionID
 	t.Cleanup(func() {
 		filesListUploadsFlag = origUploadsFlag
+		filesListFrom = origFrom
 		sessionID = origSession
 	})
-	filesListUploadsFlag = true
+	filesListUploadsFlag = false
+	filesListFrom = filesSourceUploads
 	sessionID = ""
 
 	origFormat := outputFormat
@@ -62,12 +65,15 @@ func TestRunFilesListUploadsEmpty(t *testing.T) {
 	server.AddResponse("/storage/uploads", 200, `{"files":[]}`)
 
 	origUploadsFlag := filesListUploadsFlag
+	origFrom := filesListFrom
 	origSession := sessionID
 	t.Cleanup(func() {
 		filesListUploadsFlag = origUploadsFlag
+		filesListFrom = origFrom
 		sessionID = origSession
 	})
 	filesListUploadsFlag = true
+	filesListFrom = ""
 	sessionID = ""
 
 	origFormat := outputFormat
@@ -100,12 +106,15 @@ func TestRunFilesListDownloads(t *testing.T) {
 	server.AddResponse("/storage/sess_123/downloads", 200, `{"files":[{"name":"b.txt","file_ext":".txt","size":200}]}`)
 
 	origDownloadsFlag := filesListDownloadsFlag
+	origFrom := filesListFrom
 	origSession := sessionID
 	t.Cleanup(func() {
 		filesListDownloadsFlag = origDownloadsFlag
+		filesListFrom = origFrom
 		sessionID = origSession
 	})
 	filesListDownloadsFlag = true
+	filesListFrom = ""
 	sessionID = "sess_123"
 
 	origFormat := outputFormat
@@ -138,12 +147,15 @@ func TestRunFilesListDownloadsMissingSession(t *testing.T) {
 	t.Cleanup(func() { config.SetTestConfigDir("") })
 
 	origDownloadsFlag := filesListDownloadsFlag
+	origFrom := filesListFrom
 	origSession := sessionID
 	t.Cleanup(func() {
 		filesListDownloadsFlag = origDownloadsFlag
+		filesListFrom = origFrom
 		sessionID = origSession
 	})
 	filesListDownloadsFlag = true
+	filesListFrom = ""
 	sessionID = ""
 
 	cmd := &cobra.Command{}
@@ -230,12 +242,15 @@ func TestRunFilesDownload(t *testing.T) {
 	env.SetEnv("NOTTE_API_URL", server.URL())
 
 	origSession := sessionID
+	origFrom := filesDownloadFrom
 	origOutput := filesDownloadOutput
 	t.Cleanup(func() {
 		sessionID = origSession
+		filesDownloadFrom = origFrom
 		filesDownloadOutput = origOutput
 	})
 	sessionID = "sess_123"
+	filesDownloadFrom = ""
 
 	outDir := t.TempDir()
 	outputPath := filepath.Join(outDir, "download.txt")
@@ -270,6 +285,50 @@ func TestRunFilesDownload(t *testing.T) {
 	}
 }
 
+func TestRunFilesDownloadFromUploads(t *testing.T) {
+	env := testutil.SetupTestEnv(t)
+	env.SetEnv("NOTTE_API_KEY", "test-key")
+	env.SetEnv("NOTTE_SESSION_ID", "")
+
+	fileServer := testutil.NewMockServer()
+	defer fileServer.Close()
+	fileServer.AddResponseWithHeaders("/input.txt", 200, "uploaded-file-data", map[string]string{
+		"Content-Type": "application/octet-stream",
+	})
+
+	server := testutil.NewMockServer()
+	defer server.Close()
+	env.SetEnv("NOTTE_API_URL", server.URL())
+	server.AddResponse("/storage/uploads/input.txt", 200, `{"url":"`+fileServer.URL()+`/input.txt"}`)
+
+	origSession := sessionID
+	origFrom := filesDownloadFrom
+	origOutput := filesDownloadOutput
+	t.Cleanup(func() {
+		sessionID = origSession
+		filesDownloadFrom = origFrom
+		filesDownloadOutput = origOutput
+	})
+	sessionID = ""
+	filesDownloadFrom = filesSourceUploads
+	filesDownloadOutput = filepath.Join(t.TempDir(), "input.txt")
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	if err := runFilesDownload(cmd, []string{"input.txt"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(filesDownloadOutput)
+	if err != nil {
+		t.Fatalf("failed to read downloaded file: %v", err)
+	}
+	if string(got) != "uploaded-file-data" {
+		t.Fatalf("unexpected file content: %q", string(got))
+	}
+}
+
 func TestRunFilesDownloadMissingSession(t *testing.T) {
 	env := testutil.SetupTestEnv(t)
 	env.SetEnv("NOTTE_SESSION_ID", "") // Clear session env var
@@ -280,8 +339,11 @@ func TestRunFilesDownloadMissingSession(t *testing.T) {
 	t.Cleanup(func() { config.SetTestConfigDir("") })
 
 	origSession := sessionID
+	origFrom := filesDownloadFrom
 	t.Cleanup(func() { sessionID = origSession })
+	t.Cleanup(func() { filesDownloadFrom = origFrom })
 	sessionID = ""
+	filesDownloadFrom = ""
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -292,5 +354,43 @@ func TestRunFilesDownloadMissingSession(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "session ID required") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveFilesSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		from      string
+		uploads   bool
+		downloads bool
+		want      string
+		wantErr   bool
+	}{
+		{name: "defaults to session", want: filesSourceSession},
+		{name: "from uploads", from: filesSourceUploads, want: filesSourceUploads},
+		{name: "from session", from: filesSourceSession, want: filesSourceSession},
+		{name: "legacy uploads", uploads: true, want: filesSourceUploads},
+		{name: "legacy downloads", downloads: true, want: filesSourceSession},
+		{name: "invalid source", from: "local", wantErr: true},
+		{name: "conflicting legacy flags", uploads: true, downloads: true, wantErr: true},
+		{name: "mixed source flags", from: filesSourceUploads, downloads: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveFilesSource(tt.from, tt.uploads, tt.downloads)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/cmd/files_test.go
+++ b/internal/cmd/files_test.go
@@ -91,6 +91,44 @@ func TestDownloadFileWithContextPreservesDestinationOnFailure(t *testing.T) {
 	}
 }
 
+func TestDownloadFileWithContextPreservesDestinationSymlink(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("downloaded-content"))
+	}))
+	defer server.Close()
+
+	outputDir := t.TempDir()
+	targetPath := filepath.Join(outputDir, "target.txt")
+	if err := os.WriteFile(targetPath, []byte("existing-content"), 0o644); err != nil {
+		t.Fatalf("failed to create symlink target: %v", err)
+	}
+	linkPath := filepath.Join(outputDir, "download.txt")
+	if err := os.Symlink(filepath.Base(targetPath), linkPath); err != nil {
+		t.Skipf("symlinks are not available: %v", err)
+	}
+
+	if err := downloadFileWithContext(context.Background(), server.URL, linkPath); err != nil {
+		t.Fatalf("unexpected download error: %v", err)
+	}
+
+	linkInfo, err := os.Lstat(linkPath)
+	if err != nil {
+		t.Fatalf("failed to inspect destination symlink: %v", err)
+	}
+	if linkInfo.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("destination symlink was replaced")
+	}
+
+	content, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("failed to read symlink target: %v", err)
+	}
+	if string(content) != "downloaded-content" {
+		t.Fatalf("symlink target was not updated: %q", string(content))
+	}
+}
+
 func TestRunFilesListUploads(t *testing.T) {
 	env := testutil.SetupTestEnv(t)
 	env.SetEnv("NOTTE_API_KEY", "test-key")

--- a/internal/cmd/files_test.go
+++ b/internal/cmd/files_test.go
@@ -2,16 +2,94 @@ package cmd
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/nottelabs/notte-cli/internal/config"
 	"github.com/nottelabs/notte-cli/internal/testutil"
 )
+
+func TestDownloadFileWithContextHonorsCancellation(t *testing.T) {
+	requestStarted := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial"))
+		w.(http.Flusher).Flush()
+		close(requestStarted)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	outputPath := filepath.Join(t.TempDir(), "download.txt")
+	result := make(chan error, 1)
+	go func() {
+		result <- downloadFileWithContext(ctx, server.URL, outputPath)
+	}()
+
+	select {
+	case <-requestStarted:
+		cancel()
+	case <-time.After(2 * time.Second):
+		cancel()
+		t.Fatal("download request did not start")
+	}
+
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected canceled download to fail")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("download did not stop after context cancellation")
+	}
+
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("canceled download left destination file behind: %v", err)
+	}
+}
+
+func TestDownloadFileWithContextPreservesDestinationOnFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial"))
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "download.txt")
+	if err := os.WriteFile(outputPath, []byte("existing-content"), 0o644); err != nil {
+		t.Fatalf("failed to create destination: %v", err)
+	}
+
+	if err := downloadFileWithContext(context.Background(), server.URL, outputPath); err == nil {
+		t.Fatal("expected interrupted download to fail")
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read destination: %v", err)
+	}
+	if string(content) != "existing-content" {
+		t.Fatalf("destination was modified after failed download: %q", string(content))
+	}
+
+	tempFiles, err := filepath.Glob(filepath.Join(filepath.Dir(outputPath), ".download.txt.tmp-*"))
+	if err != nil {
+		t.Fatalf("failed to inspect temporary files: %v", err)
+	}
+	if len(tempFiles) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", tempFiles)
+	}
+}
 
 func TestRunFilesListUploads(t *testing.T) {
 	env := testutil.SetupTestEnv(t)

--- a/tests/integration/storage_test.go
+++ b/tests/integration/storage_test.go
@@ -17,7 +17,7 @@ func TestStorageListUploads(t *testing.T) {
 	t.Log("Successfully listed uploads")
 }
 
-func TestStorageUploadAndList(t *testing.T) {
+func TestStorageUploadListAndDownload(t *testing.T) {
 	// Create a temporary file to upload
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test-upload.txt")
@@ -38,6 +38,20 @@ func TestStorageUploadAndList(t *testing.T) {
 		t.Log("Upload might use different filename, but list succeeded")
 	}
 	t.Log("Successfully verified file in uploads list")
+
+	// Download the uploaded file again
+	downloadPath := filepath.Join(tmpDir, "downloaded-test-upload.txt")
+	result = runCLI(t, "files", "download", "test-upload.txt", "--from", "uploads", "--path", downloadPath)
+	requireSuccess(t, result)
+
+	downloadedContent, err := os.ReadFile(downloadPath)
+	if err != nil {
+		t.Fatalf("Failed to read downloaded file: %v", err)
+	}
+	if string(downloadedContent) != string(testContent) {
+		t.Fatalf("Downloaded content does not match uploaded content")
+	}
+	t.Log("Successfully downloaded uploaded file")
 }
 
 func TestStorageDownloadFromSession(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `--from uploads|session` to `notte files list` and `notte files download`
- download persistent user uploads through the new storage endpoint
- preserve session downloads as the default and retain deprecated list aliases
- update README examples and add unit and integration coverage

## Backend dependency

- https://github.com/nottelabs/monorepo/pull/1946

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go test -race -short ./... -count=1`
- integration package compiles with the `integration` build tag

Linear: NOT-678 https://linear.app/nottelabsinc/issue/NOT-678/notte-cli-pr-54-featfiles-download-uploaded-files