### PR TITLE
[NOT-715] chore: sync generated client with staging OpenAPI

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -694,12 +694,18 @@ type BodyFunctionCreateFunctionsPost struct {
 	Description *string `json:"description,omitempty"`
 	File        string  `json:"file"`
 	Name        *string `json:"name,omitempty"`
-	Shared      *bool   `json:"shared,omitempty"`
+
+	// ResponseFormat JSON Schema of run()'s return value, computed by the caller from its pydantic model
+	ResponseFormat *string `json:"response_format,omitempty"`
+	Shared         *bool   `json:"shared,omitempty"`
 }
 
 // BodyFunctionUpdateFunctionsFunctionIdPost defines model for Body_function_update_functions__function_id__post.
 type BodyFunctionUpdateFunctionsFunctionIdPost struct {
 	File string `json:"file"`
+
+	// ResponseFormat JSON Schema of run()'s return value, computed by the caller from its pydantic model
+	ResponseFormat *string `json:"response_format,omitempty"`
 }
 
 // BodySessionCookiesSetSessionsSessionIdCookiesPost defines model for Body_session_cookies_set_sessions__session_id__cookies_post.
@@ -1267,6 +1273,45 @@ type FrameData struct {
 	FrameUrl string `json:"frameUrl"`
 }
 
+// FunctionResponse defines model for FunctionResponse.
+type FunctionResponse struct {
+	// CreatedAt The creation time of the workflow
+	CreatedAt FlexibleTime `json:"created_at"`
+
+	// Description The description of the workflow
+	Description *string `json:"description,omitempty"`
+
+	// FunctionId The ID of the function
+	FunctionId string `json:"function_id"`
+
+	// LatestVersion The version of the workflow
+	LatestVersion string `json:"latest_version"`
+
+	// Name The name of the workflow
+	Name      *string `json:"name,omitempty"`
+	Published *bool   `json:"published,omitempty"`
+
+	// ReferenceWorkflowId The ID of the reference workflow (i.e wether the workflow was forked from another workflow or not)
+	ReferenceWorkflowId *string   `json:"reference_workflow_id,omitempty"`
+	RequiredSecrets     *[]string `json:"required_secrets,omitempty"`
+
+	// Shared Whether the workflow is public and can beshared with other users
+	Shared *bool `json:"shared,omitempty"`
+
+	// Status The status of the workflow
+	Status string `json:"status"`
+
+	// UpdatedAt The last update time of the workflow
+	UpdatedAt FlexibleTime `json:"updated_at"`
+
+	// Variables The variables to run the workflow with
+	Variables *[]ParameterInfo `json:"variables,omitempty"`
+
+	// Versions The versions of the workflow
+	Versions   []string `json:"versions"`
+	WorkflowId *string  `json:"workflow_id,omitempty"`
+}
+
 // FunctionRunUpdateRequest defines model for FunctionRunUpdateRequest.
 type FunctionRunUpdateRequest struct {
 	// Logs The logs of the workflow run
@@ -1294,23 +1339,8 @@ type FunctionScheduleCreateRequest struct {
 	Variables *map[string]interface{} `json:"variables,omitempty"`
 }
 
-// GetCookiesResponse defines model for GetCookiesResponse.
-type GetCookiesResponse struct {
-	Cookies []Cookie `json:"cookies"`
-}
-
-// GetCredentialsResponse defines model for GetCredentialsResponse.
-type GetCredentialsResponse struct {
-	Credentials CredentialsDictOutput `json:"credentials"`
-}
-
-// GetCreditCardResponse defines model for GetCreditCardResponse.
-type GetCreditCardResponse struct {
-	CreditCard CreditCardDictOutput `json:"credit_card"`
-}
-
-// GetFunctionResponse defines model for GetFunctionResponse.
-type GetFunctionResponse struct {
+// FunctionWithLinkResponse defines model for FunctionWithLinkResponse.
+type FunctionWithLinkResponse struct {
 	// CreatedAt The creation time of the workflow
 	CreatedAt FlexibleTime `json:"created_at"`
 
@@ -1324,10 +1354,12 @@ type GetFunctionResponse struct {
 	LatestVersion string `json:"latest_version"`
 
 	// Name The name of the workflow
-	Name *string `json:"name,omitempty"`
+	Name      *string `json:"name,omitempty"`
+	Published *bool   `json:"published,omitempty"`
 
 	// ReferenceWorkflowId The ID of the reference workflow (i.e wether the workflow was forked from another workflow or not)
-	ReferenceWorkflowId *string `json:"reference_workflow_id,omitempty"`
+	ReferenceWorkflowId *string   `json:"reference_workflow_id,omitempty"`
+	RequiredSecrets     *[]string `json:"required_secrets,omitempty"`
 
 	// Shared Whether the workflow is public and can beshared with other users
 	Shared *bool `json:"shared,omitempty"`
@@ -1338,12 +1370,30 @@ type GetFunctionResponse struct {
 	// UpdatedAt The last update time of the workflow
 	UpdatedAt FlexibleTime `json:"updated_at"`
 
+	// Url URL to download file from
+	Url string `json:"url"`
+
 	// Variables The variables to run the workflow with
 	Variables *[]ParameterInfo `json:"variables,omitempty"`
 
 	// Versions The versions of the workflow
 	Versions   []string `json:"versions"`
 	WorkflowId *string  `json:"workflow_id,omitempty"`
+}
+
+// GetCookiesResponse defines model for GetCookiesResponse.
+type GetCookiesResponse struct {
+	Cookies []Cookie `json:"cookies"`
+}
+
+// GetCredentialsResponse defines model for GetCredentialsResponse.
+type GetCredentialsResponse struct {
+	Credentials CredentialsDictOutput `json:"credentials"`
+}
+
+// GetCreditCardResponse defines model for GetCreditCardResponse.
+type GetCreditCardResponse struct {
+	CreditCard CreditCardDictOutput `json:"credit_card"`
 }
 
 // GetFunctionRunResponse defines model for GetFunctionRunResponse.
@@ -1378,46 +1428,6 @@ type GetFunctionRunResponse struct {
 
 // GetFunctionRunResponseStatus defines model for GetFunctionRunResponse.Status.
 type GetFunctionRunResponseStatus string
-
-// GetFunctionWithLinkResponse defines model for GetFunctionWithLinkResponse.
-type GetFunctionWithLinkResponse struct {
-	// CreatedAt The creation time of the workflow
-	CreatedAt FlexibleTime `json:"created_at"`
-
-	// Description The description of the workflow
-	Description *string `json:"description,omitempty"`
-
-	// FunctionId The ID of the function
-	FunctionId string `json:"function_id"`
-
-	// LatestVersion The version of the workflow
-	LatestVersion string `json:"latest_version"`
-
-	// Name The name of the workflow
-	Name *string `json:"name,omitempty"`
-
-	// ReferenceWorkflowId The ID of the reference workflow (i.e wether the workflow was forked from another workflow or not)
-	ReferenceWorkflowId *string `json:"reference_workflow_id,omitempty"`
-
-	// Shared Whether the workflow is public and can beshared with other users
-	Shared *bool `json:"shared,omitempty"`
-
-	// Status The status of the workflow
-	Status string `json:"status"`
-
-	// UpdatedAt The last update time of the workflow
-	UpdatedAt FlexibleTime `json:"updated_at"`
-
-	// Url URL to download file from
-	Url string `json:"url"`
-
-	// Variables The variables to run the workflow with
-	Variables *[]ParameterInfo `json:"variables,omitempty"`
-
-	// Versions The versions of the workflow
-	Versions   []string `json:"versions"`
-	WorkflowId *string  `json:"workflow_id,omitempty"`
-}
 
 // GlobalScrapeRequest defines model for GlobalScrapeRequest.
 type GlobalScrapeRequest struct {
@@ -1797,13 +1807,13 @@ type PaginatedResponseAgentResponse struct {
 	PageSize    int             `json:"page_size"`
 }
 
-// PaginatedResponseGetFunctionResponse defines model for PaginatedResponse_GetFunctionResponse_.
-type PaginatedResponseGetFunctionResponse struct {
-	HasNext     bool                  `json:"has_next"`
-	HasPrevious *bool                 `json:"has_previous,omitempty"`
-	Items       []GetFunctionResponse `json:"items"`
-	Page        int                   `json:"page"`
-	PageSize    int                   `json:"page_size"`
+// PaginatedResponseFunctionResponse defines model for PaginatedResponse_FunctionResponse_.
+type PaginatedResponseFunctionResponse struct {
+	HasNext     bool               `json:"has_next"`
+	HasPrevious *bool              `json:"has_previous,omitempty"`
+	Items       []FunctionResponse `json:"items"`
+	Page        int                `json:"page"`
+	PageSize    int                `json:"page_size"`
 }
 
 // PaginatedResponseGetFunctionRunResponse defines model for PaginatedResponse_GetFunctionRunResponse_.
@@ -1942,6 +1952,12 @@ type ProfileCreateRequest struct {
 type ProfileDeleteResponse struct {
 	Message *string `json:"message,omitempty"`
 	Success *bool   `json:"success,omitempty"`
+}
+
+// ProfileDuplicateRequest defines model for ProfileDuplicateRequest.
+type ProfileDuplicateRequest struct {
+	// Name Optional name for the duplicate; defaults to the source profile name
+	Name *string `json:"name,omitempty"`
 }
 
 // ProfileResponse defines model for ProfileResponse.
@@ -2890,6 +2906,12 @@ type ProfileCookiesSetParams struct {
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
 
+// ProfileDuplicateParams defines parameters for ProfileDuplicate.
+type ProfileDuplicateParams struct {
+	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
+	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
+}
+
 // SearchWebParams defines parameters for SearchWeb.
 type SearchWebParams struct {
 	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
@@ -3195,6 +3217,9 @@ type ProfileCreateJSONRequestBody = ProfileCreateRequest
 
 // ProfileCookiesSetJSONRequestBody defines body for ProfileCookiesSet for application/json ContentType.
 type ProfileCookiesSetJSONRequestBody = ProfileCookiesImportRequest
+
+// ProfileDuplicateJSONRequestBody defines body for ProfileDuplicate for application/json ContentType.
+type ProfileDuplicateJSONRequestBody = ProfileDuplicateRequest
 
 // SearchWebJSONRequestBody defines body for SearchWeb for application/json ContentType.
 type SearchWebJSONRequestBody = SearchRequest
@@ -8393,6 +8418,11 @@ type ClientInterface interface {
 
 	ProfileCookiesSet(ctx context.Context, profileId string, params *ProfileCookiesSetParams, body ProfileCookiesSetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ProfileDuplicateWithBody request with any body
+	ProfileDuplicateWithBody(ctx context.Context, profileId string, params *ProfileDuplicateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ProfileDuplicate(ctx context.Context, profileId string, params *ProfileDuplicateParams, body ProfileDuplicateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ReadyCheck request
 	ReadyCheck(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -8992,6 +9022,30 @@ func (c *Client) ProfileCookiesSetWithBody(ctx context.Context, profileId string
 
 func (c *Client) ProfileCookiesSet(ctx context.Context, profileId string, params *ProfileCookiesSetParams, body ProfileCookiesSetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewProfileCookiesSetRequest(c.Server, profileId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ProfileDuplicateWithBody(ctx context.Context, profileId string, params *ProfileDuplicateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewProfileDuplicateRequestWithBody(c.Server, profileId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ProfileDuplicate(ctx context.Context, profileId string, params *ProfileDuplicateParams, body ProfileDuplicateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewProfileDuplicateRequest(c.Server, profileId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -12156,6 +12210,79 @@ func NewProfileCookiesSetRequestWithBody(server string, profileId string, params
 	return req, nil
 }
 
+// NewProfileDuplicateRequest calls the generic ProfileDuplicate builder with application/json body
+func NewProfileDuplicateRequest(server string, profileId string, params *ProfileDuplicateParams, body ProfileDuplicateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewProfileDuplicateRequestWithBody(server, profileId, params, "application/json", bodyReader)
+}
+
+// NewProfileDuplicateRequestWithBody generates requests for ProfileDuplicate with any type of body
+func NewProfileDuplicateRequestWithBody(server string, profileId string, params *ProfileDuplicateParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "profile_id", runtime.ParamLocationPath, profileId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/profiles/%s/duplicate", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.XNotteRequestOrigin != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-request-origin", headerParam0)
+		}
+
+		if params.XNotteSdkVersion != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-sdk-version", headerParam1)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewReadyCheckRequest generates requests for ReadyCheck
 func NewReadyCheckRequest(server string) (*http.Request, error) {
 	var err error
@@ -15066,6 +15193,11 @@ type ClientWithResponsesInterface interface {
 
 	ProfileCookiesSetWithResponse(ctx context.Context, profileId string, params *ProfileCookiesSetParams, body ProfileCookiesSetJSONRequestBody, reqEditors ...RequestEditorFn) (*ProfileCookiesSetResult, error)
 
+	// ProfileDuplicateWithBodyWithResponse request with any body
+	ProfileDuplicateWithBodyWithResponse(ctx context.Context, profileId string, params *ProfileDuplicateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ProfileDuplicateResult, error)
+
+	ProfileDuplicateWithResponse(ctx context.Context, profileId string, params *ProfileDuplicateParams, body ProfileDuplicateJSONRequestBody, reqEditors ...RequestEditorFn) (*ProfileDuplicateResult, error)
+
 	// ReadyCheckWithResponse request
 	ReadyCheckWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ReadyCheckResult, error)
 
@@ -15336,7 +15468,7 @@ func (r AnythingStartResult) StatusCode() int {
 type ListFunctionsResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *PaginatedResponseGetFunctionResponse
+	JSON200      *PaginatedResponseFunctionResponse
 	JSON422      *HTTPValidationError
 }
 
@@ -15359,7 +15491,7 @@ func (r ListFunctionsResult) StatusCode() int {
 type FunctionCreateResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *GetFunctionResponse
+	JSON200      *FunctionResponse
 	JSON422      *HTTPValidationError
 }
 
@@ -15405,7 +15537,7 @@ func (r FunctionDeleteResult) StatusCode() int {
 type FunctionDownloadUrlResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *GetFunctionWithLinkResponse
+	JSON200      *FunctionWithLinkResponse
 	JSON422      *HTTPValidationError
 }
 
@@ -15428,7 +15560,7 @@ func (r FunctionDownloadUrlResult) StatusCode() int {
 type FunctionUpdateResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *GetFunctionResponse
+	JSON200      *FunctionResponse
 	JSON422      *HTTPValidationError
 }
 
@@ -15451,7 +15583,7 @@ func (r FunctionUpdateResult) StatusCode() int {
 type FunctionForkResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *GetFunctionResponse
+	JSON200      *FunctionResponse
 	JSON422      *HTTPValidationError
 }
 
@@ -15924,6 +16056,29 @@ func (r ProfileCookiesSetResult) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ProfileCookiesSetResult) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ProfileDuplicateResult struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProfileResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ProfileDuplicateResult) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ProfileDuplicateResult) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -17110,6 +17265,23 @@ func (c *ClientWithResponses) ProfileCookiesSetWithResponse(ctx context.Context,
 	return ParseProfileCookiesSetResult(rsp)
 }
 
+// ProfileDuplicateWithBodyWithResponse request with arbitrary body returning *ProfileDuplicateResult
+func (c *ClientWithResponses) ProfileDuplicateWithBodyWithResponse(ctx context.Context, profileId string, params *ProfileDuplicateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ProfileDuplicateResult, error) {
+	rsp, err := c.ProfileDuplicateWithBody(ctx, profileId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseProfileDuplicateResult(rsp)
+}
+
+func (c *ClientWithResponses) ProfileDuplicateWithResponse(ctx context.Context, profileId string, params *ProfileDuplicateParams, body ProfileDuplicateJSONRequestBody, reqEditors ...RequestEditorFn) (*ProfileDuplicateResult, error) {
+	rsp, err := c.ProfileDuplicate(ctx, profileId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseProfileDuplicateResult(rsp)
+}
+
 // ReadyCheckWithResponse request returning *ReadyCheckResult
 func (c *ClientWithResponses) ReadyCheckWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ReadyCheckResult, error) {
 	rsp, err := c.ReadyCheck(ctx, reqEditors...)
@@ -17727,7 +17899,7 @@ func ParseListFunctionsResult(rsp *http.Response) (*ListFunctionsResult, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest PaginatedResponseGetFunctionResponse
+		var dest PaginatedResponseFunctionResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17760,7 +17932,7 @@ func ParseFunctionCreateResult(rsp *http.Response) (*FunctionCreateResult, error
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest GetFunctionResponse
+		var dest FunctionResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17826,7 +17998,7 @@ func ParseFunctionDownloadUrlResult(rsp *http.Response) (*FunctionDownloadUrlRes
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest GetFunctionWithLinkResponse
+		var dest FunctionWithLinkResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17859,7 +18031,7 @@ func ParseFunctionUpdateResult(rsp *http.Response) (*FunctionUpdateResult, error
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest GetFunctionResponse
+		var dest FunctionResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -17892,7 +18064,7 @@ func ParseFunctionForkResult(rsp *http.Response) (*FunctionForkResult, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest GetFunctionResponse
+		var dest FunctionResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -18546,6 +18718,39 @@ func ParseProfileCookiesSetResult(rsp *http.Response) (*ProfileCookiesSetResult,
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ProfileCookiesImportResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseProfileDuplicateResult parses an HTTP response from a ProfileDuplicateWithResponse call
+func ParseProfileDuplicateResult(rsp *http.Response) (*ProfileDuplicateResult, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ProfileDuplicateResult{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProfileResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -354,7 +354,7 @@ func runFunctionsList(cmd *cobra.Command, args []string) error {
 
 	formatter := GetFormatter()
 
-	var items []api.GetFunctionResponse
+	var items []api.FunctionResponse
 	if resp.JSON200 != nil {
 		items = resp.JSON200.Items
 	}


### PR DESCRIPTION
## Summary

- regenerate the Go API client from the staging OpenAPI schema
- update the functions list formatter for the renamed `FunctionResponse` model
- include the new profile duplication endpoint and current function response fields

## Validation

- `make check`
- `go test ./...`

Linear: NOT-715 https://linear.app/nottelabsinc/issue/NOT-715/notte-cli-pr-55-chore-sync-generated-client-with-staging-openapi