### PR TITLE
[NOT-745] ci: add a cooldown to Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,6 @@
+# Dependabot proposes a release as soon as it is published; the cooldown
+# blocks below make a version age first, so a compromised or yanked release
+# has time to be caught. Security updates are exempt and are not delayed.
 version: 2
 updates:
   # Go modules
@@ -5,6 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     commit-message:
       prefix: "deps"
     groups:
@@ -17,6 +25,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     commit-message:
       prefix: "ci"
     groups:


### PR DESCRIPTION
Dependabot currently proposes a new release as soon as it is published, which is the window in which a compromised or yanked version is still undetected.

This adds a `cooldown` to both the `gomod` and `github-actions` update configs, so a release has to age before an update is opened:

- 3 days for patches
- 7 days for minors
- 14 days for majors

Security updates are exempt from cooldown, so advisories and CVE fixes are not delayed by this.

Linear: NOT-745 — https://linear.app/nottelabsinc/issue/NOT-745/notte-cli-pr-56-ci-add-a-cooldown-to-dependabot-version-updates