### PR TITLE
fix: name list filter flags for what they actually do

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ notte personas sms --persona-id <id>     # List SMS messages
 ### Profiles
 
 ```bash
-notte profiles list [--page N] [--page-size N] [--name "..."]  # List all profiles
+notte profiles list [--page N] [--page-size N] [--name "..."] [--include-deleted]  # List all profiles
 notte profiles create                    # Create a new profile
 notte profiles show --profile-id <id>    # View profile details
 notte profiles delete --profile-id <id>  # Delete a profile

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ response for scripting.
 ### Browser Sessions
 
 ```bash
-notte sessions list [--page N] [--page-size N] [--only-active]  # List sessions
+notte sessions list [--page N] [--page-size N] [-a|--all]  # List running sessions (-a includes stopped)
 notte sessions start [flags]          # Start a new session
 notte sessions status                 # Get current session status
 notte sessions stop                   # Stop current session
@@ -167,7 +167,7 @@ notte page captcha-solve              # Solve captcha
 ### AI Agents
 
 ```bash
-notte agents list [--page N] [--page-size N] [--only-active] [--only-saved]  # List agents
+notte agents list [--page N] [--page-size N] [-a|--all] [--only-saved]  # List running agents (-a includes finished)
 notte agents start --task "..."       # Start a new AI agent (auto-uses current session)
 notte agents status                   # Get agent status (uses current agent)
 notte agents stop                     # Stop an agent (uses current agent)
@@ -180,7 +180,7 @@ notte agents replay                   # Get agent execution replay
 ### Functions
 
 ```bash
-notte functions list [--page N] [--page-size N] [--only-active]  # List functions
+notte functions list [--page N] [--page-size N] [--include-deleted]  # List functions
 notte functions create --file workflow.py  # Create a new function
 notte functions show                  # View current function details
 notte functions show --function-id <id>  # View specific function details (different from current function)
@@ -188,7 +188,7 @@ notte functions update --file workflow.py  # Update current function code
 notte functions delete                # Delete current function
 notte functions fork                  # Fork current function to new version
 notte functions run                   # Execute current function
-notte functions runs [--page N] [--page-size N] [--only-active]  # List runs for current function
+notte functions runs [--page N] [--page-size N] [--running]  # List runs for current function (--running = in-flight only)
 notte functions run-stop --run-id <id>  # Stop a running function execution
 notte functions run-metadata --run-id <id>  # Get run logs and results
 notte functions schedule --cron "0 9 * * *"  # Schedule current function
@@ -200,7 +200,7 @@ notte functions unschedule            # Remove schedule from current function
 ### Vaults
 
 ```bash
-notte vaults list [--page N] [--page-size N] [--only-active]  # List all vaults
+notte vaults list [--page N] [--page-size N] [--include-deleted]  # List all vaults
 notte vaults create                                   # Create a new vault
 notte vaults update --vault-id <id>                   # Update vault metadata
 notte vaults delete --vault-id <id>                   # Delete a vault
@@ -213,7 +213,7 @@ notte vaults credentials delete --vault-id <id>       # Delete credentials
 ### Personas
 
 ```bash
-notte personas list [--page N] [--page-size N] [--only-active]  # List all personas
+notte personas list [--page N] [--page-size N] [--include-deleted]  # List all personas
 notte personas create                    # Create a new persona
 notte personas show --persona-id <id>    # View persona details
 notte personas delete --persona-id <id>  # Delete a persona
@@ -351,7 +351,7 @@ notte sessions stop
 
 ```bash
 # Get only active sessions (using built-in filter)
-notte sessions list --only-active
+notte sessions list --all
 
 # Paginate through results
 notte sessions list --page 2 --page-size 5

--- a/internal/cmd/agents.go
+++ b/internal/cmd/agents.go
@@ -132,7 +132,7 @@ func init() {
 	rootCmd.AddCommand(agentsCmd)
 	agentsCmd.AddCommand(agentsListCmd)
 	registerPaginationFlags(agentsListCmd)
-	agentsListCmd.Flags().Bool("only-active", false, "Only return active agents")
+	registerFilterFlag(agentsListCmd, flagAll, "a", "Include finished agents")
 	agentsListCmd.Flags().Bool("only-saved", false, "Only return saved agents")
 
 	agentsCmd.AddCommand(agentsStartCmd)
@@ -179,14 +179,8 @@ func runAgentsList(cmd *cobra.Command, args []string) error {
 		Page:     page,
 		PageSize: pageSize,
 	}
-	if cmd.Flags().Changed("only-active") {
-		v, _ := cmd.Flags().GetBool("only-active")
-		params.OnlyActive = &v
-	}
-	if cmd.Flags().Changed("only-saved") {
-		v, _ := cmd.Flags().GetBool("only-saved")
-		params.OnlySaved = &v
-	}
+	params.OnlyActive = resolveOnlyActive(cmd, flagAll, true)
+	params.OnlySaved = alwaysSend(cmd, "only-saved")
 	resp, err := client.Client().ListAgentsWithResponse(ctx, params)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)

--- a/internal/cmd/flags_test.go
+++ b/internal/cmd/flags_test.go
@@ -121,7 +121,7 @@ func TestPaginatedListCommandsHaveFlags(t *testing.T) {
 		{functionsListCmd, "functions list", []string{"page", "page-size", "only-active"}},
 		{functionsRunsCmd, "functions runs", []string{"page", "page-size", "only-active"}},
 		{personasListCmd, "personas list", []string{"page", "page-size", "only-active"}},
-		{profilesListCmd, "profiles list", []string{"page", "page-size", "name"}},
+		{profilesListCmd, "profiles list", []string{"page", "page-size", "name", "include-deleted"}},
 		{vaultsListCmd, "vaults list", []string{"page", "page-size", "only-active"}},
 	}
 

--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -238,7 +238,7 @@ func init() {
 	rootCmd.AddCommand(functionsCmd)
 	functionsCmd.AddCommand(functionsListCmd)
 	registerPaginationFlags(functionsListCmd)
-	functionsListCmd.Flags().Bool("only-active", false, "Only return active functions")
+	registerFilterFlag(functionsListCmd, flagIncludeDeleted, "", "Include deleted functions")
 
 	functionsCmd.AddCommand(functionsCreateCmd)
 	functionsCmd.AddCommand(functionsShowCmd)
@@ -247,7 +247,7 @@ func init() {
 	functionsCmd.AddCommand(functionsRunCmd)
 	functionsCmd.AddCommand(functionsRunsCmd)
 	registerPaginationFlags(functionsRunsCmd)
-	functionsRunsCmd.Flags().Bool("only-active", false, "Only return active runs")
+	registerFilterFlag(functionsRunsCmd, flagRunning, "", "Only show runs that are still executing")
 
 	functionsCmd.AddCommand(functionsForkCmd)
 	functionsCmd.AddCommand(functionsRunStopCmd)
@@ -339,10 +339,7 @@ func runFunctionsList(cmd *cobra.Command, args []string) error {
 		Page:     page,
 		PageSize: pageSize,
 	}
-	if cmd.Flags().Changed("only-active") {
-		v, _ := cmd.Flags().GetBool("only-active")
-		params.OnlyActive = &v
-	}
+	params.OnlyActive = resolveOnlyActive(cmd, flagIncludeDeleted, true)
 	resp, err := client.Client().ListFunctionsWithResponse(ctx, params)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)
@@ -669,10 +666,9 @@ func runFunctionRuns(cmd *cobra.Command, args []string) error {
 		Page:     page,
 		PageSize: pageSize,
 	}
-	if cmd.Flags().Changed("only-active") {
-		v, _ := cmd.Flags().GetBool("only-active")
-		params.OnlyActive = &v
-	}
+	// Runs default to the full history: "active" here means still executing, so
+	// filtering by it would make run history permanently empty.
+	params.OnlyActive = resolveOnlyActive(cmd, flagRunning, false)
 	resp, err := client.Client().ListFunctionRunsByFunctionIdWithResponse(ctx, functionID, params)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)

--- a/internal/cmd/pagination.go
+++ b/internal/cmd/pagination.go
@@ -32,3 +32,60 @@ func getPageSizeFlag(cmd *cobra.Command) (*int, error) {
 	}
 	return nil, nil
 }
+
+// The API exposes a single `only_active` parameter, but it means a different
+// thing for each resource:
+//
+//   - stored artifacts (functions, vaults, personas): active == not deleted
+//   - live instances (sessions, agents):               active == still running
+//   - function runs:                                   active == still executing
+//
+// One flag named --only-active for all three is unlearnable: whatever a user
+// infers from `sessions list` is wrong on `functions list`. So each resource
+// gets a flag named after what it actually does, and --only-active is kept as a
+// deprecated alias that still maps straight onto the API parameter.
+const (
+	flagIncludeDeleted = "include-deleted" // artifacts
+	flagAll            = "all"             // live instances
+	flagRunning        = "running"         // function runs
+	flagOnlyActive     = "only-active"     // deprecated alias for all of the above
+)
+
+// registerFilterFlag registers a list command's filter flag plus the deprecated
+// --only-active it replaces.
+func registerFilterFlag(cmd *cobra.Command, name, shorthand, usage string) {
+	cmd.Flags().BoolP(name, shorthand, false, usage)
+	cmd.Flags().Bool(flagOnlyActive, false, "Deprecated: use --"+name)
+	_ = cmd.Flags().MarkDeprecated(flagOnlyActive, "use --"+name)
+}
+
+// resolveOnlyActive maps a command's user-facing filter flag onto the API's
+// only_active parameter. Set negates when the flag widens the result set
+// (--all, --include-deleted) rather than narrowing it (--running).
+//
+// The returned pointer is always non-nil, so the value travels on every
+// request. That matters independently of the defaults: previously the CLI only
+// sent the parameter when cobra reported the flag as Changed, which left the
+// server's default in charge of the CLI's documented behaviour. Sending it
+// always keeps these defaults authoritative and immune to a server-side change.
+func resolveOnlyActive(cmd *cobra.Command, name string, negates bool) *bool {
+	// The deprecated flag maps directly onto the API parameter, so an explicit
+	// --only-active=false keeps working for anyone already relying on it.
+	if cmd.Flags().Changed(flagOnlyActive) {
+		v, _ := cmd.Flags().GetBool(flagOnlyActive)
+		return &v
+	}
+
+	v, _ := cmd.Flags().GetBool(name)
+	if negates {
+		v = !v
+	}
+	return &v
+}
+
+// alwaysSend returns a non-nil pointer to a plain boolean filter flag that
+// needs no renaming, for the same reason resolveOnlyActive does.
+func alwaysSend(cmd *cobra.Command, name string) *bool {
+	v, _ := cmd.Flags().GetBool(name)
+	return &v
+}

--- a/internal/cmd/pagination_test.go
+++ b/internal/cmd/pagination_test.go
@@ -1,0 +1,216 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newListCmd builds a bare list command carrying one renamed filter flag plus
+// the deprecated --only-active alias, the way registerFilterFlag does.
+func newListCmd(name, shorthand string) *cobra.Command {
+	cmd := &cobra.Command{Use: "list", RunE: func(*cobra.Command, []string) error { return nil }}
+	registerFilterFlag(cmd, name, shorthand, "usage")
+	return cmd
+}
+
+func execute(t *testing.T, cmd *cobra.Command, args ...string) {
+	t.Helper()
+	cmd.SetArgs(args)
+	// Deprecated flags print a notice to stderr; keep test output quiet.
+	cmd.SetOut(nil)
+	cmd.SetErr(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(%v) error = %v", args, err)
+	}
+}
+
+// TestResolveOnlyActiveArtifacts covers functions/vaults/personas, where the
+// API's only_active means "not deleted". The default must keep deleted records
+// hidden - surfacing tombstones in a plain `list` would be a regression.
+func TestResolveOnlyActiveArtifacts(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"default hides deleted", []string{}, true},
+		{"--include-deleted shows them", []string{"--include-deleted"}, false},
+		{"--include-deleted=false", []string{"--include-deleted=false"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newListCmd(flagIncludeDeleted, "")
+			execute(t, cmd, tc.args...)
+
+			got := resolveOnlyActive(cmd, flagIncludeDeleted, true)
+			if got == nil {
+				t.Fatal("resolveOnlyActive returned nil; the value must always be sent so the " +
+					"API cannot substitute its own default")
+			}
+			if *got != tc.want {
+				t.Errorf("only_active = %v, want %v", *got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveOnlyActiveInstances covers sessions/agents, where only_active
+// means "still running". The default stays running-only, matching `docker ps`.
+func TestResolveOnlyActiveInstances(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"default shows running only", []string{}, true},
+		{"--all includes finished", []string{"--all"}, false},
+		{"-a includes finished", []string{"-a"}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newListCmd(flagAll, "a")
+			execute(t, cmd, tc.args...)
+
+			got := resolveOnlyActive(cmd, flagAll, true)
+			if got == nil {
+				t.Fatal("resolveOnlyActive returned nil")
+			}
+			if *got != tc.want {
+				t.Errorf("only_active = %v, want %v", *got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveOnlyActiveRuns is the regression test for the bug that started
+// this: for function runs, only_active means "still executing", so defaulting
+// to it made run history permanently empty. `notte functions runs` returned []
+// for a function whose runs had all completed, which reads as "this function
+// never ran" and misleads anything diagnosing a failure.
+func TestResolveOnlyActiveRuns(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"default returns full history", []string{}, false},
+		{"--running narrows to in-flight", []string{"--running"}, true},
+		{"--running=false", []string{"--running=false"}, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newListCmd(flagRunning, "")
+			execute(t, cmd, tc.args...)
+
+			got := resolveOnlyActive(cmd, flagRunning, false)
+			if got == nil {
+				t.Fatal("resolveOnlyActive returned nil")
+			}
+			if *got != tc.want {
+				t.Errorf("only_active = %v, want %v", *got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDeprecatedOnlyActiveStillWins keeps the escape hatch working: --only-active
+// maps straight onto the API parameter, so anyone already passing it - including
+// scripts written against the old behaviour - is unaffected by the rename.
+func TestDeprecatedOnlyActiveStillWins(t *testing.T) {
+	for _, tc := range []struct {
+		flagName string
+		negates  bool
+		args     []string
+		want     bool
+	}{
+		{flagIncludeDeleted, true, []string{"--only-active=false"}, false},
+		{flagIncludeDeleted, true, []string{"--only-active"}, true},
+		{flagAll, true, []string{"--only-active=false"}, false},
+		{flagRunning, false, []string{"--only-active"}, true},
+	} {
+		cmd := newListCmd(tc.flagName, "")
+		execute(t, cmd, tc.args...)
+
+		got := resolveOnlyActive(cmd, tc.flagName, tc.negates)
+		if got == nil || *got != tc.want {
+			t.Errorf("--%s with %v: only_active = %v, want %v", tc.flagName, tc.args, got, tc.want)
+		}
+	}
+}
+
+// TestOnlyActiveIsHiddenButUsable checks the deprecation is a soft one: the flag
+// no longer clutters --help, but still parses.
+func TestOnlyActiveIsHiddenButUsable(t *testing.T) {
+	cmd := newListCmd(flagAll, "a")
+	f := cmd.Flags().Lookup(flagOnlyActive)
+	if f == nil {
+		t.Fatal("--only-active should still exist as a deprecated alias")
+	}
+	if f.Deprecated == "" {
+		t.Error("--only-active should be marked deprecated")
+	}
+	if !f.Hidden {
+		t.Error("a deprecated --only-active should be hidden from help output")
+	}
+}
+
+// TestAlwaysSendReturnsValue covers --only-saved, which needs no rename but is
+// sent explicitly for the same reason.
+func TestAlwaysSendReturnsValue(t *testing.T) {
+	cmd := &cobra.Command{Use: "list", RunE: func(*cobra.Command, []string) error { return nil }}
+	cmd.Flags().Bool("only-saved", false, "Only return saved agents")
+	execute(t, cmd)
+
+	got := alwaysSend(cmd, "only-saved")
+	if got == nil || *got != false {
+		t.Errorf("alwaysSend(only-saved) = %v, want non-nil false", got)
+	}
+}
+
+// TestPageFlagsStayUnsetWhenOmitted guards the opposite convention: pagination
+// parameters are genuinely optional and must stay absent when not supplied, so
+// the API applies its own page defaults. Don't "unify" these with the filters.
+func TestPageFlagsStayUnsetWhenOmitted(t *testing.T) {
+	cmd := &cobra.Command{Use: "list", RunE: func(*cobra.Command, []string) error { return nil }}
+	registerPaginationFlags(cmd)
+	execute(t, cmd)
+
+	page, err := getPageFlag(cmd)
+	if err != nil {
+		t.Fatalf("getPageFlag() error = %v", err)
+	}
+	if page != nil {
+		t.Errorf("getPageFlag() = %v, want nil when --page is omitted", *page)
+	}
+
+	pageSize, err := getPageSizeFlag(cmd)
+	if err != nil {
+		t.Fatalf("getPageSizeFlag() error = %v", err)
+	}
+	if pageSize != nil {
+		t.Errorf("getPageSizeFlag() = %v, want nil when --page-size is omitted", *pageSize)
+	}
+}
+
+// TestPageFlagsRejectOutOfRange keeps the existing 1-indexed validation covered.
+func TestPageFlagsRejectOutOfRange(t *testing.T) {
+	for _, flag := range []string{"--page=0", "--page-size=0"} {
+		cmd := &cobra.Command{Use: "list", RunE: func(*cobra.Command, []string) error { return nil }}
+		registerPaginationFlags(cmd)
+		execute(t, cmd, flag)
+
+		var err error
+		if flag == "--page=0" {
+			_, err = getPageFlag(cmd)
+		} else {
+			_, err = getPageSizeFlag(cmd)
+		}
+		if err == nil {
+			t.Errorf("%s: expected an error for a value < 1", flag)
+		}
+	}
+}

--- a/internal/cmd/personas.go
+++ b/internal/cmd/personas.go
@@ -60,7 +60,7 @@ func init() {
 	rootCmd.AddCommand(personasCmd)
 	personasCmd.AddCommand(personasListCmd)
 	registerPaginationFlags(personasListCmd)
-	personasListCmd.Flags().Bool("only-active", false, "Only return active personas")
+	registerFilterFlag(personasListCmd, flagIncludeDeleted, "", "Include deleted personas")
 
 	personasCmd.AddCommand(personasCreateCmd)
 	personasCmd.AddCommand(personasShowCmd)
@@ -109,10 +109,7 @@ func runPersonasList(cmd *cobra.Command, args []string) error {
 		Page:     page,
 		PageSize: pageSize,
 	}
-	if cmd.Flags().Changed("only-active") {
-		v, _ := cmd.Flags().GetBool("only-active")
-		params.OnlyActive = &v
-	}
+	params.OnlyActive = resolveOnlyActive(cmd, flagIncludeDeleted, true)
 	resp, err := client.Client().ListPersonasWithResponse(ctx, params)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)

--- a/internal/cmd/profiles.go
+++ b/internal/cmd/profiles.go
@@ -46,6 +46,7 @@ func init() {
 	rootCmd.AddCommand(profilesCmd)
 	profilesCmd.AddCommand(profilesListCmd)
 	registerPaginationFlags(profilesListCmd)
+	registerFilterFlag(profilesListCmd, flagIncludeDeleted, "", "Include deleted profiles")
 	profilesListCmd.Flags().String("name", "", "Filter profiles by name")
 
 	profilesCmd.AddCommand(profilesCreateCmd)
@@ -85,6 +86,7 @@ func runProfilesList(cmd *cobra.Command, args []string) error {
 		Page:     page,
 		PageSize: pageSize,
 	}
+	params.OnlyActive = resolveOnlyActive(cmd, flagIncludeDeleted, true)
 	if cmd.Flags().Changed("name") {
 		v, _ := cmd.Flags().GetString("name")
 		params.Name = &v

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -321,7 +321,7 @@ func init() {
 	rootCmd.AddCommand(sessionsCmd)
 	sessionsCmd.AddCommand(sessionsListCmd)
 	registerPaginationFlags(sessionsListCmd)
-	sessionsListCmd.Flags().Bool("only-active", false, "Only return active sessions")
+	registerFilterFlag(sessionsListCmd, flagAll, "a", "Include stopped sessions")
 
 	sessionsCmd.AddCommand(sessionsStartCmd)
 	sessionsCmd.AddCommand(sessionsStatusCmd)
@@ -423,10 +423,7 @@ func runSessionsList(cmd *cobra.Command, args []string) error {
 		Page:     page,
 		PageSize: pageSize,
 	}
-	if cmd.Flags().Changed("only-active") {
-		v, _ := cmd.Flags().GetBool("only-active")
-		params.OnlyActive = &v
-	}
+	params.OnlyActive = resolveOnlyActive(cmd, flagAll, true)
 	resp, err := client.Client().ListSessionsWithResponse(ctx, params)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)

--- a/internal/cmd/vaults.go
+++ b/internal/cmd/vaults.go
@@ -99,7 +99,7 @@ func init() {
 	rootCmd.AddCommand(vaultsCmd)
 	vaultsCmd.AddCommand(vaultsListCmd)
 	registerPaginationFlags(vaultsListCmd)
-	vaultsListCmd.Flags().Bool("only-active", false, "Only return active vaults")
+	registerFilterFlag(vaultsListCmd, flagIncludeDeleted, "", "Include deleted vaults")
 
 	vaultsCmd.AddCommand(vaultsCreateCmd)
 	vaultsCmd.AddCommand(vaultsUpdateCmd)
@@ -163,10 +163,7 @@ func runVaultsList(cmd *cobra.Command, args []string) error {
 		Page:     page,
 		PageSize: pageSize,
 	}
-	if cmd.Flags().Changed("only-active") {
-		v, _ := cmd.Flags().GetBool("only-active")
-		params.OnlyActive = &v
-	}
+	params.OnlyActive = resolveOnlyActive(cmd, flagIncludeDeleted, true)
 	resp, err := client.Client().ListVaultsWithResponse(ctx, params)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)


### PR DESCRIPTION
The API exposes a single `only_active` parameter, but it means a **different thing per resource**. Verified against prod by creating, deleting and stopping real records:

| Resource | `only_active` actually means | Evidence |
|---|---|---|
| `functions`, `vaults`, `personas`, `profiles` | **not deleted** | deleted a function/vault/persona/profile — each reappears only with `only_active=false` |
| `sessions`, `agents` | **still running** | stopped a session → hidden from default; all 100 hidden agents are status `closed`, not deleted |
| `functions runs` | **still executing** | a function with 2 completed runs lists as `[]` |

One flag named `--only-active` covering all three is unlearnable: whatever you infer from `sessions list` is wrong on `functions list`.

## What changes

Each resource gets a flag named after what it does:

| Command | New flag | Default |
|---|---|---|
| `functions list`, `vaults list`, `personas list`, `profiles list` | `--include-deleted` | hide deleted *(unchanged)* |
| `sessions list`, `agents list` | `-a`, `--all` | running only *(unchanged)* |
| `functions runs` | `--running` | **full history** ← only behaviour change |

`--only-active` is kept as a **deprecated, hidden alias** mapping straight onto the API parameter, so existing scripts are unaffected:

```
$ notte functions runs --function-id <id> --only-active=false
Flag --only-active has been deprecated, use --running
```

## The one behaviour change

`notte functions runs` now returns the full history. Defaulting it to active-only made run history permanently empty — it returned `[]` for a function whose two runs had both completed, which reads as *"this function never ran"* and misleads anything diagnosing a failure. That's what surfaced this.

Everything else keeps today's defaults. In particular `functions list` / `vaults list` / `personas list` continue to hide deleted records.

> **Note for reviewers:** the first draft of this PR did the opposite — it made *every* list default to showing everything, on the assumption that "active" uniformly meant "running". That would have started listing soft-deleted functions and vaults by default. The semantics are now checked per resource rather than assumed, which is what produced the three-way split above.

## `profiles list` had no filter flag at all

`profiles list` never registered or sent `only_active`, so the API's active-only default hid deleted profiles with **no way to see them**. Same class of bug as the rest, just with the flag missing rather than mis-defaulted. `ProfileListParams` already carries `OnlyActive`, so this is CLI-side only.

Verified: a profile created then deleted vanishes from the default listing and returns with `--include-deleted`; account-wide the default shows 31 where `--include-deleted` shows 40.

### Not adding it to `functions secrets list`

`ListSecretsParams` exposes only `namespace` — there is no `only_active` parameter, so there is nothing for the CLI to send. If secrets are soft-deleted server-side, surfacing them needs an API change first.

## Also: the value is now always sent

Independent of the defaults. Previously the CLI only sent the parameter when cobra reported the flag as `Changed`:

```go
if cmd.Flags().Changed("only-active") { ... }   // otherwise: parameter omitted
```

With it omitted the **server's** default decided the CLI's documented behaviour — which is why an omitted `--only-active` filtered at all despite defaulting to `false`. Sending it on every request keeps these defaults authoritative and immune to a server-side change.

Pagination keeps the opposite convention: `--page`/`--page-size` are genuinely optional and stay absent when omitted so the API applies its own paging defaults. `pagination_test.go` asserts both rules so they don't get "unified" by mistake.

## Verification

Locally built binary against prod:

```
ARTIFACTS   functions list                  64    --include-deleted  100
            vaults list                      6
            personas list                   11
            deleted fn in default list       0  ✓

INSTANCES   sessions list                    0    -a                 100
            agents list                      0    --all              100

RUNS        functions runs                   2    --running            0  ✓ fixed

PROFILES    profiles list                   31    --include-deleted   40  ✓ was unreachable
```

- `go build`, `go vet`, `gofmt -l` clean
- `go test ./internal/...` — all 10 packages pass
- New `internal/cmd/pagination_test.go` covers all three semantics, the deprecated alias still winning when passed, the alias being hidden-but-parseable, and the pagination convention

## Follow-up

The three-way meaning of `only_active` is really an API-side modelling issue — distinct parameters (or per-resource names) would let clients stop guessing. This PR makes the CLI correct and legible regardless of which default the API applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
