### PR TITLE
fix: remove Firefox from the supported browser types

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Notte CLI brings the full power of [notte.cc](https://notte.cc?ref=github) t
 ## Features
 
 - **AI agents** - run and monitor AI-powered browser functions
-- **Browser sessions** - headless or headed Chrome/Firefox with full control
+- **Browser sessions** - headless or headed Chromium/Chrome with full control
 - **Files** - upload and download files to notte.cc
 - **Output formats** - human-readable text or JSON for scripting
 - **Personas** - create and manage digital identities with email, phone, and SMS
@@ -118,7 +118,7 @@ notte sessions code                   # Get Python script for session steps
 
 ```bash
 notte sessions start \
-  --browser-type chromium|chrome|firefox  # Browser type (default: chromium)
+  --browser-type chromium|chrome  # Browser type (default: chromium)
   --headless                              # Run in headless mode (default: true)
   --idle-timeout-minutes <minutes>        # Idle timeout (closes after inactivity)
   --max-duration-minutes <minutes>        # Maximum session lifetime

--- a/internal/cmd/sessions_test.go
+++ b/internal/cmd/sessions_test.go
@@ -130,7 +130,7 @@ func TestRunSessionsStart(t *testing.T) {
 	})
 
 	SessionStartHeadless = false
-	SessionStartBrowserType = "firefox"
+	SessionStartBrowserType = "chrome"
 	SessionStartIdleTimeoutMinutes = 5
 	sessionsStartProxy = true
 	SessionStartSolveCaptchas = true

--- a/internal/cmd/validation_test.go
+++ b/internal/cmd/validation_test.go
@@ -65,8 +65,11 @@ func TestValidateBrowser(t *testing.T) {
 		wantErr bool
 	}{
 		{"chromium", "chromium", false},
-		{"firefox", "firefox", false},
-		{"webkit", "webkit", false},
+		{"chrome", "chrome", false},
+		{"chrome-nightly", "chrome-nightly", false},
+		{"chrome-turbo", "chrome-turbo", false},
+		{"firefox", "firefox", true},
+		{"webkit", "webkit", true},
 		{"invalid", "safari", true},
 		{"empty", "", true},
 	}

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -37,11 +37,11 @@ func TestAPIError_Unwrap(t *testing.T) {
 func TestValidationError_Error(t *testing.T) {
 	err := &ValidationError{
 		Field:   "browser",
-		Message: "expected chromium|firefox|webkit, got 'chrome'",
+		Message: "expected chromium|chrome, got 'firefox'",
 	}
 
 	got := err.Error()
-	want := "validation error: browser: expected chromium|firefox|webkit, got 'chrome'"
+	want := "validation error: browser: expected chromium|chrome, got 'firefox'"
 
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -45,16 +45,23 @@ func JSON(s string) error {
 	return nil
 }
 
-// Browser validates browser type
+// Browser validates browser type.
+//
+// Notte runs Chromium-family browsers only. Firefox and WebKit are not
+// supported - the API rejects a Firefox session with "Firefox sessions are not
+// supported. Please use 'chromium' or 'chrome' as `browser_type`" - and
+// `chrome` is valid despite an earlier version of this list omitting it.
+// chrome-nightly and chrome-turbo are accepted as legacy aliases for chrome.
 func Browser(s string) error {
 	valid := map[string]bool{
-		"chromium": true,
-		"firefox":  true,
-		"webkit":   true,
+		"chromium":       true,
+		"chrome":         true,
+		"chrome-nightly": true,
+		"chrome-turbo":   true,
 	}
 
 	if !valid[s] {
-		return fmt.Errorf("invalid browser: expected chromium|firefox|webkit, got %q", s)
+		return fmt.Errorf("invalid browser: expected chromium|chrome, got %q", s)
 	}
 
 	return nil

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -59,10 +59,12 @@ func TestBrowser(t *testing.T) {
 		wantErr bool
 	}{
 		{"chromium", false},
-		{"firefox", false},
-		{"webkit", false},
-		{"chrome", true}, // Not valid - should be chromium
-		{"safari", true}, // Not valid - should be webkit
+		{"chrome", false},
+		{"chrome-nightly", false}, // legacy alias for chrome
+		{"chrome-turbo", false},   // legacy alias for chrome
+		{"firefox", true},         // the API rejects Firefox sessions outright
+		{"webkit", true},          // never supported
+		{"safari", true},
 		{"", true},
 	}
 

--- a/scripts/gen-flags/types.go
+++ b/scripts/gen-flags/types.go
@@ -62,7 +62,7 @@ var FlattenWithoutPrefix = map[string]map[string]bool{
 // whose OpenAPI metadata is currently flattened away before flag generation.
 var FieldDescriptionOverrides = map[string]map[string]string{
 	"SessionStart": {
-		"browser_type": "The browser type to use. Can be chromium, chrome or firefox.",
+		"browser_type": "The browser type to use. Supported values are chromium and chrome.",
 	},
 }
 

--- a/tests/integration/errors_test.go
+++ b/tests/integration/errors_test.go
@@ -142,7 +142,7 @@ func TestErrorParsing_ValidationErrorContainsDetails(t *testing.T) {
 	stderr := result.Stderr
 
 	// Check that error mentions at least one valid browser type
-	validBrowsers := []string{"chromium", "chrome", "firefox"}
+	validBrowsers := []string{"chromium", "chrome"}
 	foundValidBrowser := false
 	for _, browser := range validBrowsers {
 		if containsString(stderr, browser) {


### PR DESCRIPTION
Notte runs Chromium-family browsers only. Starting a session with `--browser-type firefox` is rejected by the API:

```
Value error, Firefox sessions are not supported.
Please use 'chromium' or 'chrome' as `browser_type`.
```

The CLI still advertised it in several places.

## Changes

| Where | Was | Now |
|---|---|---|
| `README.md` feature list | "headless or headed **Chrome/Firefox**" | "headless or headed Chromium/Chrome" |
| `README.md` flag line | `--browser-type chromium\|chrome\|firefox` | `--browser-type chromium\|chrome` |
| `scripts/gen-flags/types.go` | "Can be chromium, chrome or **firefox**." | "Supported values are chromium and chrome." |
| `internal/validate/validate.go` | accepts `chromium\|firefox\|webkit` | accepts `chromium\|chrome` + legacy aliases |

The gen-flags override had drifted: the generated flag help already reads *"Supported values are chromium and chrome. chrome-nightly and chrome-turbo are legacy aliases for chrome"*, but the override source it is generated from still mentioned Firefox, so it would come back the next time that override applies.

## `validate.Browser` was wrong in both directions

```go
valid := map[string]bool{
    "chromium": true,
    "firefox":  true,   // rejected by the API
    "webkit":   true,   // never supported
}
// ...and "chrome", which IS valid, was rejected
```

That's Playwright's browser set, not Notte's. It now accepts `chromium` and `chrome` plus the `chrome-nightly` / `chrome-turbo` legacy aliases, and the error message names the real options.

## Two things deliberately left alone

**`validate.Browser` is dead code.** `ValidateBrowser` is referenced only by its own unit test — never wired to `--browser-type`, which is why an invalid value reaches the API today rather than failing locally. Wiring it up would give a cleaner client-side error and save a round trip, but it changes behaviour and would stop `TestErrorParsing_InvalidBrowserType` / `TestErrorParsing_ValidationErrorContainsDetails` exercising the API error path, since they use an invalid browser type as their trigger. Happy to do it in a follow-up if you want it — it needs those tests re-pointed at a different invalid input.

**`internal/api/client.gen.go` still has `SessionResponseBrowserTypeFirefox`.** It is generated from the OpenAPI spec and untouched here. Removing it means dropping `firefox` from the spec's `browser_type` Literal — worth doing, since the API currently accepts it through the Literal only to reject it in a second validator, which is what produces the slightly confusing two-layer error above.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test ./internal/...` — all 10 packages pass
- Unit tests updated to assert Firefox and WebKit are now *rejected* and that `chrome` and its aliases are accepted
- `tests/integration/errors_test.go` no longer lists `firefox` among the browser names it expects to see in a validation error

Verified against prod that `--browser-type firefox` is rejected end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)