### PR TITLE
Add --headed, --no-solve-captchas and --no-file-storage

### DIFF
--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -341,6 +341,8 @@ func init() {
 
 	// Start command flags (auto-generated + manual proxy)
 	RegisterSessionStartFlags(sessionsStartCmd)
+	// Positive opt-outs for options that default to true server-side
+	registerSessionStartOptOutFlags(sessionsStartCmd)
 	// Manual flags for proxies (union type: bool | array of proxy objects)
 	sessionsStartCmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "Use default proxies")
 	sessionsStartCmd.Flags().StringVar(&sessionsStartProxyCountry, "proxy-country", "", "Proxy country code (e.g. us, gb, fr). Implies --proxy")
@@ -498,6 +500,10 @@ func runSessionsStart(cmd *cobra.Command, args []string) error {
 	// Build request body from generated flags
 	body, err := BuildSessionStartRequest(cmd)
 	if err != nil {
+		return err
+	}
+
+	if err := applySessionStartOptOuts(cmd, body); err != nil {
 		return err
 	}
 

--- a/internal/cmd/sessions.go
+++ b/internal/cmd/sessions.go
@@ -192,9 +192,12 @@ var sessionsListCmd = &cobra.Command{
 }
 
 var sessionsStartCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start a new browser session",
-	RunE:  runSessionsStart,
+	Use: "start",
+	// Flag conflicts must be caught before RunE, which stops the current
+	// session before it builds the request.
+	PreRunE: validateSessionStartFlags,
+	Short:   "Start a new browser session",
+	RunE:    runSessionsStart,
 }
 
 var sessionsStatusCmd = &cobra.Command{
@@ -509,14 +512,10 @@ func runSessionsStart(cmd *cobra.Command, args []string) error {
 
 	// Handle proxies manually (union type: bool | array of proxy objects).
 	// At most one proxy kind may be selected per call.
-	var setProxyFlags []string
-	for _, name := range []string{"proxy", "proxy-country", "proxy-external-server", "proxy-tailnet-client-id"} {
-		if cmd.Flags().Changed(name) {
-			setProxyFlags = append(setProxyFlags, "--"+name)
-		}
-	}
-	if len(setProxyFlags) > 1 {
-		return fmt.Errorf("proxy flags are mutually exclusive, got: %s", strings.Join(setProxyFlags, ", "))
+	// Already checked in PreRunE; repeated so the invariant does not depend on
+	// the command wiring.
+	if err := validateSessionStartProxyFlags(cmd); err != nil {
+		return err
 	}
 
 	var proxyItems api.ApiSessionStartRequestProxies0

--- a/internal/cmd/sessionstart_optout.go
+++ b/internal/cmd/sessionstart_optout.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nottelabs/notte-cli/internal/api"
+)
+
+// Several session-start options default to true server-side, which left their
+// flags shaped as opt-ins for something already on. Passing --headless or
+// --solve-captchas changed nothing, and turning either off required the double
+// negative `--headless=false`. Each now has a positive way to opt out.
+//
+// Naming follows one rule: use the term the ecosystem already has, otherwise
+// prefix with --no-. Playwright exposes a visible browser as --headed, and
+// users arrive from Playwright and Puppeteer, so that is the word they will
+// guess. There is no comparable word for the other two, so they take the --no-
+// prefix used by git, docker, npm and curl.
+//
+// --no- rather than --disable- specifically because Chromium's own flags are
+// --disable-* (--disable-gpu, --disable-extensions) and this command forwards
+// them verbatim through --chrome-args. Keeping the prefixes distinct means
+// `--no-file-storage --chrome-args="--disable-gpu"` reads unambiguously as one
+// Notte flag and one browser flag.
+var (
+	sessionsStartHeaded          bool
+	sessionsStartNoSolveCaptchas bool
+	sessionsStartNoFileStorage   bool
+)
+
+// sessionStartOptOut pairs a new negative flag with the generated flag it
+// supersedes. The original stays registered and undeprecated: pinning a value
+// explicitly is legitimate defensive scripting, since a caller who needs a
+// headless session should not have to trust that the server default stays
+// true. Only passing both at once is an error.
+type sessionStartOptOut struct {
+	negative string
+	original string
+	set      *bool
+	apply    func(body *api.ApiSessionStartRequest, enabled bool)
+}
+
+func sessionStartOptOuts() []sessionStartOptOut {
+	return []sessionStartOptOut{
+		{
+			negative: "headed",
+			original: "headless",
+			set:      &sessionsStartHeaded,
+			apply:    func(b *api.ApiSessionStartRequest, enabled bool) { b.Headless = &enabled },
+		},
+		{
+			negative: "no-solve-captchas",
+			original: "solve-captchas",
+			set:      &sessionsStartNoSolveCaptchas,
+			apply:    func(b *api.ApiSessionStartRequest, enabled bool) { b.SolveCaptchas = &enabled },
+		},
+		{
+			negative: "no-file-storage",
+			original: "use-file-storage",
+			set:      &sessionsStartNoFileStorage,
+			apply:    func(b *api.ApiSessionStartRequest, enabled bool) { b.UseFileStorage = &enabled },
+		},
+	}
+}
+
+// registerSessionStartOptOutFlags adds the negative flags alongside the
+// generated ones.
+func registerSessionStartOptOutFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&sessionsStartHeaded, "headed", false,
+		"Run with a visible browser window instead of headless")
+	cmd.Flags().BoolVar(&sessionsStartNoSolveCaptchas, "no-solve-captchas", false,
+		"Do not attempt to solve captchas automatically")
+	cmd.Flags().BoolVar(&sessionsStartNoFileStorage, "no-file-storage", false,
+		"Do not attach FileStorage. Disables `notte page download` and `notte files --from session`")
+}
+
+// applySessionStartOptOuts folds the negative flags into an already-built
+// request body. Each one inverts its counterpart, so --headed sends
+// headless=false and --headed=false sends headless=true.
+func applySessionStartOptOuts(cmd *cobra.Command, body *api.ApiSessionStartRequest) error {
+	for _, o := range sessionStartOptOuts() {
+		if cmd.Flags().Changed(o.negative) && cmd.Flags().Changed(o.original) {
+			return fmt.Errorf(
+				"--%s and --%s set the same option; pass only one", o.negative, o.original)
+		}
+	}
+
+	for _, o := range sessionStartOptOuts() {
+		if cmd.Flags().Changed(o.negative) {
+			o.apply(body, !*o.set)
+		}
+	}
+	return nil
+}

--- a/internal/cmd/sessionstart_optout.go
+++ b/internal/cmd/sessionstart_optout.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -76,15 +77,30 @@ func registerSessionStartOptOutFlags(cmd *cobra.Command) {
 		"Do not attach FileStorage. Disables `notte page download` and `notte files --from session`")
 }
 
-// applySessionStartOptOuts folds the negative flags into an already-built
-// request body. Each one inverts its counterpart, so --headed sends
-// headless=false and --headed=false sends headless=true.
-func applySessionStartOptOuts(cmd *cobra.Command, body *api.ApiSessionStartRequest) error {
+// validateSessionStartOptOuts rejects a pair whose two spellings were both
+// supplied. It is deliberately separate from applying the values: `sessions
+// start` stops and clears any current session before it builds the request, so
+// validation that runs at build time would take the old session away and then
+// refuse to start a new one. This runs from PreRunE, ahead of any side effect.
+func validateSessionStartOptOuts(cmd *cobra.Command) error {
 	for _, o := range sessionStartOptOuts() {
 		if cmd.Flags().Changed(o.negative) && cmd.Flags().Changed(o.original) {
 			return fmt.Errorf(
 				"--%s and --%s set the same option; pass only one", o.negative, o.original)
 		}
+	}
+	return nil
+}
+
+// applySessionStartOptOuts folds the negative flags into an already-built
+// request body. Each one inverts its counterpart, so --headed sends
+// headless=false and --headed=false sends headless=true.
+//
+// Revalidates so the invariant holds even if a caller reaches this without
+// going through PreRunE.
+func applySessionStartOptOuts(cmd *cobra.Command, body *api.ApiSessionStartRequest) error {
+	if err := validateSessionStartOptOuts(cmd); err != nil {
+		return err
 	}
 
 	for _, o := range sessionStartOptOuts() {
@@ -93,4 +109,29 @@ func applySessionStartOptOuts(cmd *cobra.Command, body *api.ApiSessionStartReque
 		}
 	}
 	return nil
+}
+
+// validateSessionStartProxyFlags reports more than one proxy kind being
+// selected. Same reasoning as above: this used to run after the current session
+// had already been stopped.
+func validateSessionStartProxyFlags(cmd *cobra.Command) error {
+	var set []string
+	for _, name := range []string{"proxy", "proxy-country", "proxy-external-server", "proxy-tailnet-client-id"} {
+		if cmd.Flags().Changed(name) {
+			set = append(set, "--"+name)
+		}
+	}
+	if len(set) > 1 {
+		return fmt.Errorf("proxy flags are mutually exclusive, got: %s", strings.Join(set, ", "))
+	}
+	return nil
+}
+
+// validateSessionStartFlags runs every flag-consistency check that must happen
+// before `sessions start` touches anything.
+func validateSessionStartFlags(cmd *cobra.Command, _ []string) error {
+	if err := validateSessionStartOptOuts(cmd); err != nil {
+		return err
+	}
+	return validateSessionStartProxyFlags(cmd)
 }

--- a/internal/cmd/sessionstart_optout_test.go
+++ b/internal/cmd/sessionstart_optout_test.go
@@ -56,19 +56,40 @@ func TestOptOutsLeaveBodyUntouchedWhenAbsent(t *testing.T) {
 
 func TestOptOutsInvertTheirCounterpart(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
-		want func(*api.ApiSessionStartRequest) (string, *bool)
-		val  bool
+		name  string
+		args  []string
+		field string
+		get   func(*api.ApiSessionStartRequest) *bool
+		want  bool
 	}{
-		{"--headed sends headless=false", []string{"--headed"},
-			func(b *api.ApiSessionStartRequest) (string, *bool) { return "Headless", b.Headless }, false},
-		{"--headed=false sends headless=true", []string{"--headed=false"},
-			func(b *api.ApiSessionStartRequest) (string, *bool) { return "Headless", b.Headless }, true},
-		{"--no-solve-captchas sends solve_captchas=false", []string{"--no-solve-captchas"},
-			func(b *api.ApiSessionStartRequest) (string, *bool) { return "SolveCaptchas", b.SolveCaptchas }, false},
-		{"--no-file-storage sends use_file_storage=false", []string{"--no-file-storage"},
-			func(b *api.ApiSessionStartRequest) (string, *bool) { return "UseFileStorage", b.UseFileStorage }, false},
+		{
+			name:  "--headed sends headless=false",
+			args:  []string{"--headed"},
+			field: "Headless",
+			get:   func(b *api.ApiSessionStartRequest) *bool { return b.Headless },
+			want:  false,
+		},
+		{
+			name:  "--headed=false sends headless=true",
+			args:  []string{"--headed=false"},
+			field: "Headless",
+			get:   func(b *api.ApiSessionStartRequest) *bool { return b.Headless },
+			want:  true,
+		},
+		{
+			name:  "--no-solve-captchas sends solve_captchas=false",
+			args:  []string{"--no-solve-captchas"},
+			field: "SolveCaptchas",
+			get:   func(b *api.ApiSessionStartRequest) *bool { return b.SolveCaptchas },
+			want:  false,
+		},
+		{
+			name:  "--no-file-storage sends use_file_storage=false",
+			args:  []string{"--no-file-storage"},
+			field: "UseFileStorage",
+			get:   func(b *api.ApiSessionStartRequest) *bool { return b.UseFileStorage },
+			want:  false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -77,12 +98,12 @@ func TestOptOutsInvertTheirCounterpart(t *testing.T) {
 			if err != nil {
 				t.Fatalf("applySessionStartOptOuts() error = %v", err)
 			}
-			field, got := tc.want(body)
+			got := tc.get(body)
 			if got == nil {
-				t.Fatalf("%s is nil, want %v", field, tc.val)
+				t.Fatalf("%s is nil, want %v", tc.field, tc.want)
 			}
-			if *got != tc.val {
-				t.Errorf("%s = %v, want %v", field, *got, tc.val)
+			if *got != tc.want {
+				t.Errorf("%s = %v, want %v", tc.field, *got, tc.want)
 			}
 		})
 	}
@@ -121,6 +142,46 @@ func TestOriginalFlagsStillWorkAlone(t *testing.T) {
 		}
 		if f.Hidden {
 			t.Errorf("--%s should stay visible in help", name)
+		}
+	}
+}
+
+// TestConflictsRejectedBeforeSideEffects pins the ordering, not just the error.
+// runSessionsStart stops and clears the current session before it builds the
+// request, so a conflict detected at build time would cost the user their
+// existing session and give them nothing back. Validation therefore has to hang
+// off PreRunE, which cobra runs before RunE.
+func TestConflictsRejectedBeforeSideEffects(t *testing.T) {
+	if sessionsStartCmd.PreRunE == nil {
+		t.Fatal("sessions start must validate flags in PreRunE; validating inside RunE " +
+			"runs after the current session has already been stopped")
+	}
+
+	ranRunE := false
+	cmd := &cobra.Command{
+		Use:     "start",
+		PreRunE: validateSessionStartFlags,
+		RunE: func(*cobra.Command, []string) error {
+			ranRunE = true
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", false, "headless")
+	cmd.Flags().Bool("proxy", false, "proxy")
+	cmd.Flags().String("proxy-country", "", "proxy country")
+	registerSessionStartOptOutFlags(cmd)
+
+	for _, args := range [][]string{
+		{"--headed", "--headless"},
+		{"--proxy", "--proxy-country=us"},
+	} {
+		ranRunE = false
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err == nil {
+			t.Errorf("%v: expected PreRunE to reject the combination", args)
+		}
+		if ranRunE {
+			t.Errorf("%v: RunE ran despite invalid flags - the session would already be gone", args)
 		}
 	}
 }

--- a/internal/cmd/sessionstart_optout_test.go
+++ b/internal/cmd/sessionstart_optout_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nottelabs/notte-cli/internal/api"
+)
+
+// newOptOutCmd builds a command carrying both the generated flags these
+// opt-outs invert and the opt-outs themselves.
+func newOptOutCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "start", RunE: func(*cobra.Command, []string) error { return nil }}
+	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", false, "headless")
+	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "solve captchas")
+	cmd.Flags().BoolVar(&SessionStartUseFileStorage, "use-file-storage", false, "file storage")
+	registerSessionStartOptOutFlags(cmd)
+	return cmd
+}
+
+func runOptOut(t *testing.T, args ...string) (*api.ApiSessionStartRequest, error) {
+	t.Helper()
+	// Package-level flag vars are shared; reset before each case.
+	sessionsStartHeaded = false
+	sessionsStartNoSolveCaptchas = false
+	sessionsStartNoFileStorage = false
+
+	cmd := newOptOutCmd()
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute(%v) error = %v", args, err)
+	}
+	body := &api.ApiSessionStartRequest{}
+	return body, applySessionStartOptOuts(cmd, body)
+}
+
+// TestOptOutsLeaveBodyUntouchedWhenAbsent is the important one: omitting the
+// flags must send nothing at all, so the server default applies. Sending an
+// explicit value would freeze today's default into the client.
+func TestOptOutsLeaveBodyUntouchedWhenAbsent(t *testing.T) {
+	body, err := runOptOut(t)
+	if err != nil {
+		t.Fatalf("applySessionStartOptOuts() error = %v", err)
+	}
+	if body.Headless != nil {
+		t.Errorf("Headless = %v, want nil (unset) when --headed is omitted", *body.Headless)
+	}
+	if body.SolveCaptchas != nil {
+		t.Errorf("SolveCaptchas = %v, want nil when --no-solve-captchas is omitted", *body.SolveCaptchas)
+	}
+	if body.UseFileStorage != nil {
+		t.Errorf("UseFileStorage = %v, want nil when --no-file-storage is omitted", *body.UseFileStorage)
+	}
+}
+
+func TestOptOutsInvertTheirCounterpart(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want func(*api.ApiSessionStartRequest) (string, *bool)
+		val  bool
+	}{
+		{"--headed sends headless=false", []string{"--headed"},
+			func(b *api.ApiSessionStartRequest) (string, *bool) { return "Headless", b.Headless }, false},
+		{"--headed=false sends headless=true", []string{"--headed=false"},
+			func(b *api.ApiSessionStartRequest) (string, *bool) { return "Headless", b.Headless }, true},
+		{"--no-solve-captchas sends solve_captchas=false", []string{"--no-solve-captchas"},
+			func(b *api.ApiSessionStartRequest) (string, *bool) { return "SolveCaptchas", b.SolveCaptchas }, false},
+		{"--no-file-storage sends use_file_storage=false", []string{"--no-file-storage"},
+			func(b *api.ApiSessionStartRequest) (string, *bool) { return "UseFileStorage", b.UseFileStorage }, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := runOptOut(t, tc.args...)
+			if err != nil {
+				t.Fatalf("applySessionStartOptOuts() error = %v", err)
+			}
+			field, got := tc.want(body)
+			if got == nil {
+				t.Fatalf("%s is nil, want %v", field, tc.val)
+			}
+			if *got != tc.val {
+				t.Errorf("%s = %v, want %v", field, *got, tc.val)
+			}
+		})
+	}
+}
+
+// TestConflictingPairIsRejected keeps the two spellings from silently
+// disagreeing - without this, precedence would decide and the loser would be
+// invisible.
+func TestConflictingPairIsRejected(t *testing.T) {
+	for _, args := range [][]string{
+		{"--headed", "--headless"},
+		{"--headed", "--headless=false"},
+		{"--no-solve-captchas", "--solve-captchas"},
+		{"--no-file-storage", "--use-file-storage"},
+	} {
+		_, err := runOptOut(t, args...)
+		if err == nil {
+			t.Errorf("%v: expected an error for a conflicting pair, got nil", args)
+		}
+	}
+}
+
+// TestOriginalFlagsStillWorkAlone confirms the originals were not deprecated
+// away: pinning a value explicitly stays valid, which is what a caller does
+// when they cannot rely on the server default.
+func TestOriginalFlagsStillWorkAlone(t *testing.T) {
+	cmd := newOptOutCmd()
+	for _, name := range []string{"headless", "solve-captchas", "use-file-storage"} {
+		f := cmd.Flags().Lookup(name)
+		if f == nil {
+			t.Errorf("--%s should still be registered", name)
+			continue
+		}
+		if f.Deprecated != "" {
+			t.Errorf("--%s should not be deprecated: pinning a value explicitly is valid", name)
+		}
+		if f.Hidden {
+			t.Errorf("--%s should stay visible in help", name)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #60. That PR made the true defaults *visible*; this makes them *actionable*.

Three session-start options default to `true` server-side, which left their flags shaped as opt-ins for something already on. Passing `--headless` or `--solve-captchas` changed nothing, and turning either off meant a double negative.

```bash
notte sessions start --headed              # was --headless=false
notte sessions start --no-solve-captchas   # was --solve-captchas=false
notte sessions start --no-file-storage     # was --use-file-storage=false
```

## Naming

One rule: **use the word the ecosystem already has, otherwise prefix with `--no-`.**

`--headed` is Playwright's (`playwright test --headed`), and Notte's users mostly arrive from Playwright or Puppeteer, so it's the one they'll guess. The other two have no comparable term.

`--no-` rather than `--disable-` for a reason specific to this command: **Chromium's own flags are `--disable-*`**, and `sessions start` forwards them verbatim through `--chrome-args`. Distinct prefixes keep the layers legible —

```bash
notte sessions start --no-file-storage --chrome-args="--disable-gpu"
```

— one Notte flag, one browser flag, no ambiguity about which is which. `--no-` is also what git, docker, npm and curl use.

## The originals are deliberately *not* deprecated

Pinning a value explicitly is legitimate defensive scripting. A caller who *needs* a headless session shouldn't have to trust that the server default stays `true` — that's precisely the failure mode #58 and #60 dealt with. Deprecating would also print a warning on the single most common invocation in our own docs (`sessions start --headless` appears eight times across the skills).

Passing both spellings at once is an **error** rather than letting precedence quietly pick a winner:

```
$ notte sessions start --headed --headless
Error: --headed and --headless set the same option; pass only one
```

## Omitting them still sends nothing

The most important property, and the one with a dedicated test: when the new flags are absent, nothing is written to the request body, so the **server default applies**. Sending an explicit value would re-freeze today's default into the client — the bug #58 fixed.

## Verification

Against the live API:

| Command | Result |
|---|---|
| `--headed` | `headless: false` |
| `--no-file-storage` | `use_file_storage: false` |
| `--no-solve-captchas` | `solve_captchas: false` |
| *(no flags)* | all three `true` — unchanged |
| `--headed --headless` | rejected |

- New `sessionstart_optout_test.go`: absent flags leave the body untouched, each flag inverts its counterpart (including `--headed=false` → `headless=true`), conflicting pairs are rejected, and the originals stay registered, visible and undeprecated
- `go build`, `go vet`, `gofmt -l` clean; `go test ./internal/...` — all 10 packages pass
- New flags live in `sessionstart_optout.go`, not the generated file, so `make generate` won't clobber them

## Follow-up

`notte-skills` documents `--headless=false` and claims it's *"not available on remote/CI environments"* — but a cloud session accepts it and reports `headless: false`, so that claim looks wrong. I'll update the skills to use `--headed` and fix that claim once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)