### PR TITLE
[NOT-787] Default session replacement prompt to no

### DIFF
--- a/internal/cmd/confirm.go
+++ b/internal/cmd/confirm.go
@@ -38,7 +38,7 @@ func ConfirmActionWithIO(in io.Reader, out io.Writer, resource, id string) (bool
 }
 
 // confirmReplaceSession prompts the user to confirm stopping an existing session before starting a new one.
-// Defaults to "yes" if user just presses Enter.
+// Defaults to "no" if user just presses Enter or stdin reaches EOF.
 func confirmReplaceSession(id string) (bool, error) {
 	if skipConfirmation {
 		return true, nil
@@ -48,7 +48,7 @@ func confirmReplaceSession(id string) (bool, error) {
 
 // confirmReplaceSessionWithIO is the testable version of confirmReplaceSession.
 func confirmReplaceSessionWithIO(in io.Reader, out io.Writer, id string) (bool, error) {
-	if _, err := fmt.Fprintf(out, "Session %s is currently active. A new session will be created either way.\nStop the existing session before starting the new one? [Y/n]: ", id); err != nil {
+	if _, err := fmt.Fprintf(out, "Session %s is currently active. A new session will be created either way.\nStop the existing session before starting the new one? [y/N]: ", id); err != nil {
 		return false, fmt.Errorf("failed to write prompt: %w", err)
 	}
 
@@ -59,7 +59,7 @@ func confirmReplaceSessionWithIO(in io.Reader, out io.Writer, id string) (bool, 
 	}
 
 	response = strings.TrimSpace(strings.ToLower(response))
-	return response != "n" && response != "no", nil
+	return response == "y" || response == "yes", nil
 }
 
 // SetSkipConfirmation sets whether to skip confirmation prompts (for --yes flag).

--- a/internal/cmd/confirm_test.go
+++ b/internal/cmd/confirm_test.go
@@ -83,11 +83,13 @@ func TestConfirmReplaceSessionWithIO_YesNo(t *testing.T) {
 		{"y\n", true},
 		{"yes\n", true},
 		{"Y\n", true},
-		{"\n", true}, // default is yes
+		{"\n", false}, // default is no
+		{"", false},   // non-interactive EOF is also no
 		{"n\n", false},
 		{"no\n", false},
 		{"N\n", false},
 		{"NO\n", false},
+		{"maybe\n", false},
 	}
 
 	for _, tt := range tests {
@@ -107,8 +109,8 @@ func TestConfirmReplaceSessionWithIO_YesNo(t *testing.T) {
 	if !strings.Contains(out.String(), "sess_abc") {
 		t.Errorf("expected prompt to contain session ID, got %q", out.String())
 	}
-	if !strings.Contains(out.String(), "[Y/n]") {
-		t.Errorf("expected prompt to contain [Y/n], got %q", out.String())
+	if !strings.Contains(out.String(), "[y/N]") {
+		t.Errorf("expected prompt to contain [y/N], got %q", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- default the existing-session replacement prompt to no
- preserve the existing session on Enter, invalid input, or non-interactive EOF
- continue allowing explicit y/yes and --yes to stop the existing session
- cover safe defaults and EOF behavior in tests

## Testing

- go test ./internal/cmd -count=1

Linear: NOT-787 https://linear.app/nottelabsinc/issue/NOT-787/notte-cli-pr-65-default-session-replacement-prompt-to-no