### PR TITLE
Support lightweight function run list responses

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -73,6 +73,13 @@ const (
 	Success DeleteVaultResponseStatus = "success"
 )
 
+// Defines values for FunctionRunListItemResponseStatus.
+const (
+	FunctionRunListItemResponseStatusActive FunctionRunListItemResponseStatus = "active"
+	FunctionRunListItemResponseStatusClosed FunctionRunListItemResponseStatus = "closed"
+	FunctionRunListItemResponseStatusFailed FunctionRunListItemResponseStatus = "failed"
+)
+
 // Defines values for FunctionRunUpdateRequestStatus.
 const (
 	FunctionRunUpdateRequestStatusActive FunctionRunUpdateRequestStatus = "active"
@@ -1346,6 +1353,26 @@ type FunctionResponse struct {
 	WorkflowId *string  `json:"workflow_id,omitempty"`
 }
 
+// FunctionRunListItemResponse defines model for FunctionRunListItemResponse.
+type FunctionRunListItemResponse struct {
+	CreatedAt FlexibleTime `json:"created_at"`
+
+	// FunctionId The ID of the function
+	FunctionId string `json:"function_id"`
+
+	// FunctionRunId The ID of the function run
+	FunctionRunId string                            `json:"function_run_id"`
+	Local         *bool                             `json:"local,omitempty"`
+	SessionId     *string                           `json:"session_id,omitempty"`
+	Status        FunctionRunListItemResponseStatus `json:"status"`
+	UpdatedAt     FlexibleTime                      `json:"updated_at"`
+	WorkflowId    *string                           `json:"workflow_id,omitempty"`
+	WorkflowRunId *string                           `json:"workflow_run_id,omitempty"`
+}
+
+// FunctionRunListItemResponseStatus defines model for FunctionRunListItemResponse.Status.
+type FunctionRunListItemResponseStatus string
+
 // FunctionRunUpdateRequest defines model for FunctionRunUpdateRequest.
 type FunctionRunUpdateRequest struct {
 	// Logs The logs of the workflow run
@@ -1907,13 +1934,13 @@ type PaginatedResponseFunctionResponse struct {
 	PageSize    int                `json:"page_size"`
 }
 
-// PaginatedResponseGetFunctionRunResponse defines model for PaginatedResponse_GetFunctionRunResponse_.
-type PaginatedResponseGetFunctionRunResponse struct {
-	HasNext     bool                     `json:"has_next"`
-	HasPrevious *bool                    `json:"has_previous,omitempty"`
-	Items       []GetFunctionRunResponse `json:"items"`
-	Page        int                      `json:"page"`
-	PageSize    int                      `json:"page_size"`
+// PaginatedResponseFunctionRunListItemResponse defines model for PaginatedResponse_FunctionRunListItemResponse_.
+type PaginatedResponseFunctionRunListItemResponse struct {
+	HasNext     bool                          `json:"has_next"`
+	HasPrevious *bool                         `json:"has_previous,omitempty"`
+	Items       []FunctionRunListItemResponse `json:"items"`
+	Page        int                           `json:"page"`
+	PageSize    int                           `json:"page_size"`
 }
 
 // PaginatedResponsePersonaResponse defines model for PaginatedResponse_PersonaResponse_.
@@ -16698,7 +16725,7 @@ func (r FunctionForkResult) StatusCode() int {
 type ListFunctionRunsByFunctionIdResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *PaginatedResponseGetFunctionRunResponse
+	JSON200      *PaginatedResponseFunctionRunListItemResponse
 	JSON422      *HTTPValidationError
 }
 
@@ -19476,7 +19503,7 @@ func ParseListFunctionRunsByFunctionIdResult(rsp *http.Response) (*ListFunctionR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest PaginatedResponseGetFunctionRunResponse
+		var dest PaginatedResponseFunctionRunListItemResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -389,10 +389,10 @@ const (
 
 // Defines values for SessionResponseStatus.
 const (
-	SessionResponseStatusActive   SessionResponseStatus = "active"
-	SessionResponseStatusClosed   SessionResponseStatus = "closed"
-	SessionResponseStatusError    SessionResponseStatus = "error"
-	SessionResponseStatusTimedOut SessionResponseStatus = "timed_out"
+	Active   SessionResponseStatus = "active"
+	Closed   SessionResponseStatus = "closed"
+	Error    SessionResponseStatus = "error"
+	TimedOut SessionResponseStatus = "timed_out"
 )
 
 // Defines values for SpaceCategory.
@@ -1365,7 +1365,7 @@ type FunctionRunListItemResponse struct {
 	Local         *bool                             `json:"local,omitempty"`
 	SessionId     *string                           `json:"session_id,omitempty"`
 	Status        FunctionRunListItemResponseStatus `json:"status"`
-	UpdatedAt     FlexibleTime                      `json:"updated_at"`
+	UpdatedAt     time.Time                         `json:"updated_at"`
 	WorkflowId    *string                           `json:"workflow_id,omitempty"`
 	WorkflowRunId *string                           `json:"workflow_run_id,omitempty"`
 }

--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -678,7 +678,7 @@ func runFunctionRuns(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var items []api.GetFunctionRunResponse
+	var items []api.FunctionRunListItemResponse
 	if resp.JSON200 != nil {
 		items = resp.JSON200.Items
 	}

--- a/internal/cmd/functions_test.go
+++ b/internal/cmd/functions_test.go
@@ -459,7 +459,7 @@ func TestRunFunctionRun(t *testing.T) {
 
 func TestRunFunctionRuns(t *testing.T) {
 	server := setupFunctionTest(t)
-	server.AddResponse("/functions/"+functionIDTest+"/runs", 200, `{"items":[`+functionRunJSON()+`]}`)
+	server.AddResponse("/functions/"+functionIDTest+"/runs", 200, `{"items":[`+functionRunJSON()+`],"page":1,"page_size":10,"has_next":false}`)
 
 	origFormat := outputFormat
 	outputFormat = "json"
@@ -475,8 +475,20 @@ func TestRunFunctionRuns(t *testing.T) {
 		}
 	})
 
-	if stdout == "" {
-		t.Error("expected output, got empty string")
+	var runs []map[string]any
+	if err := json.Unmarshal([]byte(stdout), &runs); err != nil {
+		t.Fatalf("expected JSON run list, got %q: %v", stdout, err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("expected one run, got %d", len(runs))
+	}
+	if runs[0]["function_run_id"] != functionRunIDTest {
+		t.Errorf("expected lightweight run ID %q, got %#v", functionRunIDTest, runs[0]["function_run_id"])
+	}
+	for _, detailField := range []string{"logs", "variables", "result"} {
+		if _, exists := runs[0][detailField]; exists {
+			t.Errorf("lightweight run unexpectedly contains %q", detailField)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- regenerate the Go API client from the updated staging OpenAPI schema
- use the new `FunctionRunListItemResponse` model for function run listings
- preserve the full `GetFunctionRunResponse` model for single-run details
- cover lightweight decoding and rendered output without detail-only fields

Follows nottelabs/monorepo#2227.

## Validation

- `go test ./...`