### PR TITLE
feat: add vault field support to page fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,19 +135,23 @@ notte sessions start \
   --cdp-url <url>                         # CDP URL of remote session provider
   --profile-id <id>                       # Profile ID to use for session
   --profile-persist                       # Save browser state to profile on close
+  --vault-id <id>                         # Vault used to resolve credential fields
   --screenshot-type <type>                # Screenshot type (raw, full, last_action)
   --chrome-args <args>                    # Chrome instance arguments (repeatable)
 ```
 
 ### Page Actions
 
-Interact with pages using simplified commands (requires an active session):
+Interact with pages using simplified commands (requires an active session). Start
+the session with `--vault-id <id>` before using `page fill --vault-field`:
 
 ```bash
 notte page observe                    # Get page state and available actions
 notte page scrape --instructions "..." # Scrape content from the page 
 notte page click "@B3"            # Click an element by ID
 notte page fill "@I1" "text"    # Fill an input field
+notte page fill "#email" --vault-field email       # Fill from the session vault
+notte page fill "#password" --vault-field password # Supports email, username, password, and mfa
 notte page goto "https://example.com" # Navigate to a URL
 notte page back                       # Go back in history
 notte page forward                    # Go forward in history

--- a/internal/cmd/page.go
+++ b/internal/cmd/page.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/nottelabs/notte-cli/internal/api"
+	"github.com/nottelabs/notte-cli/internal/credentials"
 )
 
 // Page command flags
@@ -24,8 +25,9 @@ var (
 	pageClickEnter   bool
 
 	// fill flags
-	pageFillClear bool
-	pageFillEnter bool
+	pageFillClear      bool
+	pageFillEnter      bool
+	pageFillVaultField string
 
 	// check flags
 	pageCheckValue bool
@@ -186,13 +188,36 @@ func runPageClick(cmd *cobra.Command, args []string) error {
 }
 
 var pageFillCmd = &cobra.Command{
-	Use:   "fill <id|selector> <value>",
+	Use:   "fill <id|selector> [value]",
 	Short: "Fill an input field with a value",
-	Args:  cobra.ExactArgs(2),
-	RunE:  runPageFill,
+	Long: `Fill an input field with a literal value or a credential from the vault
+attached to the current session.
+
+Use --vault-field instead of a value to keep credentials out of the command:
+  notte page fill "input[name=email]" --vault-field email
+  notte page fill "input[name=password]" --vault-field password`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: runPageFill,
+}
+
+func resolvePageFillValue(args []string) (string, error) {
+	if len(args) == 2 && pageFillVaultField != "" {
+		return "", fmt.Errorf("value and --vault-field are mutually exclusive")
+	}
+	if len(args) == 2 {
+		return args[1], nil
+	}
+	if pageFillVaultField == "" {
+		return "", fmt.Errorf("requires a value or --vault-field")
+	}
+	return credentials.Sentinel(pageFillVaultField)
 }
 
 func runPageFill(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 || len(args) > 2 {
+		return fmt.Errorf("accepts 1 or 2 arg(s), received %d", len(args))
+	}
+
 	action := map[string]any{"type": "fill"}
 
 	id, selector, err := parseSelector(args[0])
@@ -205,7 +230,11 @@ func runPageFill(cmd *cobra.Command, args []string) error {
 		action["selector"] = selector
 	}
 
-	action["value"] = args[1]
+	value, err := resolvePageFillValue(args)
+	if err != nil {
+		return err
+	}
+	action["value"] = value
 
 	if pageFillClear {
 		action["clear"] = true
@@ -794,6 +823,10 @@ func init() {
 	// fill flags
 	pageFillCmd.Flags().BoolVar(&pageFillClear, "clear", false, "Clear the field before filling")
 	pageFillCmd.Flags().BoolVar(&pageFillEnter, "enter", false, "Press Enter after filling")
+	pageFillCmd.Flags().StringVar(&pageFillVaultField, "vault-field", "", "Fill from the session vault (email, username, password, mfa)")
+	_ = pageFillCmd.RegisterFlagCompletionFunc("vault-field", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return credentials.Fields(), cobra.ShellCompDirectiveNoFileComp
+	})
 
 	// check flags
 	pageCheckCmd.Flags().BoolVar(&pageCheckValue, "value", true, "Check (true) or uncheck (false)")

--- a/internal/cmd/page_test.go
+++ b/internal/cmd/page_test.go
@@ -205,6 +205,67 @@ func TestRunPageFill(t *testing.T) {
 	}
 }
 
+func TestRunPageFill_WithVaultField(t *testing.T) {
+	server := setupPageTest(t)
+	path := "/sessions/" + pageSessionIDTest + "/page/execute"
+	server.AddResponse(path, 200, pageExecResponse())
+
+	origVaultField := pageFillVaultField
+	pageFillVaultField = "email"
+	t.Cleanup(func() { pageFillVaultField = origVaultField })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	if err := runPageFill(cmd, []string{"#email"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	requests := server.Requests(path)
+	if len(requests) != 1 {
+		t.Fatalf("got %d requests, want 1", len(requests))
+	}
+	if !strings.Contains(requests[0].Body, `"value":"user@example.org"`) {
+		t.Errorf("request body does not contain the email sentinel: %s", requests[0].Body)
+	}
+}
+
+func TestRunPageFill_RejectsValueAndVaultField(t *testing.T) {
+	origVaultField := pageFillVaultField
+	pageFillVaultField = "password"
+	t.Cleanup(func() { pageFillVaultField = origVaultField })
+
+	cmd := &cobra.Command{}
+	err := runPageFill(cmd, []string{"#password", "literal"})
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("got error %v, want mutually exclusive error", err)
+	}
+}
+
+func TestRunPageFill_RequiresValueOrVaultField(t *testing.T) {
+	origVaultField := pageFillVaultField
+	pageFillVaultField = ""
+	t.Cleanup(func() { pageFillVaultField = origVaultField })
+
+	cmd := &cobra.Command{}
+	err := runPageFill(cmd, []string{"#email"})
+	if err == nil || !strings.Contains(err.Error(), "requires a value or --vault-field") {
+		t.Fatalf("got error %v, want missing value error", err)
+	}
+}
+
+func TestRunPageFill_RejectsUnknownVaultField(t *testing.T) {
+	origVaultField := pageFillVaultField
+	pageFillVaultField = "token"
+	t.Cleanup(func() { pageFillVaultField = origVaultField })
+
+	cmd := &cobra.Command{}
+	err := runPageFill(cmd, []string{"#token"})
+	if err == nil || !strings.Contains(err.Error(), "unsupported vault field") {
+		t.Fatalf("got error %v, want unsupported vault field error", err)
+	}
+}
+
 func TestRunPageFill_WithFlags(t *testing.T) {
 	server := setupPageTest(t)
 	server.AddResponse("/sessions/"+pageSessionIDTest+"/page/execute", 200, pageExecResponse())

--- a/internal/credentials/sentinels.go
+++ b/internal/credentials/sentinels.go
@@ -1,0 +1,36 @@
+// Package credentials defines the placeholder values used to resolve secrets
+// from a vault attached to a browser session.
+package credentials
+
+import "fmt"
+
+// Field identifies a credential stored in a vault.
+type Field string
+
+const (
+	Email    Field = "email"
+	Username Field = "username"
+	Password Field = "password"
+	MFA      Field = "mfa"
+)
+
+var sentinels = map[Field]string{
+	Email:    "user@example.org",
+	Username: "cooljohnny1567",
+	Password: "mycoolpassword",
+	MFA:      "999779",
+}
+
+// Fields returns the supported vault field names in display order.
+func Fields() []string {
+	return []string{string(Email), string(Username), string(Password), string(MFA)}
+}
+
+// Sentinel returns the placeholder value recognized by the Notte API.
+func Sentinel(field string) (string, error) {
+	value, ok := sentinels[Field(field)]
+	if !ok {
+		return "", fmt.Errorf("unsupported vault field %q (supported: email, username, password, mfa)", field)
+	}
+	return value, nil
+}

--- a/internal/credentials/sentinels_test.go
+++ b/internal/credentials/sentinels_test.go
@@ -1,0 +1,33 @@
+package credentials
+
+import "testing"
+
+func TestSentinel(t *testing.T) {
+	tests := []struct {
+		field string
+		want  string
+	}{
+		{field: "email", want: "user@example.org"},
+		{field: "username", want: "cooljohnny1567"},
+		{field: "password", want: "mycoolpassword"},
+		{field: "mfa", want: "999779"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			got, err := Sentinel(tt.field)
+			if err != nil {
+				t.Fatalf("Sentinel(%q) returned an error: %v", tt.field, err)
+			}
+			if got != tt.want {
+				t.Errorf("Sentinel(%q) = %q, want %q", tt.field, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSentinelRejectsUnknownField(t *testing.T) {
+	if _, err := Sentinel("token"); err == nil {
+		t.Fatal("Sentinel(\"token\") did not return an error")
+	}
+}


### PR DESCRIPTION
## Summary

- add --vault-field to page fill for email, username, password, and MFA credentials
- translate named vault fields to the sentinel values recognized by the Notte API
- reject missing, unknown, or conflicting literal and vault field values
- add shell completion, documentation, and request payload coverage

## Test plan

- go test -race -short ./...
- go build ./cmd/notte
- go vet ./...
- repository pre-commit lint hook