### PR TITLE
[NOT-861] feat(cli): use session-scoped file API

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/oapi-codegen/runtime"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
 const (
@@ -101,6 +102,12 @@ const (
 const (
 	Failure DeleteVaultResponseStatus = "failure"
 	Success DeleteVaultResponseStatus = "success"
+)
+
+// Defines values for FileSource.
+const (
+	SessionDownload FileSource = "session_download"
+	UserUpload      FileSource = "user_upload"
 )
 
 // Defines values for FunctionRunListItemResponseStatus.
@@ -714,9 +721,6 @@ type ApiSessionStartRequest struct {
 	// SolveCaptchas Whether to try to automatically solve captchas
 	SolveCaptchas *bool `json:"solve_captchas,omitempty"`
 
-	// UseFileStorage Whether FileStorage should be attached to the session.
-	UseFileStorage *bool `json:"use_file_storage,omitempty"`
-
 	// UserAgent The user agent to use for the session
 	UserAgent *string `json:"user_agent,omitempty"`
 
@@ -761,16 +765,6 @@ type ApiSessionStartRequestScreenshotType string
 // BaseModel defines model for BaseModel.
 type BaseModel = map[string]interface{}
 
-// BodyFileUploadDownloadedFileStorageSessionIdDownloadsFilenamePost defines model for Body_file_upload_downloaded_file_storage__session_id__downloads__filename__post.
-type BodyFileUploadDownloadedFileStorageSessionIdDownloadsFilenamePost struct {
-	File string `json:"file"`
-}
-
-// BodyFileUploadStorageUploadsFilenamePost defines model for Body_file_upload_storage_uploads__filename__post.
-type BodyFileUploadStorageUploadsFilenamePost struct {
-	File string `json:"file"`
-}
-
 // BodyFunctionCreateFunctionsPost defines model for Body_function_create_functions_post.
 type BodyFunctionCreateFunctionsPost struct {
 	Description *string `json:"description,omitempty"`
@@ -793,6 +787,11 @@ type BodyFunctionUpdateFunctionsFunctionIdPost struct {
 // BodySessionCookiesSetSessionsSessionIdCookiesPost defines model for Body_session_cookies_set_sessions__session_id__cookies_post.
 type BodySessionCookiesSetSessionsSessionIdCookiesPost struct {
 	Cookies []Cookie `json:"cookies"`
+}
+
+// BodyUploadSessionFileSessionsSessionIdFilesPost defines model for Body_upload_session_file_sessions__session_id__files_post.
+type BodyUploadSessionFileSessionsSessionIdFilesPost struct {
+	File string `json:"file"`
 }
 
 // BoundingBox defines model for BoundingBox.
@@ -1372,25 +1371,8 @@ type FallbackFillActionOutput_Value struct {
 	union json.RawMessage
 }
 
-// FileInfo defines model for FileInfo.
-type FileInfo struct {
-	FileExt   string  `json:"file_ext"`
-	Name      string  `json:"name"`
-	Size      int     `json:"size"`
-	UpdatedAt *string `json:"updated_at,omitempty"`
-}
-
-// FileLinkResponse defines model for FileLinkResponse.
-type FileLinkResponse struct {
-	// Url URL to download file from
-	Url string `json:"url"`
-}
-
-// FileUploadResponse defines model for FileUploadResponse.
-type FileUploadResponse struct {
-	// Success Whether the upload was successful
-	Success bool `json:"success"`
-}
+// FileSource defines model for FileSource.
+type FileSource string
 
 // FillActionInput defines model for FillAction-Input.
 type FillActionInput struct {
@@ -1875,9 +1857,6 @@ type GlobalScrapeRequest struct {
 	SolveCaptchas *bool  `json:"solve_captchas,omitempty"`
 	Url           string `json:"url"`
 
-	// UseFileStorage Whether FileStorage should be attached to the session.
-	UseFileStorage *bool `json:"use_file_storage,omitempty"`
-
 	// UseLinkPlaceholders Whether to use link/image placeholders to reduce the number of tokens in the prompt and hallucinations. However this is an experimental feature and might not work as expected.
 	UseLinkPlaceholders *bool `json:"use_link_placeholders,omitempty"`
 
@@ -2033,12 +2012,6 @@ type LegacyAgentStatusResponse struct {
 type ListCredentialsResponse struct {
 	// Credentials URLs for which we hold credentials
 	Credentials []Credential `json:"credentials"`
-}
-
-// ListFilesResponse defines model for ListFilesResponse.
-type ListFilesResponse struct {
-	// Files List of files with metadata
-	Files []FileInfo `json:"files"`
 }
 
 // LlmModel defines model for LlmModel.
@@ -2767,6 +2740,27 @@ type SessionDebugResponse struct {
 	Ws       WebSocketUrls             `json:"ws"`
 }
 
+// SessionFile defines model for SessionFile.
+type SessionFile struct {
+	Checksum  string       `json:"checksum"`
+	CreatedAt FlexibleTime `json:"created_at"`
+	ExpiresAt FlexibleTime `json:"expires_at"`
+	Filename  string       `json:"filename"`
+	Id        string       `json:"id"`
+	MimeType  string       `json:"mime_type"`
+	SessionId string       `json:"session_id"`
+	Size      int          `json:"size"`
+	Source    FileSource   `json:"source"`
+}
+
+// SessionFilesPage defines model for SessionFilesPage.
+type SessionFilesPage struct {
+	Files  []SessionFile `json:"files"`
+	Limit  int           `json:"limit"`
+	Offset int           `json:"offset"`
+	Total  int           `json:"total"`
+}
+
 // SessionOffsetResponse defines model for SessionOffsetResponse.
 type SessionOffsetResponse struct {
 	// Offset Current state of the session trajectory
@@ -2840,9 +2834,6 @@ type SessionResponse struct {
 	SystemHidden *bool `json:"system_hidden,omitempty"`
 	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	TimeoutMinutes *int `json:"timeout_minutes,omitempty"`
-
-	// UseFileStorage Whether FileStorage was attached to the session.
-	UseFileStorage *bool `json:"use_file_storage,omitempty"`
 
 	// UserAgent The user agent to use for the session
 	UserAgent *string `json:"user_agent,omitempty"`
@@ -3602,6 +3593,33 @@ type SessionDebugInfoParams struct {
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
 
+// ListSessionFilesParams defines parameters for ListSessionFiles.
+type ListSessionFilesParams struct {
+	Source              *FileSource `form:"source,omitempty" json:"source,omitempty"`
+	Limit               *int        `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset              *int        `form:"offset,omitempty" json:"offset,omitempty"`
+	XNotteRequestOrigin *string     `json:"x-notte-request-origin,omitempty"`
+	XNotteSdkVersion    *string     `json:"x-notte-sdk-version,omitempty"`
+}
+
+// UploadSessionFileParams defines parameters for UploadSessionFile.
+type UploadSessionFileParams struct {
+	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
+	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
+}
+
+// DeleteSessionFileParams defines parameters for DeleteSessionFile.
+type DeleteSessionFileParams struct {
+	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
+	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
+}
+
+// DownloadSessionFileParams defines parameters for DownloadSessionFile.
+type DownloadSessionFileParams struct {
+	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
+	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
+}
+
 // SessionNetworkLogsParams defines parameters for SessionNetworkLogs.
 type SessionNetworkLogsParams struct {
 	// Limit Maximum number of batch files to return
@@ -3675,42 +3693,6 @@ type GetSessionScriptParams struct {
 
 	// InferResponseFormat Whether to infer response_format schema for scrape calls that have instructions but no schema
 	InferResponseFormat *bool   `form:"infer_response_format,omitempty" json:"infer_response_format,omitempty"`
-	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
-	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
-}
-
-// FileListUploadsParams defines parameters for FileListUploads.
-type FileListUploadsParams struct {
-	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
-	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
-}
-
-// FileDownloadUploadedFileParams defines parameters for FileDownloadUploadedFile.
-type FileDownloadUploadedFileParams struct {
-	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
-	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
-}
-
-// FileUploadParams defines parameters for FileUpload.
-type FileUploadParams struct {
-	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
-	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
-}
-
-// FileListDownloadsParams defines parameters for FileListDownloads.
-type FileListDownloadsParams struct {
-	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
-	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
-}
-
-// FileDownloadParams defines parameters for FileDownload.
-type FileDownloadParams struct {
-	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
-	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
-}
-
-// FileUploadDownloadedFileParams defines parameters for FileUploadDownloadedFile.
-type FileUploadDownloadedFileParams struct {
 	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
@@ -3887,6 +3869,9 @@ type SessionStartJSONRequestBody = ApiSessionStartRequest
 // SessionCookiesSetJSONRequestBody defines body for SessionCookiesSet for application/json ContentType.
 type SessionCookiesSetJSONRequestBody = BodySessionCookiesSetSessionsSessionIdCookiesPost
 
+// UploadSessionFileMultipartRequestBody defines body for UploadSessionFile for multipart/form-data ContentType.
+type UploadSessionFileMultipartRequestBody = BodyUploadSessionFileSessionsSessionIdFilesPost
+
 // PageExecuteJSONRequestBody defines body for PageExecute for application/json ContentType.
 type PageExecuteJSONRequestBody PageExecuteJSONBody
 
@@ -3895,12 +3880,6 @@ type PageObserveJSONRequestBody = ObserveRequest
 
 // PageScrapeJSONRequestBody defines body for PageScrape for application/json ContentType.
 type PageScrapeJSONRequestBody = ScrapeRequest
-
-// FileUploadMultipartRequestBody defines body for FileUpload for multipart/form-data ContentType.
-type FileUploadMultipartRequestBody = BodyFileUploadStorageUploadsFilenamePost
-
-// FileUploadDownloadedFileMultipartRequestBody defines body for FileUploadDownloadedFile for multipart/form-data ContentType.
-type FileUploadDownloadedFileMultipartRequestBody = BodyFileUploadDownloadedFileStorageSessionIdDownloadsFilenamePost
 
 // VaultCreateJSONRequestBody defines body for VaultCreate for application/json ContentType.
 type VaultCreateJSONRequestBody = VaultCreateRequest
@@ -4192,14 +4171,6 @@ func (a *SessionResponse) UnmarshalJSON(b []byte) error {
 		delete(object, "timeout_minutes")
 	}
 
-	if raw, found := object["use_file_storage"]; found {
-		err = json.Unmarshal(raw, &a.UseFileStorage)
-		if err != nil {
-			return fmt.Errorf("error reading 'use_file_storage': %w", err)
-		}
-		delete(object, "use_file_storage")
-	}
-
 	if raw, found := object["user_agent"]; found {
 		err = json.Unmarshal(raw, &a.UserAgent)
 		if err != nil {
@@ -4385,13 +4356,6 @@ func (a SessionResponse) MarshalJSON() ([]byte, error) {
 	object["timeout_minutes"], err = json.Marshal(a.TimeoutMinutes)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling 'timeout_minutes': %w", err)
-	}
-
-	if a.UseFileStorage != nil {
-		object["use_file_storage"], err = json.Marshal(a.UseFileStorage)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling 'use_file_storage': %w", err)
-		}
 	}
 
 	if a.UserAgent != nil {
@@ -9719,6 +9683,18 @@ type ClientInterface interface {
 	// SessionDebugInfo request
 	SessionDebugInfo(ctx context.Context, sessionId string, params *SessionDebugInfoParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListSessionFiles request
+	ListSessionFiles(ctx context.Context, sessionId string, params *ListSessionFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UploadSessionFileWithBody request with any body
+	UploadSessionFileWithBody(ctx context.Context, sessionId string, params *UploadSessionFileParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteSessionFile request
+	DeleteSessionFile(ctx context.Context, sessionId string, fileId openapi_types.UUID, params *DeleteSessionFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DownloadSessionFile request
+	DownloadSessionFile(ctx context.Context, sessionId string, fileId openapi_types.UUID, params *DownloadSessionFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// SessionNetworkLogs request
 	SessionNetworkLogs(ctx context.Context, sessionId string, params *SessionNetworkLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -9751,24 +9727,6 @@ type ClientInterface interface {
 
 	// GetSessionScript request
 	GetSessionScript(ctx context.Context, sessionId string, params *GetSessionScriptParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// FileListUploads request
-	FileListUploads(ctx context.Context, params *FileListUploadsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// FileDownloadUploadedFile request
-	FileDownloadUploadedFile(ctx context.Context, filename string, params *FileDownloadUploadedFileParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// FileUploadWithBody request with any body
-	FileUploadWithBody(ctx context.Context, filename string, params *FileUploadParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// FileListDownloads request
-	FileListDownloads(ctx context.Context, sessionId string, params *FileListDownloadsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// FileDownload request
-	FileDownload(ctx context.Context, sessionId string, filename string, params *FileDownloadParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// FileUploadDownloadedFileWithBody request with any body
-	FileUploadDownloadedFileWithBody(ctx context.Context, sessionId string, filename string, params *FileUploadDownloadedFileParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetUsage request
 	GetUsage(ctx context.Context, params *GetUsageParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -10827,6 +10785,54 @@ func (c *Client) SessionDebugInfo(ctx context.Context, sessionId string, params 
 	return c.Client.Do(req)
 }
 
+func (c *Client) ListSessionFiles(ctx context.Context, sessionId string, params *ListSessionFilesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListSessionFilesRequest(c.Server, sessionId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UploadSessionFileWithBody(ctx context.Context, sessionId string, params *UploadSessionFileParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUploadSessionFileRequestWithBody(c.Server, sessionId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteSessionFile(ctx context.Context, sessionId string, fileId openapi_types.UUID, params *DeleteSessionFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteSessionFileRequest(c.Server, sessionId, fileId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DownloadSessionFile(ctx context.Context, sessionId string, fileId openapi_types.UUID, params *DownloadSessionFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDownloadSessionFileRequest(c.Server, sessionId, fileId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) SessionNetworkLogs(ctx context.Context, sessionId string, params *SessionNetworkLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSessionNetworkLogsRequest(c.Server, sessionId, params)
 	if err != nil {
@@ -10961,78 +10967,6 @@ func (c *Client) SessionStop(ctx context.Context, sessionId string, params *Sess
 
 func (c *Client) GetSessionScript(ctx context.Context, sessionId string, params *GetSessionScriptParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetSessionScriptRequest(c.Server, sessionId, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) FileListUploads(ctx context.Context, params *FileListUploadsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFileListUploadsRequest(c.Server, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) FileDownloadUploadedFile(ctx context.Context, filename string, params *FileDownloadUploadedFileParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFileDownloadUploadedFileRequest(c.Server, filename, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) FileUploadWithBody(ctx context.Context, filename string, params *FileUploadParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFileUploadRequestWithBody(c.Server, filename, params, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) FileListDownloads(ctx context.Context, sessionId string, params *FileListDownloadsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFileListDownloadsRequest(c.Server, sessionId, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) FileDownload(ctx context.Context, sessionId string, filename string, params *FileDownloadParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFileDownloadRequest(c.Server, sessionId, filename, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) FileUploadDownloadedFileWithBody(ctx context.Context, sessionId string, filename string, params *FileUploadDownloadedFileParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewFileUploadDownloadedFileRequestWithBody(c.Server, sessionId, filename, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -15851,6 +15785,316 @@ func NewSessionDebugInfoRequest(server string, sessionId string, params *Session
 	return req, nil
 }
 
+// NewListSessionFilesRequest generates requests for ListSessionFiles
+func NewListSessionFilesRequest(server string, sessionId string, params *ListSessionFilesParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sessions/%s/files", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Source != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "source", runtime.ParamLocationQuery, *params.Source); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "offset", runtime.ParamLocationQuery, *params.Offset); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XNotteRequestOrigin != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-request-origin", headerParam0)
+		}
+
+		if params.XNotteSdkVersion != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-sdk-version", headerParam1)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewUploadSessionFileRequestWithBody generates requests for UploadSessionFile with any type of body
+func NewUploadSessionFileRequestWithBody(server string, sessionId string, params *UploadSessionFileParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sessions/%s/files", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.XNotteRequestOrigin != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-request-origin", headerParam0)
+		}
+
+		if params.XNotteSdkVersion != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-sdk-version", headerParam1)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewDeleteSessionFileRequest generates requests for DeleteSessionFile
+func NewDeleteSessionFileRequest(server string, sessionId string, fileId openapi_types.UUID, params *DeleteSessionFileParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "file_id", runtime.ParamLocationPath, fileId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sessions/%s/files/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XNotteRequestOrigin != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-request-origin", headerParam0)
+		}
+
+		if params.XNotteSdkVersion != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-sdk-version", headerParam1)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewDownloadSessionFileRequest generates requests for DownloadSessionFile
+func NewDownloadSessionFileRequest(server string, sessionId string, fileId openapi_types.UUID, params *DownloadSessionFileParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "file_id", runtime.ParamLocationPath, fileId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/sessions/%s/files/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.XNotteRequestOrigin != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-request-origin", headerParam0)
+		}
+
+		if params.XNotteSdkVersion != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-sdk-version", headerParam1)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewSessionNetworkLogsRequest generates requests for SessionNetworkLogs
 func NewSessionNetworkLogsRequest(server string, sessionId string, params *SessionNetworkLogsParams) (*http.Request, error) {
 	var err error
@@ -16582,377 +16826,6 @@ func NewGetSessionScriptRequest(server string, sessionId string, params *GetSess
 	if err != nil {
 		return nil, err
 	}
-
-	if params != nil {
-
-		if params.XNotteRequestOrigin != nil {
-			var headerParam0 string
-
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-request-origin", headerParam0)
-		}
-
-		if params.XNotteSdkVersion != nil {
-			var headerParam1 string
-
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-sdk-version", headerParam1)
-		}
-
-	}
-
-	return req, nil
-}
-
-// NewFileListUploadsRequest generates requests for FileListUploads
-func NewFileListUploadsRequest(server string, params *FileListUploadsParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/storage/uploads")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-
-		if params.XNotteRequestOrigin != nil {
-			var headerParam0 string
-
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-request-origin", headerParam0)
-		}
-
-		if params.XNotteSdkVersion != nil {
-			var headerParam1 string
-
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-sdk-version", headerParam1)
-		}
-
-	}
-
-	return req, nil
-}
-
-// NewFileDownloadUploadedFileRequest generates requests for FileDownloadUploadedFile
-func NewFileDownloadUploadedFileRequest(server string, filename string, params *FileDownloadUploadedFileParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "filename", runtime.ParamLocationPath, filename)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/storage/uploads/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-
-		if params.XNotteRequestOrigin != nil {
-			var headerParam0 string
-
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-request-origin", headerParam0)
-		}
-
-		if params.XNotteSdkVersion != nil {
-			var headerParam1 string
-
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-sdk-version", headerParam1)
-		}
-
-	}
-
-	return req, nil
-}
-
-// NewFileUploadRequestWithBody generates requests for FileUpload with any type of body
-func NewFileUploadRequestWithBody(server string, filename string, params *FileUploadParams, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "filename", runtime.ParamLocationPath, filename)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/storage/uploads/%s", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
-
-	if params != nil {
-
-		if params.XNotteRequestOrigin != nil {
-			var headerParam0 string
-
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-request-origin", headerParam0)
-		}
-
-		if params.XNotteSdkVersion != nil {
-			var headerParam1 string
-
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-sdk-version", headerParam1)
-		}
-
-	}
-
-	return req, nil
-}
-
-// NewFileListDownloadsRequest generates requests for FileListDownloads
-func NewFileListDownloadsRequest(server string, sessionId string, params *FileListDownloadsParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/storage/%s/downloads", pathParam0)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-
-		if params.XNotteRequestOrigin != nil {
-			var headerParam0 string
-
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-request-origin", headerParam0)
-		}
-
-		if params.XNotteSdkVersion != nil {
-			var headerParam1 string
-
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-sdk-version", headerParam1)
-		}
-
-	}
-
-	return req, nil
-}
-
-// NewFileDownloadRequest generates requests for FileDownload
-func NewFileDownloadRequest(server string, sessionId string, filename string, params *FileDownloadParams) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "filename", runtime.ParamLocationPath, filename)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/storage/%s/downloads/%s", pathParam0, pathParam1)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if params != nil {
-
-		if params.XNotteRequestOrigin != nil {
-			var headerParam0 string
-
-			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-request-origin", headerParam0)
-		}
-
-		if params.XNotteSdkVersion != nil {
-			var headerParam1 string
-
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
-			if err != nil {
-				return nil, err
-			}
-
-			req.Header.Set("x-notte-sdk-version", headerParam1)
-		}
-
-	}
-
-	return req, nil
-}
-
-// NewFileUploadDownloadedFileRequestWithBody generates requests for FileUploadDownloadedFile with any type of body
-func NewFileUploadDownloadedFileRequestWithBody(server string, sessionId string, filename string, params *FileUploadDownloadedFileParams, contentType string, body io.Reader) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "filename", runtime.ParamLocationPath, filename)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/storage/%s/downloads/%s", pathParam0, pathParam1)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -18115,6 +17988,18 @@ type ClientWithResponsesInterface interface {
 	// SessionDebugInfoWithResponse request
 	SessionDebugInfoWithResponse(ctx context.Context, sessionId string, params *SessionDebugInfoParams, reqEditors ...RequestEditorFn) (*SessionDebugInfoResult, error)
 
+	// ListSessionFilesWithResponse request
+	ListSessionFilesWithResponse(ctx context.Context, sessionId string, params *ListSessionFilesParams, reqEditors ...RequestEditorFn) (*ListSessionFilesResult, error)
+
+	// UploadSessionFileWithBodyWithResponse request with any body
+	UploadSessionFileWithBodyWithResponse(ctx context.Context, sessionId string, params *UploadSessionFileParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadSessionFileResult, error)
+
+	// DeleteSessionFileWithResponse request
+	DeleteSessionFileWithResponse(ctx context.Context, sessionId string, fileId openapi_types.UUID, params *DeleteSessionFileParams, reqEditors ...RequestEditorFn) (*DeleteSessionFileResult, error)
+
+	// DownloadSessionFileWithResponse request
+	DownloadSessionFileWithResponse(ctx context.Context, sessionId string, fileId openapi_types.UUID, params *DownloadSessionFileParams, reqEditors ...RequestEditorFn) (*DownloadSessionFileResult, error)
+
 	// SessionNetworkLogsWithResponse request
 	SessionNetworkLogsWithResponse(ctx context.Context, sessionId string, params *SessionNetworkLogsParams, reqEditors ...RequestEditorFn) (*SessionNetworkLogsResult, error)
 
@@ -18147,24 +18032,6 @@ type ClientWithResponsesInterface interface {
 
 	// GetSessionScriptWithResponse request
 	GetSessionScriptWithResponse(ctx context.Context, sessionId string, params *GetSessionScriptParams, reqEditors ...RequestEditorFn) (*GetSessionScriptResult, error)
-
-	// FileListUploadsWithResponse request
-	FileListUploadsWithResponse(ctx context.Context, params *FileListUploadsParams, reqEditors ...RequestEditorFn) (*FileListUploadsResult, error)
-
-	// FileDownloadUploadedFileWithResponse request
-	FileDownloadUploadedFileWithResponse(ctx context.Context, filename string, params *FileDownloadUploadedFileParams, reqEditors ...RequestEditorFn) (*FileDownloadUploadedFileResult, error)
-
-	// FileUploadWithBodyWithResponse request with any body
-	FileUploadWithBodyWithResponse(ctx context.Context, filename string, params *FileUploadParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FileUploadResult, error)
-
-	// FileListDownloadsWithResponse request
-	FileListDownloadsWithResponse(ctx context.Context, sessionId string, params *FileListDownloadsParams, reqEditors ...RequestEditorFn) (*FileListDownloadsResult, error)
-
-	// FileDownloadWithResponse request
-	FileDownloadWithResponse(ctx context.Context, sessionId string, filename string, params *FileDownloadParams, reqEditors ...RequestEditorFn) (*FileDownloadResult, error)
-
-	// FileUploadDownloadedFileWithBodyWithResponse request with any body
-	FileUploadDownloadedFileWithBodyWithResponse(ctx context.Context, sessionId string, filename string, params *FileUploadDownloadedFileParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FileUploadDownloadedFileResult, error)
 
 	// GetUsageWithResponse request
 	GetUsageWithResponse(ctx context.Context, params *GetUsageParams, reqEditors ...RequestEditorFn) (*GetUsageResult, error)
@@ -19625,6 +19492,97 @@ func (r SessionDebugInfoResult) StatusCode() int {
 	return 0
 }
 
+type ListSessionFilesResult struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SessionFilesPage
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListSessionFilesResult) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListSessionFilesResult) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UploadSessionFileResult struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *SessionFile
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UploadSessionFileResult) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UploadSessionFileResult) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteSessionFileResult struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteSessionFileResult) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteSessionFileResult) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DownloadSessionFileResult struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DownloadSessionFileResult) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DownloadSessionFileResult) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type SessionNetworkLogsResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -19826,146 +19784,6 @@ func (r GetSessionScriptResult) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetSessionScriptResult) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type FileListUploadsResult struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *ListFilesResponse
-	JSON422      *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r FileListUploadsResult) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r FileListUploadsResult) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type FileDownloadUploadedFileResult struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *FileLinkResponse
-	JSON422      *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r FileDownloadUploadedFileResult) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r FileDownloadUploadedFileResult) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type FileUploadResult struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *FileUploadResponse
-	JSON422      *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r FileUploadResult) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r FileUploadResult) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type FileListDownloadsResult struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *ListFilesResponse
-	JSON422      *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r FileListDownloadsResult) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r FileListDownloadsResult) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type FileDownloadResult struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *struct {
-		union json.RawMessage
-	}
-	JSON422 *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r FileDownloadResult) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r FileDownloadResult) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type FileUploadDownloadedFileResult struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *FileUploadResponse
-	JSON422      *HTTPValidationError
-}
-
-// Status returns HTTPResponse.Status
-func (r FileUploadDownloadedFileResult) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r FileUploadDownloadedFileResult) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -20944,6 +20762,42 @@ func (c *ClientWithResponses) SessionDebugInfoWithResponse(ctx context.Context, 
 	return ParseSessionDebugInfoResult(rsp)
 }
 
+// ListSessionFilesWithResponse request returning *ListSessionFilesResult
+func (c *ClientWithResponses) ListSessionFilesWithResponse(ctx context.Context, sessionId string, params *ListSessionFilesParams, reqEditors ...RequestEditorFn) (*ListSessionFilesResult, error) {
+	rsp, err := c.ListSessionFiles(ctx, sessionId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListSessionFilesResult(rsp)
+}
+
+// UploadSessionFileWithBodyWithResponse request with arbitrary body returning *UploadSessionFileResult
+func (c *ClientWithResponses) UploadSessionFileWithBodyWithResponse(ctx context.Context, sessionId string, params *UploadSessionFileParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UploadSessionFileResult, error) {
+	rsp, err := c.UploadSessionFileWithBody(ctx, sessionId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUploadSessionFileResult(rsp)
+}
+
+// DeleteSessionFileWithResponse request returning *DeleteSessionFileResult
+func (c *ClientWithResponses) DeleteSessionFileWithResponse(ctx context.Context, sessionId string, fileId openapi_types.UUID, params *DeleteSessionFileParams, reqEditors ...RequestEditorFn) (*DeleteSessionFileResult, error) {
+	rsp, err := c.DeleteSessionFile(ctx, sessionId, fileId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteSessionFileResult(rsp)
+}
+
+// DownloadSessionFileWithResponse request returning *DownloadSessionFileResult
+func (c *ClientWithResponses) DownloadSessionFileWithResponse(ctx context.Context, sessionId string, fileId openapi_types.UUID, params *DownloadSessionFileParams, reqEditors ...RequestEditorFn) (*DownloadSessionFileResult, error) {
+	rsp, err := c.DownloadSessionFile(ctx, sessionId, fileId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDownloadSessionFileResult(rsp)
+}
+
 // SessionNetworkLogsWithResponse request returning *SessionNetworkLogsResult
 func (c *ClientWithResponses) SessionNetworkLogsWithResponse(ctx context.Context, sessionId string, params *SessionNetworkLogsParams, reqEditors ...RequestEditorFn) (*SessionNetworkLogsResult, error) {
 	rsp, err := c.SessionNetworkLogs(ctx, sessionId, params, reqEditors...)
@@ -21047,60 +20901,6 @@ func (c *ClientWithResponses) GetSessionScriptWithResponse(ctx context.Context, 
 		return nil, err
 	}
 	return ParseGetSessionScriptResult(rsp)
-}
-
-// FileListUploadsWithResponse request returning *FileListUploadsResult
-func (c *ClientWithResponses) FileListUploadsWithResponse(ctx context.Context, params *FileListUploadsParams, reqEditors ...RequestEditorFn) (*FileListUploadsResult, error) {
-	rsp, err := c.FileListUploads(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseFileListUploadsResult(rsp)
-}
-
-// FileDownloadUploadedFileWithResponse request returning *FileDownloadUploadedFileResult
-func (c *ClientWithResponses) FileDownloadUploadedFileWithResponse(ctx context.Context, filename string, params *FileDownloadUploadedFileParams, reqEditors ...RequestEditorFn) (*FileDownloadUploadedFileResult, error) {
-	rsp, err := c.FileDownloadUploadedFile(ctx, filename, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseFileDownloadUploadedFileResult(rsp)
-}
-
-// FileUploadWithBodyWithResponse request with arbitrary body returning *FileUploadResult
-func (c *ClientWithResponses) FileUploadWithBodyWithResponse(ctx context.Context, filename string, params *FileUploadParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FileUploadResult, error) {
-	rsp, err := c.FileUploadWithBody(ctx, filename, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseFileUploadResult(rsp)
-}
-
-// FileListDownloadsWithResponse request returning *FileListDownloadsResult
-func (c *ClientWithResponses) FileListDownloadsWithResponse(ctx context.Context, sessionId string, params *FileListDownloadsParams, reqEditors ...RequestEditorFn) (*FileListDownloadsResult, error) {
-	rsp, err := c.FileListDownloads(ctx, sessionId, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseFileListDownloadsResult(rsp)
-}
-
-// FileDownloadWithResponse request returning *FileDownloadResult
-func (c *ClientWithResponses) FileDownloadWithResponse(ctx context.Context, sessionId string, filename string, params *FileDownloadParams, reqEditors ...RequestEditorFn) (*FileDownloadResult, error) {
-	rsp, err := c.FileDownload(ctx, sessionId, filename, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseFileDownloadResult(rsp)
-}
-
-// FileUploadDownloadedFileWithBodyWithResponse request with arbitrary body returning *FileUploadDownloadedFileResult
-func (c *ClientWithResponses) FileUploadDownloadedFileWithBodyWithResponse(ctx context.Context, sessionId string, filename string, params *FileUploadDownloadedFileParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FileUploadDownloadedFileResult, error) {
-	rsp, err := c.FileUploadDownloadedFileWithBody(ctx, sessionId, filename, params, contentType, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseFileUploadDownloadedFileResult(rsp)
 }
 
 // GetUsageWithResponse request returning *GetUsageResult
@@ -23235,6 +23035,134 @@ func ParseSessionDebugInfoResult(rsp *http.Response) (*SessionDebugInfoResult, e
 	return response, nil
 }
 
+// ParseListSessionFilesResult parses an HTTP response from a ListSessionFilesWithResponse call
+func ParseListSessionFilesResult(rsp *http.Response) (*ListSessionFilesResult, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListSessionFilesResult{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SessionFilesPage
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUploadSessionFileResult parses an HTTP response from a UploadSessionFileWithResponse call
+func ParseUploadSessionFileResult(rsp *http.Response) (*UploadSessionFileResult, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UploadSessionFileResult{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest SessionFile
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteSessionFileResult parses an HTTP response from a DeleteSessionFileWithResponse call
+func ParseDeleteSessionFileResult(rsp *http.Response) (*DeleteSessionFileResult, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteSessionFileResult{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDownloadSessionFileResult parses an HTTP response from a DownloadSessionFileWithResponse call
+func ParseDownloadSessionFileResult(rsp *http.Response) (*DownloadSessionFileResult, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DownloadSessionFileResult{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	case rsp.StatusCode == 200:
+		// Content-type (application/octet-stream) unsupported
+
+	}
+
+	return response, nil
+}
+
 // ParseSessionNetworkLogsResult parses an HTTP response from a SessionNetworkLogsWithResponse call
 func ParseSessionNetworkLogsResult(rsp *http.Response) (*SessionNetworkLogsResult, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -23515,206 +23443,6 @@ func ParseGetSessionScriptResult(rsp *http.Response) (*GetSessionScriptResult, e
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AgentFunctionCodeResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest HTTPValidationError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseFileListUploadsResult parses an HTTP response from a FileListUploadsWithResponse call
-func ParseFileListUploadsResult(rsp *http.Response) (*FileListUploadsResult, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &FileListUploadsResult{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListFilesResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest HTTPValidationError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseFileDownloadUploadedFileResult parses an HTTP response from a FileDownloadUploadedFileWithResponse call
-func ParseFileDownloadUploadedFileResult(rsp *http.Response) (*FileDownloadUploadedFileResult, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &FileDownloadUploadedFileResult{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest FileLinkResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest HTTPValidationError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseFileUploadResult parses an HTTP response from a FileUploadWithResponse call
-func ParseFileUploadResult(rsp *http.Response) (*FileUploadResult, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &FileUploadResult{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest FileUploadResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest HTTPValidationError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseFileListDownloadsResult parses an HTTP response from a FileListDownloadsWithResponse call
-func ParseFileListDownloadsResult(rsp *http.Response) (*FileListDownloadsResult, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &FileListDownloadsResult{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest ListFilesResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest HTTPValidationError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseFileDownloadResult parses an HTTP response from a FileDownloadWithResponse call
-func ParseFileDownloadResult(rsp *http.Response) (*FileDownloadResult, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &FileDownloadResult{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest struct {
-			union json.RawMessage
-		}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
-		var dest HTTPValidationError
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON422 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseFileUploadDownloadedFileResult parses an HTTP response from a FileUploadDownloadedFileWithResponse call
-func ParseFileUploadDownloadedFileResult(rsp *http.Response) (*FileUploadDownloadedFileResult, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &FileUploadDownloadedFileResult{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest FileUploadResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"strings"
 	"time"
 
 	notteErrors "github.com/nottelabs/notte-cli/internal/errors"
@@ -222,28 +219,6 @@ func (c *NotteClient) BaseURL() string {
 // APIKey returns the API key used by the client
 func (c *NotteClient) APIKey() string {
 	return c.apiKey
-}
-
-// DownloadUploadedFile requests a temporary download link for a user-uploaded file.
-// This endpoint is kept here until it is available in the generated OpenAPI client.
-func (c *NotteClient) DownloadUploadedFile(ctx context.Context, filename string) (*http.Response, []byte, error) {
-	endpoint := strings.TrimRight(c.baseURL, "/") + "/storage/uploads/" + url.PathEscape(filename)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create uploaded file download request: %w", err)
-	}
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return resp, nil, fmt.Errorf("failed to read uploaded file download response: %w", err)
-	}
-	return resp, body, nil
 }
 
 // Context helper for commands

--- a/internal/cmd/files.go
+++ b/internal/cmd/files.go
@@ -6,21 +6,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
-
-	"github.com/nottelabs/notte-cli/internal/api"
 )
 
 var (
 	filesListUploadsFlag   bool
 	filesListDownloadsFlag bool
 	filesListFrom          string
-	filesDownloadFrom      string
 	filesDownloadOutput    string
 )
 
@@ -32,32 +32,30 @@ const (
 var filesCmd = &cobra.Command{
 	Use:   "files",
 	Short: "Manage stored files",
-	Long:  "Upload, list, and download files from notte.cc storage.",
+	Long:  "Upload, list, and download files owned by a browser session.",
 }
 
 var filesListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List stored files",
-	Long: `List user-uploaded files or files downloaded by a browser session.
-Use --from uploads for user uploads or --from session for session downloads.`,
-	RunE: runFilesList,
+	Long:  `List all files owned by a browser session. Use --from uploads or --from session to filter the source.`,
+	RunE:  runFilesList,
 }
 
 var filesUploadCmd = &cobra.Command{
 	Use:   "upload <file-path>",
 	Short: "Upload a file",
-	Long:  "Upload a file to notte.cc storage.",
+	Long:  "Upload a file to a browser session.",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runFilesUpload,
 }
 
 var filesDownloadCmd = &cobra.Command{
-	Use:   "download <filename>",
-	Short: "Download a file by name",
-	Long: `Download a user-uploaded file or a file produced by a browser session.
-Use --from uploads for user uploads or --from session for session downloads.`,
-	Args: cobra.ExactArgs(1),
-	RunE: runFilesDownload,
+	Use:   "download <file-id>",
+	Short: "Download a session file by ID",
+	Long:  "Download a user upload or browser download by its immutable file ID.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFilesDownload,
 }
 
 func init() {
@@ -69,15 +67,38 @@ func init() {
 	// List command flags
 	filesListCmd.Flags().BoolVar(&filesListUploadsFlag, "uploads", false, "List uploaded files")
 	filesListCmd.Flags().BoolVar(&filesListDownloadsFlag, "downloads", false, "List downloaded files from a session")
-	filesListCmd.Flags().StringVar(&filesListFrom, "from", "", "File source: uploads or session (default session)")
+	filesListCmd.Flags().StringVar(&filesListFrom, "from", "", "File source: uploads or session (default all)")
 	filesListCmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID (uses current session if not specified)")
 	_ = filesListCmd.Flags().MarkDeprecated("uploads", "use --from uploads instead")
 	_ = filesListCmd.Flags().MarkDeprecated("downloads", "use --from session instead")
 
 	// Download command flags
 	filesDownloadCmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID (uses current session if not specified)")
-	filesDownloadCmd.Flags().StringVar(&filesDownloadFrom, "from", "", "File source: uploads or session (default session)")
 	filesDownloadCmd.Flags().StringVar(&filesDownloadOutput, "path", "", "Output file path (defaults to current directory)")
+	filesUploadCmd.Flags().StringVar(&sessionID, "session-id", "", "Session ID (uses current session if not specified)")
+}
+
+type sessionFile struct {
+	ID        string `json:"id"`
+	SessionID string `json:"session_id"`
+	Filename  string `json:"filename"`
+	MimeType  string `json:"mime_type"`
+	Size      int64  `json:"size"`
+	Checksum  string `json:"checksum"`
+	CreatedAt string `json:"created_at"`
+	ExpiresAt string `json:"expires_at"`
+	Source    string `json:"source"`
+}
+
+type sessionFilesPage struct {
+	Files  []sessionFile `json:"files"`
+	Total  int           `json:"total"`
+	Limit  int           `json:"limit"`
+	Offset int           `json:"offset"`
+}
+
+func sessionFilesURL(clientBaseURL, id string) string {
+	return strings.TrimRight(clientBaseURL, "/") + "/sessions/" + url.PathEscape(sessionID) + "/files" + id
 }
 
 func resolveFilesSource(from string, uploads, downloads bool) (string, error) {
@@ -96,7 +117,9 @@ func resolveFilesSource(from string, uploads, downloads bool) (string, error) {
 	}
 
 	switch from {
-	case "", filesSourceSession:
+	case "":
+		return "", nil
+	case filesSourceSession:
 		return filesSourceSession, nil
 	case filesSourceUploads:
 		return filesSourceUploads, nil
@@ -204,81 +227,47 @@ func runFilesList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := RequireSessionID(); err != nil {
+		return err
+	}
 	client, err := GetClient()
 	if err != nil {
 		return err
 	}
-
-	formatter := GetFormatter()
-
-	if source == filesSourceUploads {
-		ctx, cancel := GetContextWithTimeout(cmd.Context())
-		defer cancel()
-
-		params := &api.FileListUploadsParams{}
-		resp, err := client.Client().FileListUploadsWithResponse(ctx, params)
-		if err != nil {
-			return fmt.Errorf("API request failed: %w", err)
-		}
-
-		if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
-			return err
-		}
-
-		var fileNames []string
-		if resp.JSON200 != nil {
-			for _, f := range resp.JSON200.Files {
-				fileNames = append(fileNames, f.Name)
-			}
-		}
-		if printed, err := PrintListOrEmpty(fileNames, "No uploaded files."); err != nil {
-			return err
-		} else if printed {
-			return nil
-		}
-
-		if !IsJSONOutput() {
-			fmt.Println("Your uploaded files:")
-		}
-		return formatter.Print(fileNames)
-	}
-
-	// Default: list downloads for a session
-	if err := RequireSessionID(); err != nil {
-		return err
-	}
-
 	ctx, cancel := GetContextWithTimeout(cmd.Context())
 	defer cancel()
-
-	params := &api.FileListDownloadsParams{}
-	resp, err := client.Client().FileListDownloadsWithResponse(ctx, sessionID, params)
+	endpoint := sessionFilesURL(client.BaseURL(), "") + "?limit=1000"
+	if source == filesSourceUploads {
+		endpoint += "&source=user_upload"
+	} else {
+		endpoint += "&source=session_download"
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.HTTPClient().Do(req)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)
 	}
-
-	if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
 		return err
 	}
-
-	var fileNames []string
-	if resp.JSON200 != nil {
-		for _, f := range resp.JSON200.Files {
-			fileNames = append(fileNames, f.Name)
-		}
+	if err := HandleAPIResponse(resp, body); err != nil {
+		return err
 	}
-	if printed, err := PrintListOrEmpty(fileNames, fmt.Sprintf("No downloaded files in session %s.", sessionID)); err != nil {
+	var page sessionFilesPage
+	if err := json.Unmarshal(body, &page); err != nil {
+		return fmt.Errorf("failed to parse files response: %w", err)
+	}
+	if printed, err := PrintListOrEmpty(page.Files, fmt.Sprintf("No files in session %s.", sessionID)); err != nil {
 		return err
 	} else if printed {
 		return nil
 	}
-
-	if !IsJSONOutput() {
-		fmt.Printf("Downloaded files in session %s:\n", sessionID)
-		fmt.Println("Fetch locally with: notte files download <filename>")
-		fmt.Println()
-	}
-	return formatter.Print(fileNames)
+	return GetFormatter().Print(page.Files)
 }
 
 func runFilesUpload(cmd *cobra.Command, args []string) error {
@@ -292,6 +281,9 @@ func runFilesUpload(cmd *cobra.Command, args []string) error {
 
 	if fileInfo.IsDir() {
 		return fmt.Errorf("path is a directory, not a file: %s", filePath)
+	}
+	if err := RequireSessionID(); err != nil {
+		return err
 	}
 
 	client, err := GetClient()
@@ -321,54 +313,39 @@ func runFilesUpload(cmd *cobra.Command, args []string) error {
 
 	_ = writer.Close()
 
-	// Get the filename to use in the API call
 	filename := filepath.Base(filePath)
-
 	ctx, cancel := GetContextWithTimeout(cmd.Context())
 	defer cancel()
-
-	params := &api.FileUploadParams{}
-	resp, err := client.Client().FileUploadWithBodyWithResponse(
-		ctx,
-		filename,
-		params,
-		writer.FormDataContentType(),
-		&buf,
-	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sessionFilesURL(client.BaseURL(), ""), &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	resp, err := client.HTTPClient().Do(req)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)
 	}
-
-	if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
-		return err
-	}
-
-	formatter := GetFormatter()
-	if resp.JSON200 != nil && resp.JSON200.Success {
-		if IsJSONOutput() {
-			return formatter.Print(resp.JSON200)
-		}
-		return PrintResult(fmt.Sprintf("File uploaded successfully: %s", filename), map[string]any{
-			"filename": filename,
-			"success":  true,
-		})
-	}
-
-	return formatter.Print(resp.JSON200)
-}
-
-func runFilesDownload(cmd *cobra.Command, args []string) error {
-	filename := args[0]
-
-	source, err := resolveFilesSource(filesDownloadFrom, false, false)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
+	if err := HandleAPIResponse(resp, body); err != nil {
+		return err
+	}
+	var uploaded sessionFile
+	if err := json.Unmarshal(body, &uploaded); err != nil {
+		return fmt.Errorf("failed to parse upload response: %w", err)
+	}
+	return PrintResult(fmt.Sprintf("File uploaded successfully: %s", filename), map[string]any{
+		"file": uploaded,
+	})
+}
 
-	if source == filesSourceSession {
-		if err := RequireSessionID(); err != nil {
-			return err
-		}
+func runFilesDownload(cmd *cobra.Command, args []string) error {
+	fileID := args[0]
+	if err := RequireSessionID(); err != nil {
+		return err
 	}
 
 	client, err := GetClient()
@@ -379,57 +356,56 @@ func runFilesDownload(cmd *cobra.Command, args []string) error {
 	ctx, cancel := GetContextWithTimeout(cmd.Context())
 	defer cancel()
 
-	var httpResponse *http.Response
-	var responseBody []byte
-	if source == filesSourceUploads {
-		httpResponse, responseBody, err = client.DownloadUploadedFile(ctx, filename)
-		if err != nil {
-			return fmt.Errorf("API request failed: %w", err)
-		}
-	} else {
-		params := &api.FileDownloadParams{}
-		resp, err := client.Client().FileDownloadWithResponse(
-			ctx,
-			sessionID,
-			filename,
-			params,
-		)
-		if err != nil {
-			return fmt.Errorf("API request failed: %w", err)
-		}
-		httpResponse = resp.HTTPResponse
-		responseBody = resp.Body
-	}
-
-	if err := HandleAPIResponse(httpResponse, responseBody); err != nil {
+	req, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, sessionFilesURL(client.BaseURL(), "/"+url.PathEscape(fileID)), nil,
+	)
+	if err != nil {
 		return err
 	}
-
-	// Parse the JSON response to get the presigned URL
-	var downloadResp struct {
-		URL string `json:"url"`
+	resp, err := client.HTTPClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("API request failed: %w", err)
 	}
-	if err := json.Unmarshal(responseBody, &downloadResp); err != nil {
-		return fmt.Errorf("failed to parse download response: %w", err)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return readErr
+		}
+		return HandleAPIResponse(resp, body)
 	}
-
-	if downloadResp.URL == "" {
-		return fmt.Errorf("no download URL in response")
-	}
-
-	// Determine output path
 	outputPath := filesDownloadOutput
 	if outputPath == "" {
-		outputPath = filename
+		outputPath = fileID
+		if _, params, parseErr := mime.ParseMediaType(resp.Header.Get("Content-Disposition")); parseErr == nil {
+			if filename := filepath.Base(params["filename"]); filename != "." && filename != "" {
+				outputPath = filename
+			}
+		}
 	}
-
-	if err := downloadFileWithContext(ctx, downloadResp.URL, outputPath); err != nil {
-		return fmt.Errorf("failed to download file: %w", err)
+	destinationPath, err := resolveDownloadOutputPath(outputPath)
+	if err != nil {
+		return err
 	}
-
+	temporary, err := os.CreateTemp(filepath.Dir(destinationPath), ".notte-download-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer func() { _ = os.Remove(temporaryPath) }()
+	if _, err := io.Copy(temporary, resp.Body); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, destinationPath); err != nil {
+		return err
+	}
 	return PrintResult(fmt.Sprintf("File downloaded successfully: %s", outputPath), map[string]any{
-		"filename": filename,
-		"path":     outputPath,
-		"success":  true,
+		"id":      fileID,
+		"path":    outputPath,
+		"success": true,
 	})
 }

--- a/internal/cmd/files_test.go
+++ b/internal/cmd/files_test.go
@@ -137,7 +137,7 @@ func TestRunFilesListUploads(t *testing.T) {
 	defer server.Close()
 	env.SetEnv("NOTTE_API_URL", server.URL())
 
-	server.AddResponse("/storage/uploads", 200, `{"files":[{"name":"a.txt","file_ext":".txt","size":100}]}`)
+	server.AddResponse("/sessions/sess_123/files", 200, `{"files":[{"id":"f1","session_id":"sess_123","filename":"a.txt","mime_type":"text/plain","size":100,"checksum":"abc","created_at":"2026-08-21T00:00:00Z","expires_at":"2026-08-22T00:00:00Z","source":"user_upload"}],"total":1,"limit":1000,"offset":0}`)
 
 	origUploadsFlag := filesListUploadsFlag
 	origFrom := filesListFrom
@@ -149,7 +149,7 @@ func TestRunFilesListUploads(t *testing.T) {
 	})
 	filesListUploadsFlag = false
 	filesListFrom = filesSourceUploads
-	sessionID = ""
+	sessionID = "sess_123"
 
 	origFormat := outputFormat
 	outputFormat = "json"
@@ -178,7 +178,7 @@ func TestRunFilesListUploadsEmpty(t *testing.T) {
 	defer server.Close()
 	env.SetEnv("NOTTE_API_URL", server.URL())
 
-	server.AddResponse("/storage/uploads", 200, `{"files":[]}`)
+	server.AddResponse("/sessions/sess_123/files", 200, `{"files":[],"total":0,"limit":1000,"offset":0}`)
 
 	origUploadsFlag := filesListUploadsFlag
 	origFrom := filesListFrom
@@ -190,7 +190,7 @@ func TestRunFilesListUploadsEmpty(t *testing.T) {
 	})
 	filesListUploadsFlag = true
 	filesListFrom = ""
-	sessionID = ""
+	sessionID = "sess_123"
 
 	origFormat := outputFormat
 	outputFormat = "text"
@@ -206,7 +206,7 @@ func TestRunFilesListUploadsEmpty(t *testing.T) {
 		}
 	})
 
-	if !strings.Contains(stdout, "No uploaded files.") {
+	if !strings.Contains(stdout, "No files in session") {
 		t.Fatalf("expected empty message, got %q", stdout)
 	}
 }
@@ -219,7 +219,7 @@ func TestRunFilesListDownloads(t *testing.T) {
 	defer server.Close()
 	env.SetEnv("NOTTE_API_URL", server.URL())
 
-	server.AddResponse("/storage/sess_123/downloads", 200, `{"files":[{"name":"b.txt","file_ext":".txt","size":200}]}`)
+	server.AddResponse("/sessions/sess_123/files", 200, `{"files":[{"id":"f2","session_id":"sess_123","filename":"b.txt","mime_type":"text/plain","size":200,"checksum":"abc","created_at":"2026-08-21T00:00:00Z","expires_at":"2026-08-22T00:00:00Z","source":"session_download"}],"total":1,"limit":1000,"offset":0}`)
 
 	origDownloadsFlag := filesListDownloadsFlag
 	origFrom := filesListFrom
@@ -306,7 +306,10 @@ func TestRunFilesUpload(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Remove(tmpFile.Name()) })
 
-	server.AddResponse("/storage/uploads/"+filepath.Base(tmpFile.Name()), 200, `{"success":true}`)
+	server.AddResponse("/sessions/sess_123/files", 201, `{"id":"f1","session_id":"sess_123","filename":"`+filepath.Base(tmpFile.Name())+`","mime_type":"text/plain","size":5,"checksum":"abc","created_at":"2026-08-21T00:00:00Z","expires_at":"2026-08-22T00:00:00Z","source":"user_upload"}`)
+	origSession := sessionID
+	sessionID = "sess_123"
+	t.Cleanup(func() { sessionID = origSession })
 
 	origFormat := outputFormat
 	outputFormat = "text"
@@ -345,35 +348,23 @@ func TestRunFilesDownload(t *testing.T) {
 	env := testutil.SetupTestEnv(t)
 	env.SetEnv("NOTTE_API_KEY", "test-key")
 
-	// Create a server for the actual file content (simulating S3)
-	fileServer := testutil.NewMockServer()
-	defer fileServer.Close()
-	fileServer.AddResponseWithHeaders("/file.txt", 200, "filedata", map[string]string{
-		"Content-Type": "application/octet-stream",
-	})
-
-	// Create the API server that returns the presigned URL
 	server := testutil.NewMockServer()
 	defer server.Close()
 	env.SetEnv("NOTTE_API_URL", server.URL())
 
 	origSession := sessionID
-	origFrom := filesDownloadFrom
 	origOutput := filesDownloadOutput
 	t.Cleanup(func() {
 		sessionID = origSession
-		filesDownloadFrom = origFrom
 		filesDownloadOutput = origOutput
 	})
 	sessionID = "sess_123"
-	filesDownloadFrom = ""
 
 	outDir := t.TempDir()
 	outputPath := filepath.Join(outDir, "download.txt")
 	filesDownloadOutput = outputPath
 
-	// API returns JSON with the presigned URL pointing to our file server
-	server.AddResponse("/storage/sess_123/downloads/file.txt", 200, `{"url":"`+fileServer.URL()+`/file.txt"}`)
+	server.AddResponse("/sessions/sess_123/files/file-id", 200, "filedata")
 
 	origFormat := outputFormat
 	outputFormat = "text"
@@ -383,7 +374,7 @@ func TestRunFilesDownload(t *testing.T) {
 	cmd.SetContext(context.Background())
 
 	stdout, _ := testutil.CaptureOutput(func() {
-		err := runFilesDownload(cmd, []string{"file.txt"})
+		err := runFilesDownload(cmd, []string{"file-id"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -406,33 +397,24 @@ func TestRunFilesDownloadFromUploads(t *testing.T) {
 	env.SetEnv("NOTTE_API_KEY", "test-key")
 	env.SetEnv("NOTTE_SESSION_ID", "")
 
-	fileServer := testutil.NewMockServer()
-	defer fileServer.Close()
-	fileServer.AddResponseWithHeaders("/input.txt", 200, "uploaded-file-data", map[string]string{
-		"Content-Type": "application/octet-stream",
-	})
-
 	server := testutil.NewMockServer()
 	defer server.Close()
 	env.SetEnv("NOTTE_API_URL", server.URL())
-	server.AddResponse("/storage/uploads/input.txt", 200, `{"url":"`+fileServer.URL()+`/input.txt"}`)
+	server.AddResponse("/sessions/sess_123/files/upload-id", 200, "uploaded-file-data")
 
 	origSession := sessionID
-	origFrom := filesDownloadFrom
 	origOutput := filesDownloadOutput
 	t.Cleanup(func() {
 		sessionID = origSession
-		filesDownloadFrom = origFrom
 		filesDownloadOutput = origOutput
 	})
-	sessionID = ""
-	filesDownloadFrom = filesSourceUploads
+	sessionID = "sess_123"
 	filesDownloadOutput = filepath.Join(t.TempDir(), "input.txt")
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
 
-	if err := runFilesDownload(cmd, []string{"input.txt"}); err != nil {
+	if err := runFilesDownload(cmd, []string{"upload-id"}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -455,11 +437,8 @@ func TestRunFilesDownloadMissingSession(t *testing.T) {
 	t.Cleanup(func() { config.SetTestConfigDir("") })
 
 	origSession := sessionID
-	origFrom := filesDownloadFrom
 	t.Cleanup(func() { sessionID = origSession })
-	t.Cleanup(func() { filesDownloadFrom = origFrom })
 	sessionID = ""
-	filesDownloadFrom = ""
 
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
@@ -482,7 +461,7 @@ func TestResolveFilesSource(t *testing.T) {
 		want      string
 		wantErr   bool
 	}{
-		{name: "defaults to session", want: filesSourceSession},
+		{name: "defaults to all"},
 		{name: "from uploads", from: filesSourceUploads, want: filesSourceUploads},
 		{name: "from session", from: filesSourceSession, want: filesSourceSession},
 		{name: "legacy uploads", uploads: true, want: filesSourceUploads},

--- a/internal/cmd/sessions_test.go
+++ b/internal/cmd/sessions_test.go
@@ -114,7 +114,6 @@ func TestRunSessionsStart(t *testing.T) {
 	origVH := SessionStartViewportHeight
 	origUA := SessionStartUserAgent
 	origCDP := SessionStartCdpUrl
-	origFileStorage := SessionStartUseFileStorage
 	t.Cleanup(func() {
 		SessionStartBrowserType = origBrowser
 		SessionStartIdleTimeoutMinutes = origTimeout
@@ -124,7 +123,6 @@ func TestRunSessionsStart(t *testing.T) {
 		SessionStartViewportHeight = origVH
 		SessionStartUserAgent = origUA
 		SessionStartCdpUrl = origCDP
-		SessionStartUseFileStorage = origFileStorage
 	})
 
 	SessionStartBrowserType = "chrome"
@@ -135,7 +133,6 @@ func TestRunSessionsStart(t *testing.T) {
 	SessionStartViewportHeight = 720
 	SessionStartUserAgent = "test-agent"
 	SessionStartCdpUrl = "ws://cdp"
-	SessionStartUseFileStorage = true
 
 	origFormat := outputFormat
 	outputFormat = "json"
@@ -144,10 +141,8 @@ func TestRunSessionsStart(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
-	cmd.Flags().BoolVar(&SessionStartUseFileStorage, "file-storage", false, "")
 	_ = cmd.Flags().Set("proxy", "true")
 	_ = cmd.Flags().Set("solve-captchas", "true")
-	_ = cmd.Flags().Set("file-storage", "true")
 	cmd.SetContext(context.Background())
 
 	stdout, _ := testutil.CaptureOutput(func() {

--- a/internal/cmd/sessionstart_flags.gen.go
+++ b/internal/cmd/sessionstart_flags.gen.go
@@ -48,9 +48,6 @@ var (
 	// Whether to try to automatically solve captchas
 	SessionStartSolveCaptchas bool
 
-	// Whether FileStorage should be attached to the session.
-	SessionStartUseFileStorage bool
-
 	// The user agent to use for the session
 	SessionStartUserAgent string
 
@@ -86,7 +83,6 @@ func RegisterSessionStartFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&SessionStartProfilePersist, "profile-persist", false, "Whether to save browser state to profile on session close (API default: false)")
 	cmd.Flags().StringVar(&SessionStartScreenshotType, "screenshot-type", "", "The type of screenshot to use for the session. (API default: last_action) (raw, full, last_action)")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "Whether to try to automatically solve captchas (API default: true)")
-	cmd.Flags().BoolVar(&SessionStartUseFileStorage, "use-file-storage", false, "Whether FileStorage should be attached to the session. (API default: true)")
 	cmd.Flags().StringVar(&SessionStartUserAgent, "user-agent", "", "The user agent to use for the session")
 	cmd.Flags().StringVar(&SessionStartVaultId, "vault-id", "", "The vault to use for the session")
 	cmd.Flags().IntVar(&SessionStartViewportHeight, "viewport-height", 0, "The height of the viewport")
@@ -159,10 +155,6 @@ func BuildSessionStartRequest(cmd *cobra.Command) (*api.ApiSessionStartRequest, 
 
 	if cmd.Flags().Changed("solve-captchas") {
 		body.SolveCaptchas = &SessionStartSolveCaptchas
-	}
-
-	if cmd.Flags().Changed("use-file-storage") {
-		body.UseFileStorage = &SessionStartUseFileStorage
 	}
 
 	if SessionStartUserAgent != "" {

--- a/internal/cmd/sessionstart_optout.go
+++ b/internal/cmd/sessionstart_optout.go
@@ -20,12 +20,9 @@ import (
 //
 // --no- rather than --disable- specifically because Chromium's own flags are
 // --disable-* (--disable-gpu, --disable-extensions) and this command forwards
-// them verbatim through --chrome-args. Keeping the prefixes distinct means
-// `--no-file-storage --chrome-args="--disable-gpu"` reads unambiguously as one
-// Notte flag and one browser flag.
+// them verbatim through --chrome-args.
 var (
 	sessionsStartNoSolveCaptchas bool
-	sessionsStartNoFileStorage   bool
 )
 
 // sessionStartOptOut pairs a new negative flag with the generated flag it
@@ -48,12 +45,6 @@ func sessionStartOptOuts() []sessionStartOptOut {
 			set:      &sessionsStartNoSolveCaptchas,
 			apply:    func(b *api.ApiSessionStartRequest, enabled bool) { b.SolveCaptchas = &enabled },
 		},
-		{
-			negative: "no-file-storage",
-			original: "use-file-storage",
-			set:      &sessionsStartNoFileStorage,
-			apply:    func(b *api.ApiSessionStartRequest, enabled bool) { b.UseFileStorage = &enabled },
-		},
 	}
 }
 
@@ -62,11 +53,6 @@ func sessionStartOptOuts() []sessionStartOptOut {
 func registerSessionStartOptOutFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&sessionsStartNoSolveCaptchas, "no-solve-captchas", false,
 		"Do not attempt to solve captchas automatically")
-	// No backticks in usage strings: cobra's UnquoteUsage treats the first
-	// backquoted span as the flag's value placeholder, so this rendered as
-	// "--no-file-storage notte page download" in --help.
-	cmd.Flags().BoolVar(&sessionsStartNoFileStorage, "no-file-storage", false,
-		"Do not attach FileStorage. Disables 'notte page download' and 'notte files --from session'")
 }
 
 // validateSessionStartOptOuts rejects a pair whose two spellings were both

--- a/internal/cmd/sessionstart_optout_test.go
+++ b/internal/cmd/sessionstart_optout_test.go
@@ -13,7 +13,6 @@ import (
 func newOptOutCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "start", RunE: func(*cobra.Command, []string) error { return nil }}
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "solve captchas")
-	cmd.Flags().BoolVar(&SessionStartUseFileStorage, "use-file-storage", false, "file storage")
 	registerSessionStartOptOutFlags(cmd)
 	return cmd
 }
@@ -22,7 +21,6 @@ func runOptOut(t *testing.T, args ...string) (*api.ApiSessionStartRequest, error
 	t.Helper()
 	// Package-level flag vars are shared; reset before each case.
 	sessionsStartNoSolveCaptchas = false
-	sessionsStartNoFileStorage = false
 
 	cmd := newOptOutCmd()
 	cmd.SetArgs(args)
@@ -44,9 +42,6 @@ func TestOptOutsLeaveBodyUntouchedWhenAbsent(t *testing.T) {
 	if body.SolveCaptchas != nil {
 		t.Errorf("SolveCaptchas = %v, want nil when --no-solve-captchas is omitted", *body.SolveCaptchas)
 	}
-	if body.UseFileStorage != nil {
-		t.Errorf("UseFileStorage = %v, want nil when --no-file-storage is omitted", *body.UseFileStorage)
-	}
 }
 
 func TestOptOutsInvertTheirCounterpart(t *testing.T) {
@@ -62,13 +57,6 @@ func TestOptOutsInvertTheirCounterpart(t *testing.T) {
 			args:  []string{"--no-solve-captchas"},
 			field: "SolveCaptchas",
 			get:   func(b *api.ApiSessionStartRequest) *bool { return b.SolveCaptchas },
-			want:  false,
-		},
-		{
-			name:  "--no-file-storage sends use_file_storage=false",
-			args:  []string{"--no-file-storage"},
-			field: "UseFileStorage",
-			get:   func(b *api.ApiSessionStartRequest) *bool { return b.UseFileStorage },
 			want:  false,
 		},
 	}
@@ -96,7 +84,6 @@ func TestOptOutsInvertTheirCounterpart(t *testing.T) {
 func TestConflictingPairIsRejected(t *testing.T) {
 	for _, args := range [][]string{
 		{"--no-solve-captchas", "--solve-captchas"},
-		{"--no-file-storage", "--use-file-storage"},
 	} {
 		_, err := runOptOut(t, args...)
 		if err == nil {
@@ -110,7 +97,7 @@ func TestConflictingPairIsRejected(t *testing.T) {
 // when they cannot rely on the server default.
 func TestOriginalFlagsStillWorkAlone(t *testing.T) {
 	cmd := newOptOutCmd()
-	for _, name := range []string{"solve-captchas", "use-file-storage"} {
+	for _, name := range []string{"solve-captchas"} {
 		f := cmd.Flags().Lookup(name)
 		if f == nil {
 			t.Errorf("--%s should still be registered", name)

--- a/scripts/endpoint-coverage.txt
+++ b/scripts/endpoint-coverage.txt
@@ -17,8 +17,9 @@
 # --- reached by hand-written requests ---------------------------------------
 manual POST /functions/{function_id}/runs/start # notte functions run builds the body itself to send function_id and variables
 manual POST /sessions/{session_id}/page/screenshot # notte page screenshot writes the image bytes out rather than decoding JSON
-manual GET  /storage/uploads/{filename} # notte files download streams to disk
-manual POST /storage/{session_id}/downloads/{filename} # notte files upload streams from disk
+manual GET  /sessions/{session_id}/files # notte files list builds the source-filtered request itself
+manual POST /sessions/{session_id}/files # notte files upload streams multipart data from disk
+manual GET  /sessions/{session_id}/files/{file_id} # notte files download streams the response to disk
 
 # --- removed from the CLI ----------------------------------------------------
 skip GET    /agents # agents were removed from the CLI in #64
@@ -26,6 +27,7 @@ skip POST   /agents/start # agents were removed from the CLI in #64
 skip GET    /agents/{agent_id} # agents were removed from the CLI in #64
 skip DELETE /agents/{agent_id}/stop # agents were removed from the CLI in #64
 skip GET    /agents/{agent_id}/workflow/code # agents were removed from the CLI in #64
+skip DELETE /sessions/{session_id}/files/{file_id} # file deletion is not exposed by the CLI
 
 # --- superseded by a session-scoped equivalent -------------------------------
 skip POST /scrape # use notte page scrape, which runs in a session

--- a/tests/integration/storage_test.go
+++ b/tests/integration/storage_test.go
@@ -10,14 +10,36 @@ import (
 	"time"
 )
 
+func startStorageSession(t *testing.T) string {
+	t.Helper()
+	result := runCLI(t, "sessions", "start")
+	requireSuccess(t, result)
+
+	var response struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &response); err != nil {
+		t.Fatalf("Failed to parse session start response: %v", err)
+	}
+	if response.SessionID == "" {
+		t.Fatal("Session start response did not include a session_id")
+	}
+	t.Cleanup(func() { cleanupSession(t, response.SessionID) })
+	return response.SessionID
+}
+
 func TestStorageListUploads(t *testing.T) {
+	sessionID := startStorageSession(t)
+
 	// List uploads - should work even if empty
-	result := runCLI(t, "files", "list", "--uploads")
+	result := runCLI(t, "files", "list", "--from", "uploads", "--session-id", sessionID)
 	requireSuccess(t, result)
 	t.Log("Successfully listed uploads")
 }
 
 func TestStorageUploadListAndDownload(t *testing.T) {
+	sessionID := startStorageSession(t)
+
 	// Create a temporary file to upload
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test-upload.txt")
@@ -27,12 +49,23 @@ func TestStorageUploadListAndDownload(t *testing.T) {
 	}
 
 	// Upload the file
-	result := runCLI(t, "files", "upload", testFile)
+	result := runCLI(t, "files", "upload", testFile, "--session-id", sessionID)
 	requireSuccess(t, result)
 	t.Log("Successfully uploaded file")
+	var uploadResp struct {
+		File struct {
+			ID string `json:"id"`
+		} `json:"file"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &uploadResp); err != nil {
+		t.Fatalf("Failed to parse upload response: %v", err)
+	}
+	if uploadResp.File.ID == "" {
+		t.Fatal("Upload response did not include a file ID")
+	}
 
 	// List uploads - should include our file
-	result = runCLI(t, "files", "list", "--uploads")
+	result = runCLI(t, "files", "list", "--from", "uploads", "--session-id", sessionID)
 	requireSuccess(t, result)
 	if !containsString(result.Stdout, "test-upload.txt") {
 		t.Log("Upload might use different filename, but list succeeded")
@@ -41,7 +74,7 @@ func TestStorageUploadListAndDownload(t *testing.T) {
 
 	// Download the uploaded file again
 	downloadPath := filepath.Join(tmpDir, "downloaded-test-upload.txt")
-	result = runCLI(t, "files", "download", "test-upload.txt", "--from", "uploads", "--path", downloadPath)
+	result = runCLI(t, "files", "download", uploadResp.File.ID, "--session-id", sessionID, "--path", downloadPath)
 	requireSuccess(t, result)
 
 	downloadedContent, err := os.ReadFile(downloadPath)
@@ -55,24 +88,13 @@ func TestStorageUploadListAndDownload(t *testing.T) {
 }
 
 func TestStorageDownloadFromSession(t *testing.T) {
-	// Start a session with file storage enabled
-	result := runCLI(t, "sessions", "start", "--use-file-storage")
-	requireSuccess(t, result)
-
-	var startResp struct {
-		SessionID string `json:"session_id"`
-	}
-	if err := json.Unmarshal([]byte(result.Stdout), &startResp); err != nil {
-		t.Fatalf("Failed to parse session start response: %v", err)
-	}
-	sessionID := startResp.SessionID
-	defer cleanupSession(t, sessionID)
+	sessionID := startStorageSession(t)
 
 	// Wait for session to be ready
 	time.Sleep(2 * time.Second)
 
 	// List downloads from session (likely empty)
-	result = runCLI(t, "files", "list", "--downloads", "--session-id", sessionID)
+	result := runCLI(t, "files", "list", "--from", "session", "--session-id", sessionID)
 	requireSuccess(t, result)
 	t.Log("Successfully listed session downloads")
 }
@@ -85,26 +107,17 @@ func TestStorageListDownloadsRequiresSession(t *testing.T) {
 }
 
 func TestStorageDownloadNonexistent(t *testing.T) {
-	// Start a session with file storage enabled
-	result := runCLI(t, "sessions", "start", "--use-file-storage")
-	requireSuccess(t, result)
-
-	var startResp struct {
-		SessionID string `json:"session_id"`
-	}
-	if err := json.Unmarshal([]byte(result.Stdout), &startResp); err != nil {
-		t.Fatalf("Failed to parse session start response: %v", err)
-	}
-	sessionID := startResp.SessionID
-	defer cleanupSession(t, sessionID)
+	sessionID := startStorageSession(t)
 
 	// Try to download a non-existent file
-	result = runCLI(t, "files", "download", "nonexistent-file-12345.txt", "--session-id", sessionID)
+	result := runCLI(t, "files", "download", "00000000-0000-0000-0000-000000000000", "--session-id", sessionID)
 	requireFailure(t, result)
 	t.Log("Correctly failed to download non-existent file")
 }
 
 func TestStorageUploadLargeFile(t *testing.T) {
+	sessionID := startStorageSession(t)
+
 	// Create a larger test file (1MB)
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "large-test-file.bin")
@@ -120,7 +133,7 @@ func TestStorageUploadLargeFile(t *testing.T) {
 	}
 
 	// Upload the file
-	result := runCLIWithTimeout(t, 120*time.Second, "files", "upload", testFile)
+	result := runCLIWithTimeout(t, 120*time.Second, "files", "upload", testFile, "--session-id", sessionID)
 	requireSuccess(t, result)
 	t.Log("Successfully uploaded large file")
 }


### PR DESCRIPTION
## Summary
- require a session for every file operation
- list uploads and browser downloads through the unified session catalog
- download files by immutable ID
- remove the obsolete file-storage session flags

## Tests
- `go test ./internal/cmd ./internal/api`

Linear: NOT-861 https://linear.app/nottelabsinc/issue/NOT-861/notte-cli-pr-70-featcli-use-session-scoped-file-api