### PR TITLE
docs(readme): document page eval-js and its output contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,25 @@ notte page close-tab                  # Close current tab
 notte page reload                     # Reload page
 notte page wait <seconds>             # Wait for duration
 notte page captcha-solve              # Solve captcha
+notte page eval-js "document.title"   # Evaluate JavaScript in the page
 ```
+
+#### Evaluating JavaScript
+
+`page eval-js` prints the evaluated value **alone on stdout** — objects and
+arrays as JSON, a JS `null` as `null` — with the status line on stderr, so it
+captures and pipes without post-processing:
+
+```bash
+title=$(notte page eval-js "document.title")
+
+notte page eval-js "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" | jq length
+```
+
+Return `JSON.stringify(...)` when the answer is structured. `console.log` output
+is discarded — only the returned value comes back. A failing script exits
+non-zero and reports the actual JavaScript error; use `-o json` to get the full
+execution result instead of the bare value.
 
 ### Functions
 


### PR DESCRIPTION
## Why

`page eval-js` was **missing from the README's Page Actions list entirely** — the command existed but was never documented there. And after #72 its output is worth explaining: the evaluated value now prints alone on stdout with the status line on stderr, which makes it composable in a shell.

## What

- Add `notte page eval-js` to the Page Actions command list.
- New short "Evaluating JavaScript" section covering the contract: value alone on stdout (objects/arrays as JSON, a JS `null` as `null`), status on stderr, `console.log` discarded, failures exit non-zero with the actual JavaScript error, `-o json` for the full execution result — with the two shapes users actually want:

```bash
title=$(notte page eval-js "document.title")

notte page eval-js "JSON.stringify([...document.querySelectorAll('a')].map(a => a.href))" | jq length
```

## Verification

Both examples were run verbatim against a live staging session with a CLI built from main: the capture returned `Example Domain`, the jq pipe returned a count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)