### PR TITLE
fix: sync CLI with staging OpenAPI

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -627,6 +627,9 @@ type ApiExecutionResponse_Action struct {
 
 // ApiSessionStartRequest defines model for ApiSessionStartRequest.
 type ApiSessionStartRequest struct {
+	// AdvancedStealth Enable Notte's highest-fidelity browser environment for sites with sophisticated bot detection. Available to approved workspaces.
+	AdvancedStealth *bool `json:"advanced_stealth,omitempty"`
+
 	// AspectRatio Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.
 	AspectRatio *string `json:"aspect_ratio,omitempty"`
 
@@ -647,9 +650,6 @@ type ApiSessionStartRequest struct {
 
 	// ExtraHttpHeaders Extra HTTP headers to be sent with every request.
 	ExtraHttpHeaders *map[string]interface{} `json:"extra_http_headers,omitempty"`
-
-	// Headless Whether to run the session in headless mode.
-	Headless *bool `json:"headless,omitempty"`
 
 	// IdleTimeoutMinutes Idle timeout in minutes. Session closes after this period of inactivity (resets on each operation).
 	IdleTimeoutMinutes *int `json:"idle_timeout_minutes,omitempty"`
@@ -1324,8 +1324,8 @@ type FrameData struct {
 	FrameUrl string `json:"frameUrl"`
 }
 
-// FunctionResponse defines model for FunctionResponse.
-type FunctionResponse struct {
+// FunctionListItemResponse defines model for FunctionListItemResponse.
+type FunctionListItemResponse struct {
 	// CreatedAt The creation time of the workflow
 	CreatedAt FlexibleTime `json:"created_at"`
 
@@ -1346,8 +1346,77 @@ type FunctionResponse struct {
 	ReferenceWorkflowId *string   `json:"reference_workflow_id,omitempty"`
 	RequiredSecrets     *[]string `json:"required_secrets,omitempty"`
 
+	// SelfHealing Whether the build is finished and the function may be healed automatically. Can only be enabled on a function that has a thread for self-heal to resume.
+	SelfHealing *bool `json:"self_healing,omitempty"`
+
 	// Shared Whether the workflow is public and can beshared with other users
 	Shared *bool `json:"shared,omitempty"`
+
+	// Source Where the function was created from, stamped at creation. Read-only.
+	Source *string `json:"source,omitempty"`
+
+	// Status The status of the workflow
+	Status string `json:"status"`
+
+	// UpdatedAt The last update time of the workflow
+	UpdatedAt FlexibleTime `json:"updated_at"`
+
+	// Variables The variables to run the workflow with
+	Variables *[]ParameterInfo `json:"variables,omitempty"`
+
+	// Versions The versions of the workflow
+	Versions   []string `json:"versions"`
+	WorkflowId *string  `json:"workflow_id,omitempty"`
+}
+
+// FunctionMetadataUpdateRequest defines model for FunctionMetadataUpdateRequest.
+type FunctionMetadataUpdateRequest struct {
+	Instructions *string `json:"instructions,omitempty"`
+	SelfHealing  *bool   `json:"self_healing,omitempty"`
+}
+
+// FunctionResponse defines model for FunctionResponse.
+type FunctionResponse struct {
+	// CreatedAt The creation time of the workflow
+	CreatedAt FlexibleTime `json:"created_at"`
+
+	// Description The description of the workflow
+	Description *string `json:"description,omitempty"`
+
+	// FunctionId The ID of the function
+	FunctionId string `json:"function_id"`
+
+	// Instructions Builder's operating notes: typical run duration, known failure modes, which parameters matter.
+	Instructions *string `json:"instructions,omitempty"`
+
+	// LatestVersion The version of the workflow
+	LatestVersion string `json:"latest_version"`
+
+	// Name The name of the workflow
+	Name      *string `json:"name,omitempty"`
+	Published *bool   `json:"published,omitempty"`
+
+	// ReferenceWorkflowId The ID of the reference workflow (i.e wether the workflow was forked from another workflow or not)
+	ReferenceWorkflowId *string   `json:"reference_workflow_id,omitempty"`
+	RequiredSecrets     *[]string `json:"required_secrets,omitempty"`
+
+	// ScheduleCron Cron expression the function runs on, or null if it is not scheduled.
+	ScheduleCron *string `json:"schedule_cron,omitempty"`
+
+	// ScheduleState 'enabled' while the schedule fires, 'paused' once the backend disabled it after a deterministic failure (exhausted credit, or an inactive function), null when there is no schedule.
+	ScheduleState *string `json:"schedule_state,omitempty"`
+
+	// ScheduleVariables Variables passed to each scheduled run, or null if it is not scheduled.
+	ScheduleVariables *map[string]interface{} `json:"schedule_variables,omitempty"`
+
+	// SelfHealing Whether the build is finished and the function may be healed automatically. Can only be enabled on a function that has a thread for self-heal to resume.
+	SelfHealing *bool `json:"self_healing,omitempty"`
+
+	// Shared Whether the workflow is public and can beshared with other users
+	Shared *bool `json:"shared,omitempty"`
+
+	// Source Where the function was created from, stamped at creation. Read-only.
+	Source *string `json:"source,omitempty"`
 
 	// Status The status of the workflow
 	Status string `json:"status"`
@@ -1421,6 +1490,9 @@ type FunctionWithLinkResponse struct {
 	// FunctionId The ID of the function
 	FunctionId string `json:"function_id"`
 
+	// Instructions Builder's operating notes: typical run duration, known failure modes, which parameters matter.
+	Instructions *string `json:"instructions,omitempty"`
+
 	// LatestVersion The version of the workflow
 	LatestVersion string `json:"latest_version"`
 
@@ -1432,8 +1504,23 @@ type FunctionWithLinkResponse struct {
 	ReferenceWorkflowId *string   `json:"reference_workflow_id,omitempty"`
 	RequiredSecrets     *[]string `json:"required_secrets,omitempty"`
 
+	// ScheduleCron Cron expression the function runs on, or null if it is not scheduled.
+	ScheduleCron *string `json:"schedule_cron,omitempty"`
+
+	// ScheduleState 'enabled' while the schedule fires, 'paused' once the backend disabled it after a deterministic failure (exhausted credit, or an inactive function), null when there is no schedule.
+	ScheduleState *string `json:"schedule_state,omitempty"`
+
+	// ScheduleVariables Variables passed to each scheduled run, or null if it is not scheduled.
+	ScheduleVariables *map[string]interface{} `json:"schedule_variables,omitempty"`
+
+	// SelfHealing Whether the build is finished and the function may be healed automatically. Can only be enabled on a function that has a thread for self-heal to resume.
+	SelfHealing *bool `json:"self_healing,omitempty"`
+
 	// Shared Whether the workflow is public and can beshared with other users
 	Shared *bool `json:"shared,omitempty"`
+
+	// Source Where the function was created from, stamped at creation. Read-only.
+	Source *string `json:"source,omitempty"`
 
 	// Status The status of the workflow
 	Status string `json:"status"`
@@ -1502,6 +1589,9 @@ type GetFunctionRunResponseStatus string
 
 // GlobalScrapeRequest defines model for GlobalScrapeRequest.
 type GlobalScrapeRequest struct {
+	// AdvancedStealth Enable Notte's highest-fidelity browser environment for sites with sophisticated bot detection. Available to approved workspaces.
+	AdvancedStealth *bool `json:"advanced_stealth,omitempty"`
+
 	// AspectRatio Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.
 	AspectRatio *string `json:"aspect_ratio,omitempty"`
 
@@ -1519,9 +1609,6 @@ type GlobalScrapeRequest struct {
 
 	// ExtraHttpHeaders Extra HTTP headers to be sent with every request.
 	ExtraHttpHeaders *map[string]interface{} `json:"extra_http_headers,omitempty"`
-
-	// Headless Whether to run the session in headless mode.
-	Headless *bool `json:"headless,omitempty"`
 
 	// IdleTimeoutMinutes Idle timeout in minutes. Session closes after this period of inactivity (resets on each operation).
 	IdleTimeoutMinutes *int `json:"idle_timeout_minutes,omitempty"`
@@ -1935,13 +2022,13 @@ type PaginatedResponseAgentResponse struct {
 	PageSize    int             `json:"page_size"`
 }
 
-// PaginatedResponseFunctionResponse defines model for PaginatedResponse_FunctionResponse_.
-type PaginatedResponseFunctionResponse struct {
-	HasNext     bool               `json:"has_next"`
-	HasPrevious *bool              `json:"has_previous,omitempty"`
-	Items       []FunctionResponse `json:"items"`
-	Page        int                `json:"page"`
-	PageSize    int                `json:"page_size"`
+// PaginatedResponseFunctionListItemResponse defines model for PaginatedResponse_FunctionListItemResponse_.
+type PaginatedResponseFunctionListItemResponse struct {
+	HasNext     bool                       `json:"has_next"`
+	HasPrevious *bool                      `json:"has_previous,omitempty"`
+	Items       []FunctionListItemResponse `json:"items"`
+	Page        int                        `json:"page"`
+	PageSize    int                        `json:"page_size"`
 }
 
 // PaginatedResponseFunctionRunListItemResponse defines model for PaginatedResponse_FunctionRunListItemResponse_.
@@ -2468,9 +2555,6 @@ type SessionResponse struct {
 	// Error Error message if the operation failed to complete
 	Error *string `json:"error,omitempty"`
 
-	// Headless Whether to run the session in headless mode.
-	Headless *bool `json:"headless,omitempty"`
-
 	// IdleTimeoutMinutes Session idle timeout in minutes. Will timeout if now() > last access time + idle_timeout_minutes
 	IdleTimeoutMinutes int `json:"idle_timeout_minutes"`
 
@@ -2874,6 +2958,12 @@ type FunctionDownloadUrlParams struct {
 
 	// DecryptionKey The decryption key for the function
 	DecryptionKey       *string `form:"decryption_key,omitempty" json:"decryption_key,omitempty"`
+	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
+	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
+}
+
+// FunctionMetadataUpdateParams defines parameters for FunctionMetadataUpdate.
+type FunctionMetadataUpdateParams struct {
 	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
@@ -3419,6 +3509,9 @@ type AnythingStartJSONRequestBody = AnythingStartRequest
 
 // FunctionCreateMultipartRequestBody defines body for FunctionCreate for multipart/form-data ContentType.
 type FunctionCreateMultipartRequestBody = BodyFunctionCreateFunctionsPost
+
+// FunctionMetadataUpdateJSONRequestBody defines body for FunctionMetadataUpdate for application/json ContentType.
+type FunctionMetadataUpdateJSONRequestBody = FunctionMetadataUpdateRequest
 
 // FunctionUpdateMultipartRequestBody defines body for FunctionUpdate for multipart/form-data ContentType.
 type FunctionUpdateMultipartRequestBody = BodyFunctionUpdateFunctionsFunctionIdPost
@@ -8671,6 +8764,11 @@ type ClientInterface interface {
 	// FunctionDownloadUrl request
 	FunctionDownloadUrl(ctx context.Context, functionId string, params *FunctionDownloadUrlParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// FunctionMetadataUpdateWithBody request with any body
+	FunctionMetadataUpdateWithBody(ctx context.Context, functionId string, params *FunctionMetadataUpdateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	FunctionMetadataUpdate(ctx context.Context, functionId string, params *FunctionMetadataUpdateParams, body FunctionMetadataUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// FunctionUpdateWithBody request with any body
 	FunctionUpdateWithBody(ctx context.Context, functionId string, params *FunctionUpdateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -9049,6 +9147,30 @@ func (c *Client) FunctionDelete(ctx context.Context, functionId string, params *
 
 func (c *Client) FunctionDownloadUrl(ctx context.Context, functionId string, params *FunctionDownloadUrlParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewFunctionDownloadUrlRequest(c.Server, functionId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FunctionMetadataUpdateWithBody(ctx context.Context, functionId string, params *FunctionMetadataUpdateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFunctionMetadataUpdateRequestWithBody(c.Server, functionId, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) FunctionMetadataUpdate(ctx context.Context, functionId string, params *FunctionMetadataUpdateParams, body FunctionMetadataUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewFunctionMetadataUpdateRequest(c.Server, functionId, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -10962,6 +11084,79 @@ func NewFunctionDownloadUrlRequest(server string, functionId string, params *Fun
 	if err != nil {
 		return nil, err
 	}
+
+	if params != nil {
+
+		if params.XNotteRequestOrigin != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-request-origin", headerParam0)
+		}
+
+		if params.XNotteSdkVersion != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-sdk-version", headerParam1)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewFunctionMetadataUpdateRequest calls the generic FunctionMetadataUpdate builder with application/json body
+func NewFunctionMetadataUpdateRequest(server string, functionId string, params *FunctionMetadataUpdateParams, body FunctionMetadataUpdateJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewFunctionMetadataUpdateRequestWithBody(server, functionId, params, "application/json", bodyReader)
+}
+
+// NewFunctionMetadataUpdateRequestWithBody generates requests for FunctionMetadataUpdate with any type of body
+func NewFunctionMetadataUpdateRequestWithBody(server string, functionId string, params *FunctionMetadataUpdateParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "function_id", runtime.ParamLocationPath, functionId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/functions/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -16251,6 +16446,11 @@ type ClientWithResponsesInterface interface {
 	// FunctionDownloadUrlWithResponse request
 	FunctionDownloadUrlWithResponse(ctx context.Context, functionId string, params *FunctionDownloadUrlParams, reqEditors ...RequestEditorFn) (*FunctionDownloadUrlResult, error)
 
+	// FunctionMetadataUpdateWithBodyWithResponse request with any body
+	FunctionMetadataUpdateWithBodyWithResponse(ctx context.Context, functionId string, params *FunctionMetadataUpdateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FunctionMetadataUpdateResult, error)
+
+	FunctionMetadataUpdateWithResponse(ctx context.Context, functionId string, params *FunctionMetadataUpdateParams, body FunctionMetadataUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*FunctionMetadataUpdateResult, error)
+
 	// FunctionUpdateWithBodyWithResponse request with any body
 	FunctionUpdateWithBodyWithResponse(ctx context.Context, functionId string, params *FunctionUpdateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FunctionUpdateResult, error)
 
@@ -16636,7 +16836,7 @@ func (r AnythingStartResult) StatusCode() int {
 type ListFunctionsResult struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *PaginatedResponseFunctionResponse
+	JSON200      *PaginatedResponseFunctionListItemResponse
 	JSON422      *HTTPValidationError
 }
 
@@ -16719,6 +16919,29 @@ func (r FunctionDownloadUrlResult) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r FunctionDownloadUrlResult) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type FunctionMetadataUpdateResult struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *FunctionResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r FunctionMetadataUpdateResult) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r FunctionMetadataUpdateResult) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -18370,6 +18593,23 @@ func (c *ClientWithResponses) FunctionDownloadUrlWithResponse(ctx context.Contex
 	return ParseFunctionDownloadUrlResult(rsp)
 }
 
+// FunctionMetadataUpdateWithBodyWithResponse request with arbitrary body returning *FunctionMetadataUpdateResult
+func (c *ClientWithResponses) FunctionMetadataUpdateWithBodyWithResponse(ctx context.Context, functionId string, params *FunctionMetadataUpdateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FunctionMetadataUpdateResult, error) {
+	rsp, err := c.FunctionMetadataUpdateWithBody(ctx, functionId, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFunctionMetadataUpdateResult(rsp)
+}
+
+func (c *ClientWithResponses) FunctionMetadataUpdateWithResponse(ctx context.Context, functionId string, params *FunctionMetadataUpdateParams, body FunctionMetadataUpdateJSONRequestBody, reqEditors ...RequestEditorFn) (*FunctionMetadataUpdateResult, error) {
+	rsp, err := c.FunctionMetadataUpdate(ctx, functionId, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseFunctionMetadataUpdateResult(rsp)
+}
+
 // FunctionUpdateWithBodyWithResponse request with arbitrary body returning *FunctionUpdateResult
 func (c *ClientWithResponses) FunctionUpdateWithBodyWithResponse(ctx context.Context, functionId string, params *FunctionUpdateParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*FunctionUpdateResult, error) {
 	rsp, err := c.FunctionUpdateWithBody(ctx, functionId, params, contentType, body, reqEditors...)
@@ -19354,7 +19594,7 @@ func ParseListFunctionsResult(rsp *http.Response) (*ListFunctionsResult, error) 
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest PaginatedResponseFunctionResponse
+		var dest PaginatedResponseFunctionListItemResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -19454,6 +19694,39 @@ func ParseFunctionDownloadUrlResult(rsp *http.Response) (*FunctionDownloadUrlRes
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest FunctionWithLinkResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseFunctionMetadataUpdateResult parses an HTTP response from a FunctionMetadataUpdateWithResponse call
+func ParseFunctionMetadataUpdateResult(rsp *http.Response) (*FunctionMetadataUpdateResult, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &FunctionMetadataUpdateResult{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest FunctionResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -351,7 +351,7 @@ func runFunctionsList(cmd *cobra.Command, args []string) error {
 
 	formatter := GetFormatter()
 
-	var items []api.FunctionResponse
+	var items []api.FunctionListItemResponse
 	if resp.JSON200 != nil {
 		items = resp.JSON200.Items
 	}

--- a/internal/cmd/sessions_test.go
+++ b/internal/cmd/sessions_test.go
@@ -106,7 +106,6 @@ func TestRunSessionsStart(t *testing.T) {
 
 	server.AddResponse("/sessions/start", 200, `{"session_id":"sess_123","status":"ACTIVE","created_at":"2020-01-01T00:00:00Z","last_accessed_at":"2020-01-01T00:00:00Z","timeout_minutes":5}`)
 
-	origHeadless := SessionStartHeadless
 	origBrowser := SessionStartBrowserType
 	origTimeout := SessionStartIdleTimeoutMinutes
 	origProxies := sessionsStartProxy
@@ -117,7 +116,6 @@ func TestRunSessionsStart(t *testing.T) {
 	origCDP := SessionStartCdpUrl
 	origFileStorage := SessionStartUseFileStorage
 	t.Cleanup(func() {
-		SessionStartHeadless = origHeadless
 		SessionStartBrowserType = origBrowser
 		SessionStartIdleTimeoutMinutes = origTimeout
 		sessionsStartProxy = origProxies
@@ -129,7 +127,6 @@ func TestRunSessionsStart(t *testing.T) {
 		SessionStartUseFileStorage = origFileStorage
 	})
 
-	SessionStartHeadless = false
 	SessionStartBrowserType = "chrome"
 	SessionStartIdleTimeoutMinutes = 5
 	sessionsStartProxy = true
@@ -145,11 +142,9 @@ func TestRunSessionsStart(t *testing.T) {
 	t.Cleanup(func() { outputFormat = origFormat })
 
 	cmd := &cobra.Command{}
-	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
 	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.Flags().BoolVar(&SessionStartUseFileStorage, "file-storage", false, "")
-	_ = cmd.Flags().Set("headless", "false")
 	_ = cmd.Flags().Set("proxy", "true")
 	_ = cmd.Flags().Set("solve-captchas", "true")
 	_ = cmd.Flags().Set("file-storage", "true")
@@ -177,7 +172,6 @@ func TestRunSessionsStart_Minimal(t *testing.T) {
 
 	server.AddResponse("/sessions/start", 200, `{"session_id":"sess_456","status":"ACTIVE","created_at":"2020-01-01T00:00:00Z","last_accessed_at":"2020-01-01T00:00:00Z","timeout_minutes":3}`)
 
-	origHeadless := SessionStartHeadless
 	origBrowser := SessionStartBrowserType
 	origTimeout := SessionStartIdleTimeoutMinutes
 	origProxies := sessionsStartProxy
@@ -187,7 +181,6 @@ func TestRunSessionsStart_Minimal(t *testing.T) {
 	origUA := SessionStartUserAgent
 	origCDP := SessionStartCdpUrl
 	t.Cleanup(func() {
-		SessionStartHeadless = origHeadless
 		SessionStartBrowserType = origBrowser
 		SessionStartIdleTimeoutMinutes = origTimeout
 		sessionsStartProxy = origProxies
@@ -198,7 +191,6 @@ func TestRunSessionsStart_Minimal(t *testing.T) {
 		SessionStartCdpUrl = origCDP
 	})
 
-	SessionStartHeadless = true
 	SessionStartBrowserType = ""
 	SessionStartIdleTimeoutMinutes = 0
 	sessionsStartProxy = false
@@ -213,7 +205,6 @@ func TestRunSessionsStart_Minimal(t *testing.T) {
 	t.Cleanup(func() { outputFormat = origFormat })
 
 	cmd := &cobra.Command{}
-	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
 	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())
@@ -1071,7 +1062,6 @@ func TestSessionsStart_SetsCurrentSession(t *testing.T) {
 	t.Cleanup(func() { outputFormat = origFormat })
 
 	cmd := &cobra.Command{}
-	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
 	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())
@@ -1278,7 +1268,6 @@ func TestSessionsStart_SavesExpiry(t *testing.T) {
 	t.Cleanup(func() { outputFormat = origFormat })
 
 	cmd := &cobra.Command{}
-	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
 	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())
@@ -1349,7 +1338,6 @@ func TestSessionsStart_AutoClearsExpiredSession(t *testing.T) {
 	env.SetEnv("NOTTE_SESSION_ID", "")
 
 	cmd := &cobra.Command{}
-	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
 	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())
@@ -1418,7 +1406,6 @@ func TestSessionsStart_DoesNotAutoClearNonExpiredSession(t *testing.T) {
 	t.Cleanup(func() { outputFormat = origFormat })
 
 	cmd := &cobra.Command{}
-	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", true, "")
 	cmd.Flags().BoolVar(&sessionsStartProxy, "proxy", false, "")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "")
 	cmd.SetContext(context.Background())

--- a/internal/cmd/sessionstart_flags.gen.go
+++ b/internal/cmd/sessionstart_flags.gen.go
@@ -11,6 +11,9 @@ import (
 
 // SessionStart command flags
 var (
+	// Enable Notte's highest-fidelity browser environment for sites with sophisticated bot detection. Available to approved workspaces.
+	SessionStartAdvancedStealth bool
+
 	// Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.
 	SessionStartAspectRatio string
 
@@ -28,9 +31,6 @@ var (
 
 	// Whether to enable the Notte recorder extension for this session. The extension is installed but remains inactive when this is false.
 	SessionStartDemonstrate bool
-
-	// Whether to run the session in headless mode.
-	SessionStartHeadless bool
 
 	// Idle timeout in minutes. Session closes after this period of inactivity (resets on each operation).
 	SessionStartIdleTimeoutMinutes int
@@ -72,13 +72,13 @@ var (
 
 // RegisterSessionStartFlags registers all flags for SessionStart command
 func RegisterSessionStartFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&SessionStartAdvancedStealth, "advanced-stealth", false, "Enable Notte's highest-fidelity browser environment for sites with sophisticated bot detection. Available to approved workspaces. (API default: false)")
 	cmd.Flags().StringVar(&SessionStartAspectRatio, "aspect-ratio", "", "Viewport shape preset. When set, the backend fits the largest rectangle of this aspect ratio inside the sampled available screen area. Cannot be combined with explicit viewport_width/viewport_height.")
 	cmd.Flags().StringSliceVar(&SessionStartAuthIds, "auth-ids", []string{}, "Managed Auth connection IDs to verify and, when necessary, authenticate inside this session. Authentication finishes before the session is returned unless wait_for_authentication is false. (repeatable)")
 	cmd.Flags().StringVar(&SessionStartBrowserType, "browser-type", "", "The browser type to use. Supported values are chromium and chrome. chrome-nightly and chrome-turbo are legacy aliases for chrome. (API default: chromium) (chromium, chrome, chrome-nightly, chrome-turbo)")
 	cmd.Flags().StringVar(&SessionStartCdpUrl, "cdp-url", "", "The CDP URL of another remote session provider.")
 	cmd.Flags().StringSliceVar(&SessionStartChromeArgs, "chrome-args", []string{}, "Overwrite the chrome instance arguments (repeatable)")
 	cmd.Flags().BoolVar(&SessionStartDemonstrate, "demonstrate", false, "Whether to enable the Notte recorder extension for this session. The extension is installed but remains inactive when this is false. (API default: false)")
-	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", false, "Whether to run the session in headless mode. (API default: true)")
 	cmd.Flags().IntVar(&SessionStartIdleTimeoutMinutes, "idle-timeout-minutes", 0, "Idle timeout in minutes. Session closes after this period of inactivity (resets on each operation). (API default: 3)")
 	cmd.Flags().IntVar(&SessionStartMaxDurationMinutes, "max-duration-minutes", 0, "Maximum session lifetime in minutes (absolute maximum, not affected by activity). (API default: 15)")
 	// profile (flattened object)
@@ -98,6 +98,10 @@ func RegisterSessionStartFlags(cmd *cobra.Command) {
 // BuildSessionStartRequest builds the API request from CLI flags
 func BuildSessionStartRequest(cmd *cobra.Command) (*api.ApiSessionStartRequest, error) {
 	body := &api.ApiSessionStartRequest{}
+
+	if cmd.Flags().Changed("advanced-stealth") {
+		body.AdvancedStealth = &SessionStartAdvancedStealth
+	}
 
 	if SessionStartAspectRatio != "" {
 		body.AspectRatio = &SessionStartAspectRatio
@@ -122,10 +126,6 @@ func BuildSessionStartRequest(cmd *cobra.Command) (*api.ApiSessionStartRequest, 
 
 	if cmd.Flags().Changed("demonstrate") {
 		body.Demonstrate = &SessionStartDemonstrate
-	}
-
-	if cmd.Flags().Changed("headless") {
-		body.Headless = &SessionStartHeadless
 	}
 
 	if SessionStartIdleTimeoutMinutes > 0 {

--- a/internal/cmd/sessionstart_optout.go
+++ b/internal/cmd/sessionstart_optout.go
@@ -30,9 +30,9 @@ var (
 
 // sessionStartOptOut pairs a new negative flag with the generated flag it
 // supersedes. The original stays registered and undeprecated: pinning a value
-// explicitly is legitimate defensive scripting, since a caller who needs a
-// headless session should not have to trust that the server default stays
-// true. Only passing both at once is an error.
+// explicitly is legitimate defensive scripting, since a caller should not
+// have to trust that the server default stays true. Only passing both at once
+// is an error.
 type sessionStartOptOut struct {
 	negative string
 	original string

--- a/internal/cmd/sessionstart_optout.go
+++ b/internal/cmd/sessionstart_optout.go
@@ -10,15 +10,13 @@ import (
 )
 
 // Several session-start options default to true server-side, which left their
-// flags shaped as opt-ins for something already on. Passing --headless or
-// --solve-captchas changed nothing, and turning either off required the double
-// negative `--headless=false`. Each now has a positive way to opt out.
+// flags shaped as opt-ins for something already on. Passing --solve-captchas
+// changed nothing, and turning it off required the double negative
+// `--solve-captchas=false`. Each now has a positive way to opt out.
 //
 // Naming follows one rule: use the term the ecosystem already has, otherwise
-// prefix with --no-. Playwright exposes a visible browser as --headed, and
-// users arrive from Playwright and Puppeteer, so that is the word they will
-// guess. There is no comparable word for the other two, so they take the --no-
-// prefix used by git, docker, npm and curl.
+// prefix with --no-. The prefix follows the convention used by git, docker,
+// npm and curl.
 //
 // --no- rather than --disable- specifically because Chromium's own flags are
 // --disable-* (--disable-gpu, --disable-extensions) and this command forwards
@@ -26,7 +24,6 @@ import (
 // `--no-file-storage --chrome-args="--disable-gpu"` reads unambiguously as one
 // Notte flag and one browser flag.
 var (
-	sessionsStartHeaded          bool
 	sessionsStartNoSolveCaptchas bool
 	sessionsStartNoFileStorage   bool
 )
@@ -46,12 +43,6 @@ type sessionStartOptOut struct {
 func sessionStartOptOuts() []sessionStartOptOut {
 	return []sessionStartOptOut{
 		{
-			negative: "headed",
-			original: "headless",
-			set:      &sessionsStartHeaded,
-			apply:    func(b *api.ApiSessionStartRequest, enabled bool) { b.Headless = &enabled },
-		},
-		{
 			negative: "no-solve-captchas",
 			original: "solve-captchas",
 			set:      &sessionsStartNoSolveCaptchas,
@@ -69,8 +60,6 @@ func sessionStartOptOuts() []sessionStartOptOut {
 // registerSessionStartOptOutFlags adds the negative flags alongside the
 // generated ones.
 func registerSessionStartOptOutFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&sessionsStartHeaded, "headed", false,
-		"Run with a visible browser window instead of headless")
 	cmd.Flags().BoolVar(&sessionsStartNoSolveCaptchas, "no-solve-captchas", false,
 		"Do not attempt to solve captchas automatically")
 	// No backticks in usage strings: cobra's UnquoteUsage treats the first
@@ -96,9 +85,7 @@ func validateSessionStartOptOuts(cmd *cobra.Command) error {
 }
 
 // applySessionStartOptOuts folds the negative flags into an already-built
-// request body. Each one inverts its counterpart, so --headed sends
-// headless=false and --headed=false sends headless=true.
-//
+// request body. Each one inverts its counterpart.
 // Revalidates so the invariant holds even if a caller reaches this without
 // going through PreRunE.
 func applySessionStartOptOuts(cmd *cobra.Command, body *api.ApiSessionStartRequest) error {

--- a/internal/cmd/sessionstart_optout_test.go
+++ b/internal/cmd/sessionstart_optout_test.go
@@ -12,7 +12,6 @@ import (
 // opt-outs invert and the opt-outs themselves.
 func newOptOutCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "start", RunE: func(*cobra.Command, []string) error { return nil }}
-	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", false, "headless")
 	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "solve captchas")
 	cmd.Flags().BoolVar(&SessionStartUseFileStorage, "use-file-storage", false, "file storage")
 	registerSessionStartOptOutFlags(cmd)
@@ -22,7 +21,6 @@ func newOptOutCmd() *cobra.Command {
 func runOptOut(t *testing.T, args ...string) (*api.ApiSessionStartRequest, error) {
 	t.Helper()
 	// Package-level flag vars are shared; reset before each case.
-	sessionsStartHeaded = false
 	sessionsStartNoSolveCaptchas = false
 	sessionsStartNoFileStorage = false
 
@@ -43,9 +41,6 @@ func TestOptOutsLeaveBodyUntouchedWhenAbsent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("applySessionStartOptOuts() error = %v", err)
 	}
-	if body.Headless != nil {
-		t.Errorf("Headless = %v, want nil (unset) when --headed is omitted", *body.Headless)
-	}
 	if body.SolveCaptchas != nil {
 		t.Errorf("SolveCaptchas = %v, want nil when --no-solve-captchas is omitted", *body.SolveCaptchas)
 	}
@@ -62,20 +57,6 @@ func TestOptOutsInvertTheirCounterpart(t *testing.T) {
 		get   func(*api.ApiSessionStartRequest) *bool
 		want  bool
 	}{
-		{
-			name:  "--headed sends headless=false",
-			args:  []string{"--headed"},
-			field: "Headless",
-			get:   func(b *api.ApiSessionStartRequest) *bool { return b.Headless },
-			want:  false,
-		},
-		{
-			name:  "--headed=false sends headless=true",
-			args:  []string{"--headed=false"},
-			field: "Headless",
-			get:   func(b *api.ApiSessionStartRequest) *bool { return b.Headless },
-			want:  true,
-		},
 		{
 			name:  "--no-solve-captchas sends solve_captchas=false",
 			args:  []string{"--no-solve-captchas"},
@@ -114,8 +95,6 @@ func TestOptOutsInvertTheirCounterpart(t *testing.T) {
 // invisible.
 func TestConflictingPairIsRejected(t *testing.T) {
 	for _, args := range [][]string{
-		{"--headed", "--headless"},
-		{"--headed", "--headless=false"},
 		{"--no-solve-captchas", "--solve-captchas"},
 		{"--no-file-storage", "--use-file-storage"},
 	} {
@@ -131,7 +110,7 @@ func TestConflictingPairIsRejected(t *testing.T) {
 // when they cannot rely on the server default.
 func TestOriginalFlagsStillWorkAlone(t *testing.T) {
 	cmd := newOptOutCmd()
-	for _, name := range []string{"headless", "solve-captchas", "use-file-storage"} {
+	for _, name := range []string{"solve-captchas", "use-file-storage"} {
 		f := cmd.Flags().Lookup(name)
 		if f == nil {
 			t.Errorf("--%s should still be registered", name)
@@ -166,13 +145,12 @@ func TestConflictsRejectedBeforeSideEffects(t *testing.T) {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&SessionStartHeadless, "headless", false, "headless")
 	cmd.Flags().Bool("proxy", false, "proxy")
 	cmd.Flags().String("proxy-country", "", "proxy country")
 	registerSessionStartOptOutFlags(cmd)
 
 	for _, args := range [][]string{
-		{"--headed", "--headless"},
+		{"--no-solve-captchas", "--solve-captchas"},
 		{"--proxy", "--proxy-country=us"},
 	} {
 		ranRunE = false

--- a/tests/integration/errors_test.go
+++ b/tests/integration/errors_test.go
@@ -90,7 +90,7 @@ func TestErrorParsing_NonexistentProfile(t *testing.T) {
 
 func TestErrorParsing_InvalidSessionExecuteAction(t *testing.T) {
 	// Start a session first
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	if result.ExitCode != 0 {
 		t.Skipf("Could not start session for test: %s", result.Stderr)
 	}

--- a/tests/integration/json_output_test.go
+++ b/tests/integration/json_output_test.go
@@ -13,7 +13,7 @@ import (
 // Commands that produce invalid JSON will be logged and the test will fail.
 func TestJSONOutputValidity(t *testing.T) {
 	// Start a session for commands that need one
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -146,4 +146,3 @@ func TestJSONOutputValidity(t *testing.T) {
 		t.Logf("\nCommands with broken JSON output: %v", brokenCommands)
 	}
 }
-

--- a/tests/integration/page_commands_test.go
+++ b/tests/integration/page_commands_test.go
@@ -11,7 +11,7 @@ import (
 // startTestSession is a helper that starts a session and returns its ID
 func startTestSession(t *testing.T) string {
 	t.Helper()
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -318,7 +318,7 @@ func TestPageFormFill(t *testing.T) {
 // TestPageUsesCurrentSession tests that page commands use the current session when --session-id is not specified
 func TestPageUsesCurrentSession(t *testing.T) {
 	// Start a session (this sets the current session)
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {

--- a/tests/integration/page_test.go
+++ b/tests/integration/page_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPageObserve(t *testing.T) {
 	// Start a session first
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -42,7 +42,7 @@ func TestPageObserve(t *testing.T) {
 
 func TestPageExecuteAction(t *testing.T) {
 	// Start a session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -73,7 +73,7 @@ func TestPageExecuteAction(t *testing.T) {
 
 func TestPageScrapeBasic(t *testing.T) {
 	// Start a session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -108,7 +108,7 @@ func TestPageScrapeBasic(t *testing.T) {
 
 func TestPageScrapeWithInstructions(t *testing.T) {
 	// Start a session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -138,7 +138,7 @@ func TestPageScrapeWithInstructions(t *testing.T) {
 
 func TestPageScrapeOnlyMainContent(t *testing.T) {
 	// Start a session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -168,7 +168,7 @@ func TestPageScrapeOnlyMainContent(t *testing.T) {
 
 func TestPageObserveExecuteScrapeFlow(t *testing.T) {
 	// Start a session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {

--- a/tests/integration/sessions_test.go
+++ b/tests/integration/sessions_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestSessionsLifecycle(t *testing.T) {
 	// Start a new session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	// Parse the response to get session ID
@@ -50,7 +50,6 @@ func TestSessionsLifecycle(t *testing.T) {
 func TestSessionsStartWithOptions(t *testing.T) {
 	// Start session with custom options
 	result := runCLI(t, "sessions", "start",
-		"--headless",
 		"--browser-type", "chromium",
 		"--idle-timeout-minutes", "5",
 		"--max-duration-minutes", "10",
@@ -79,7 +78,7 @@ func TestSessionsStartWithOptions(t *testing.T) {
 
 func TestSessionsCookies(t *testing.T) {
 	// Start a session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -99,7 +98,7 @@ func TestSessionsCookies(t *testing.T) {
 
 func TestSessionsObserve(t *testing.T) {
 	// Start a session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -126,7 +125,7 @@ func TestSessionsObserve(t *testing.T) {
 
 func TestSessionsScrape(t *testing.T) {
 	// Start a session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -156,7 +155,7 @@ func TestSessionsScrape(t *testing.T) {
 
 func TestSessionsNetwork(t *testing.T) {
 	// Start a session
-	result := runCLI(t, "sessions", "start", "--headless")
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -192,8 +191,8 @@ func TestSessionsList(t *testing.T) {
 }
 
 func TestSessionsReplay(t *testing.T) {
-	// Start a headless session
-	result := runCLI(t, "sessions", "start", "--headless")
+	// Start a session
+	result := runCLI(t, "sessions", "start")
 	requireSuccess(t, result)
 
 	var startResp struct {

--- a/tests/integration/storage_test.go
+++ b/tests/integration/storage_test.go
@@ -56,7 +56,7 @@ func TestStorageUploadListAndDownload(t *testing.T) {
 
 func TestStorageDownloadFromSession(t *testing.T) {
 	// Start a session with file storage enabled
-	result := runCLI(t, "sessions", "start", "--headless", "--use-file-storage")
+	result := runCLI(t, "sessions", "start", "--use-file-storage")
 	requireSuccess(t, result)
 
 	var startResp struct {
@@ -86,7 +86,7 @@ func TestStorageListDownloadsRequiresSession(t *testing.T) {
 
 func TestStorageDownloadNonexistent(t *testing.T) {
 	// Start a session with file storage enabled
-	result := runCLI(t, "sessions", "start", "--headless", "--use-file-storage")
+	result := runCLI(t, "sessions", "start", "--use-file-storage")
 	requireSuccess(t, result)
 
 	var startResp struct {


### PR DESCRIPTION
## Summary
- regenerate the Go API client and session-start flags from the current staging OpenAPI schema
- use the new lightweight function-list response type
- remove the retired `headless`/`headed` session flags and their compatibility handling

This supersedes the generated-only update in #74, which no longer builds against the current staging schema.

## Validation
- `go test ./...`
- `go build ./cmd/notte`
- generated output reproduced with `make generate`