### PR TITLE
docs: drop retired --headed from README, cover --advanced-stealth

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Notte CLI brings the full power of [notte.cc](https://notte.cc?ref=github) t
 
 ## Features
 
-- **Browser sessions** - headless or headed Chromium/Chrome with full control
+- **Browser sessions** - remote Chromium/Chrome with full control
 - **Files** - upload and download files to notte.cc
 - **Output formats** - human-readable text or JSON for scripting
 - **Personas** - create and manage digital identities with email, phone, and SMS
@@ -73,8 +73,7 @@ notte auth status
 notte sessions start
 ```
 
-Sessions are headless by default. Add `--headed` for a visible browser, and
-watch it through the `ViewerUrl` in the output.
+Watch the session live through the `ViewerUrl` in the output.
 
 ## Commands
 
@@ -121,7 +120,6 @@ notte sessions code                   # Get Python script for session steps
 ```bash
 notte sessions start \
   --browser-type chromium|chrome  # Browser type (default: chromium)
-  --headed                                # Show a browser window (headless is the default)
   --idle-timeout-minutes <minutes>        # Idle timeout (default: 3)
   --max-duration-minutes <minutes>        # Maximum session lifetime (default: 15)
   --user-agent <string>                   # Custom user agent
@@ -132,6 +130,8 @@ notte sessions start \
   --no-solve-captchas                     # Turn OFF captcha solving (on by default)
   --no-file-storage                       # Detach FileStorage (attached by default).
                                           # Disables page download and files --from session
+  --advanced-stealth                      # Highest-fidelity browser for sites with
+                                          # sophisticated bot detection (approved workspaces)
   --cdp-url <url>                         # CDP URL of remote session provider
   --profile-id <id>                       # Profile ID to use for session
   --profile-persist                       # Save browser state to profile on close
@@ -415,7 +415,7 @@ Core workflow:
 
 ### Tips
 
-- **Viewing sessions**: When you start a session, the output includes a `ViewerUrl` - open it to watch the browser live, headless or not
+- **Viewing sessions**: When you start a session, the output includes a `ViewerUrl` - open it to watch the browser live
 - **Session lifetime**: sessions close after **3 minutes idle** or **15 minutes total** by default. Raise `--idle-timeout-minutes`/`--max-duration-minutes` for anything slow, or the next command fails with `Session closed`
 - **Element selectors**: If element IDs from `observe` (like `@B1`) don't work, use Playwright selectors: `#id`, `.class`, `button:has-text('Submit')`
 - **Multiple matches**: Use `>> nth=0` suffix to select the first match: `button:has-text('OK') >> nth=0`

--- a/internal/cmd/sessionstart_flags_test.go
+++ b/internal/cmd/sessionstart_flags_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newSessionStartFlagsCmd registers the real generated flag set, so these tests
+// exercise RegisterSessionStartFlags/BuildSessionStartRequest as a pair rather
+// than a hand-rolled duplicate that could drift from the generator.
+func newSessionStartFlagsCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "start", RunE: func(*cobra.Command, []string) error { return nil }}
+	// BoolVar and friends write the default into the package-level flag var, so
+	// registering per test is also what resets shared state between cases.
+	RegisterSessionStartFlags(cmd)
+	return cmd
+}
+
+// TestAdvancedStealthMapping covers the flag added by the OpenAPI regeneration
+// that introduced advanced_stealth. The nil case is the important one: omitting
+// the flag has to send nothing so the server default applies, and an explicit
+// value would freeze today's default into the client.
+func TestAdvancedStealthMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want *bool
+	}{
+		{name: "omitted sends nothing", args: nil, want: nil},
+		{name: "--advanced-stealth sends true", args: []string{"--advanced-stealth"}, want: boolPtr(true)},
+		{name: "--advanced-stealth=false sends false", args: []string{"--advanced-stealth=false"}, want: boolPtr(false)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := newSessionStartFlagsCmd()
+			cmd.SetArgs(tc.args)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute(%v) error = %v", tc.args, err)
+			}
+
+			body, err := BuildSessionStartRequest(cmd)
+			if err != nil {
+				t.Fatalf("BuildSessionStartRequest() error = %v", err)
+			}
+
+			switch {
+			case tc.want == nil && body.AdvancedStealth != nil:
+				t.Errorf("AdvancedStealth = %v, want nil (unset)", *body.AdvancedStealth)
+			case tc.want != nil && body.AdvancedStealth == nil:
+				t.Errorf("AdvancedStealth = nil, want %v", *tc.want)
+			case tc.want != nil && *body.AdvancedStealth != *tc.want:
+				t.Errorf("AdvancedStealth = %v, want %v", *body.AdvancedStealth, *tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/sessionstart_optout_test.go
+++ b/internal/cmd/sessionstart_optout_test.go
@@ -145,6 +145,10 @@ func TestConflictsRejectedBeforeSideEffects(t *testing.T) {
 			return nil
 		},
 	}
+	// --solve-captchas has to be registered here too: without it the pair below
+	// fails on cobra's "unknown flag" before PreRunE ever runs, so the case would
+	// pass without exercising validateSessionStartOptOuts at all.
+	cmd.Flags().BoolVar(&SessionStartSolveCaptchas, "solve-captchas", false, "solve captchas")
 	cmd.Flags().Bool("proxy", false, "proxy")
 	cmd.Flags().String("proxy-country", "", "proxy country")
 	registerSessionStartOptOutFlags(cmd)


### PR DESCRIPTION
Follow-up to #76, which removed the `headless`/`headed` session flags and added `--advanced-stealth`. Three gaps were left behind.

## 1. README documents a flag that no longer exists

`--headed` is still referenced in four places, so the documented command now fails with `unknown flag`:

- the Session Start Options block
- the getting-started paragraph ("Sessions are headless by default. Add `--headed`...")
- the Features bullet
- the Tips section

`--advanced-stealth` shipped in #76 but was never documented, so it's added to the options block.

## 2. A test that stopped testing anything

`TestConflictsRejectedBeforeSideEffects` exists to pin that flag conflicts are caught in `PreRunE`, *before* `runSessionsStart` stops the current session — otherwise a conflict costs the user their session and gives nothing back.

#76 removed the only `BoolVar` registration on its throwaway command. The `--no-solve-captchas`/`--solve-captchas` case then started failing on cobra's unknown-flag error instead of reaching `validateSessionStartOptOuts`. Probed against `c27cacd`:

```
PROBE [--no-solve-captchas --solve-captchas] -> unknown flag: --solve-captchas
PROBE [--proxy --proxy-country=us] -> proxy flags are mutually exclusive, got: --proxy, --proxy-country
```

The first case passed green while exercising none of the logic it names. Registering `--solve-captchas` restores the real path; a comment explains why the registration is load-bearing.

## 3. `--advanced-stealth` had no coverage

New `internal/cmd/sessionstart_flags_test.go` covers the flag-to-request mapping (this was also Greptile's third comment on #74):

- omitted → `AdvancedStealth == nil` — the load-bearing case, so the server default applies rather than freezing today's default into the client
- `--advanced-stealth` → `true`
- `--advanced-stealth=false` → `false`

It registers through the real `RegisterSessionStartFlags` rather than a hand-rolled duplicate, so it can't drift from the generator.

## Validation

- `go build ./...`
- `go vet ./...` and `go vet -tags=integration ./tests/integration/...`
- `go test -race -short ./...`
- `golangci-lint run` — no new findings (6 pre-existing staticcheck warnings in `pagination_test.go`/`skills_test.go`, untouched here; local lint is v2.8.0 vs the v2.12.0 CI pins)

## Out of scope

`notte-skills/` is a submodule and its `--headless` references need a separate PR in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)