### PR TITLE
Guard endpoint and command coverage in pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,14 @@ jobs:
             exit 1
           fi
 
+      # Both guards read a live source of truth, so they run with -strict: in CI
+      # an unreachable API or skills repository is a failure, not a skip.
+      - name: Check every API endpoint is exposed or explicitly skipped
+        run: make check-endpoints
+
+      - name: Check every command is documented in notte-skills
+        run: make check-skills
+
       - name: Test
         run: go test -v -race -short -coverprofile=coverage.out ./...
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: build install clean test test-integration test-all lint fmt generate check setup help
+.PHONY: build install clean test test-integration test-all lint fmt generate check setup help \
+        check-endpoints check-skills check-coverage
 
 VERSION ?= dev
 LDFLAGS := -ldflags "-X main.version=$(VERSION)"
@@ -71,6 +72,14 @@ fmt: ## Format code
 
 generate: ## Generate code (API client, etc.)
 	./scripts/generate.sh
+
+check-endpoints: ## Fail if an API endpoint is neither reachable from a command nor recorded as skipped
+	@go run ./scripts/checkcoverage -check endpoints -strict
+
+check-skills: ## Fail if a command is undocumented in the notte-skills repository
+	@go run ./scripts/checkcoverage -check skills -strict
+
+check-coverage: check-endpoints check-skills ## Run both coverage guards
 
 check: ## Verify generated code is up to date (fails if `make generate` would produce a diff)
 	@echo "Checking for local changes in generated files..."

--- a/README.md
+++ b/README.md
@@ -521,3 +521,31 @@ This project is licensed under the MIT License.
 - [Main repository (nottelabs/notte)](https://github.com/nottelabs/notte)
 
 Copyright © 2025 Notte Labs, Inc.
+
+## Coverage guards
+
+Two checks keep the CLI in step with what surrounds it. Both read a live source
+of truth, so both need the network; `make` runs them with `-strict`, where an
+unreachable source is a failure. The pre-commit hooks run them without it, so an
+offline commit warns and proceeds.
+
+```bash
+make check-endpoints   # every API endpoint is reachable or recorded as skipped
+make check-skills      # every command is documented in nottelabs/notte-skills
+make check-coverage    # both
+```
+
+`check-endpoints` compares the API's OpenAPI spec against the commands. An
+endpoint is covered when a command calls its generated client method; anything
+else has to be listed in [`scripts/endpoint-coverage.txt`](scripts/endpoint-coverage.txt)
+with a reason, as `manual` (a command builds the request itself) or `skip` (not
+exposed on purpose). A line whose endpoint the API no longer serves fails too,
+so the file cannot rot the way the flag generator's endpoint map did.
+
+`check-skills` walks the cobra tree and requires every non-hidden command to be
+mentioned somewhere under `plugins/notte/skills/` in the skills repository. Pass
+`-skills-dir <path>` to check against a working copy before pushing it:
+
+```bash
+go run ./scripts/checkcoverage -check skills -skills-dir ../notte-skills -strict
+```

--- a/internal/cmd/root_export.go
+++ b/internal/cmd/root_export.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+// RootCommand exposes the assembled command tree.
+//
+// Only the coverage checker in scripts/ uses it: enumerating commands by
+// walking cobra is the one way to get a list that cannot drift from the CLI,
+// which parsing --help output or maintaining a second list both can.
+func RootCommand() *cobra.Command {
+	return rootCmd
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,12 +28,21 @@ pre-commit:
     # notte-skills repository - so both need the network. Without -strict an
     # unreachable source is a warning rather than a blocked commit; CI runs the
     # same checks with -strict, so nothing merges on a skipped check.
+    # The globs cover what can invalidate each answer: a command change, the
+    # manifest itself, and the checker. A manifest-only commit is exactly when
+    # a bad line gets written, so leaving it out would skip the run that
+    # catches it.
     endpoint-coverage:
-      glob: "internal/cmd/*.go"
+      glob:
+        - "internal/cmd/*.go"
+        - "scripts/endpoint-coverage.txt"
+        - "scripts/checkcoverage/*.go"
       run: go run ./scripts/checkcoverage -check endpoints
 
     skill-coverage:
-      glob: "internal/cmd/*.go"
+      glob:
+        - "internal/cmd/*.go"
+        - "scripts/checkcoverage/*.go"
       run: go run ./scripts/checkcoverage -check skills
 
 pre-push:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,6 +24,18 @@ pre-commit:
           exit 1
         fi
 
+    # Both checks read a live source of truth - the API's spec, and the
+    # notte-skills repository - so both need the network. Without -strict an
+    # unreachable source is a warning rather than a blocked commit; CI runs the
+    # same checks with -strict, so nothing merges on a skipped check.
+    endpoint-coverage:
+      glob: "internal/cmd/*.go"
+      run: go run ./scripts/checkcoverage -check endpoints
+
+    skill-coverage:
+      glob: "internal/cmd/*.go"
+      run: go run ./scripts/checkcoverage -check skills
+
 pre-push:
   parallel: true
   commands:

--- a/scripts/checkcoverage/coverage_test.go
+++ b/scripts/checkcoverage/coverage_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+const testSpec = `{
+  "paths": {
+    "/functions": {"post": {"operationId": "function_create"}},
+    "/functions/{function_id}": {
+      "post":  {"operationId": "function_update"},
+      "patch": {"operationId": "function_metadata_update"}
+    },
+    "/mailboxes": {"get": {"operationId": "mailbox_list"}}
+  }
+}`
+
+func endpointsFor(t *testing.T) []Endpoint {
+	t.Helper()
+	endpoints, err := parseEndpoints([]byte(testSpec))
+	if err != nil {
+		t.Fatalf("parsing spec: %v", err)
+	}
+	return endpoints
+}
+
+// A path carrying two methods is two endpoints. Collapsing them is how
+// `functions update` (POST) and the metadata patch (PATCH) were treated as one.
+func TestParseEndpointsKeepsMethodsApart(t *testing.T) {
+	endpoints := endpointsFor(t)
+	if len(endpoints) != 4 {
+		t.Fatalf("got %d endpoints, want 4: %v", len(endpoints), endpoints)
+	}
+	var patch, post bool
+	for _, e := range endpoints {
+		if e.Path == "/functions/{function_id}" && e.Method == "PATCH" {
+			patch = true
+		}
+		if e.Path == "/functions/{function_id}" && e.Method == "POST" {
+			post = true
+		}
+	}
+	if !patch || !post {
+		t.Errorf("both methods on /functions/{function_id} should appear, got %v", endpoints)
+	}
+}
+
+// The failure this whole check exists for: the API grows an endpoint and
+// nothing in the repository notices.
+func TestUnwiredEndpointIsReported(t *testing.T) {
+	source := `FunctionCreateWithBodyWithResponse(ctx)
+	FunctionUpdateWithBodyWithResponse(ctx)
+	FunctionMetadataUpdateWithResponse(ctx)`
+
+	problems := checkEndpoints(endpointsFor(t), source, nil)
+	if len(problems) != 1 {
+		t.Fatalf("got %d problems, want 1: %v", len(problems), problems)
+	}
+	if !strings.Contains(problems[0], "GET /mailboxes") {
+		t.Errorf("expected the uncalled endpoint to be named, got %q", problems[0])
+	}
+	if !strings.Contains(problems[0], "endpoint-coverage.txt") {
+		t.Error("the message should say how to record the decision")
+	}
+}
+
+func TestRecordedExceptionSilencesTheEndpoint(t *testing.T) {
+	source := `FunctionCreateWithBodyWithResponse(ctx)
+	FunctionUpdateWithBodyWithResponse(ctx)
+	FunctionMetadataUpdateWithResponse(ctx)`
+	exceptions := []Exception{{Verdict: VerdictSkip, Method: "GET", Path: "/mailboxes", Reason: "console only", Line: 3}}
+
+	if problems := checkEndpoints(endpointsFor(t), source, exceptions); len(problems) != 0 {
+		t.Errorf("a recorded skip should pass, got %v", problems)
+	}
+}
+
+// The other half of the ratchet: an exception whose endpoint the API renamed
+// has to be noticed, or the file rots the way the flag generator's map did.
+func TestExceptionForAVanishedEndpointIsReported(t *testing.T) {
+	source := `FunctionCreateWithBodyWithResponse(ctx)
+	FunctionUpdateWithBodyWithResponse(ctx)
+	FunctionMetadataUpdateWithResponse(ctx)`
+	exceptions := []Exception{
+		{Verdict: VerdictSkip, Method: "GET", Path: "/mailboxes", Reason: "console only", Line: 3},
+		{Verdict: VerdictSkip, Method: "POST", Path: "/functions/schedule", Reason: "stale", Line: 4},
+	}
+
+	problems := checkEndpoints(endpointsFor(t), source, exceptions)
+	if len(problems) != 1 {
+		t.Fatalf("got %d problems, want 1: %v", len(problems), problems)
+	}
+	if !strings.Contains(problems[0], "/functions/schedule") {
+		t.Errorf("expected the stale line to be named, got %q", problems[0])
+	}
+}
+
+// A skip that stops being true should be deleted, not left asserting something
+// false about the CLI.
+func TestSkipContradictedByACallIsReported(t *testing.T) {
+	source := `MailboxListWithResponse(ctx)
+	FunctionCreateWithBodyWithResponse(ctx)
+	FunctionUpdateWithBodyWithResponse(ctx)
+	FunctionMetadataUpdateWithResponse(ctx)`
+	exceptions := []Exception{{Verdict: VerdictSkip, Method: "GET", Path: "/mailboxes", Reason: "console only", Line: 3}}
+
+	problems := checkEndpoints(endpointsFor(t), source, exceptions)
+	if len(problems) != 1 || !strings.Contains(problems[0], "drop the line") {
+		t.Fatalf("expected a contradiction to be reported, got %v", problems)
+	}
+}
+
+func TestManifestRequiresAReason(t *testing.T) {
+	if _, err := parseManifest([]byte("skip GET /mailboxes\n"), "test.txt"); err == nil {
+		t.Fatal("an exception without a reason should be rejected")
+	}
+	if _, err := parseManifest([]byte("maybe GET /mailboxes # hm\n"), "test.txt"); err == nil {
+		t.Fatal("an unknown verdict should be rejected")
+	}
+	if _, err := parseManifest([]byte("skip GET /a # one\nskip GET /a # two\n"), "test.txt"); err == nil {
+		t.Fatal("a duplicate entry should be rejected")
+	}
+
+	exceptions, err := parseManifest([]byte("# comment\n\nskip GET /mailboxes # console only\n"), "test.txt")
+	if err != nil {
+		t.Fatalf("valid manifest rejected: %v", err)
+	}
+	if len(exceptions) != 1 || exceptions[0].Reason != "console only" || exceptions[0].Line != 3 {
+		t.Errorf("unexpected parse: %+v", exceptions)
+	}
+}
+
+func TestOperationGoName(t *testing.T) {
+	for operation, want := range map[string]string{
+		"function_create":      "FunctionCreate",
+		"_connect_link_status": "ConnectLinkStatus",
+		"ready_check":          "ReadyCheck",
+	} {
+		if got := operationGoName(operation); got != want {
+			t.Errorf("operationGoName(%q) = %q, want %q", operation, got, want)
+		}
+	}
+}
+
+func testTree() *cobra.Command {
+	root := &cobra.Command{Use: "notte"}
+	functions := &cobra.Command{Use: "functions"}
+	functions.AddCommand(&cobra.Command{Use: "rollback"})
+	functions.AddCommand(&cobra.Command{Use: "run-metadata-update", Hidden: true})
+	root.AddCommand(functions)
+	root.AddCommand(&cobra.Command{Use: "search"})
+	return root
+}
+
+// Leaves, not groups: `notte functions` is not something to document, and a
+// hidden command is deliberately undocumented, so requiring prose for it would
+// contradict the reason it is hidden.
+func TestLeafCommandsSkipsGroupsAndHiddenCommands(t *testing.T) {
+	got := leafCommands(testTree())
+	want := []string{"notte functions rollback", "notte search"}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestUndocumentedCommandIsReported(t *testing.T) {
+	files := map[string]string{
+		"plugins/notte/skills/notte-functions-build/SKILL.md": "Run `notte search` to find things.",
+	}
+
+	problems := checkSkills(leafCommands(testTree()), files)
+	if len(problems) != 1 {
+		t.Fatalf("got %d problems, want 1: %v", len(problems), problems)
+	}
+	if !strings.Contains(problems[0], "notte functions rollback") {
+		t.Errorf("expected the undocumented command to be named, got %q", problems[0])
+	}
+}
+
+// A mention anywhere counts, in any file and across line breaks: which skill
+// documents which command is an editorial decision, not this check's business.
+func TestMentionIsFoundInAnyFileAndAcrossWhitespace(t *testing.T) {
+	files := map[string]string{
+		"plugins/notte/skills/notte-browser/references/function-management.md": "notte search",
+		"plugins/notte/skills/notte-functions-doctor/SKILL.md":                 "notte functions\n  rollback --version v1",
+	}
+
+	if problems := checkSkills(leafCommands(testTree()), files); len(problems) != 0 {
+		t.Errorf("both commands are documented, got %v", problems)
+	}
+}
+
+// "notte search" must not be satisfied by "notte searching", which is what a
+// plain substring match would accept.
+func TestMentionDoesNotMatchALongerWord(t *testing.T) {
+	files := map[string]string{"a.md": "notte searching the web"}
+
+	if mentions(files, "notte search") {
+		t.Error("a prefix of a longer word should not count as a mention")
+	}
+}

--- a/scripts/checkcoverage/endpoints.go
+++ b/scripts/checkcoverage/endpoints.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Endpoint is one operation in the OpenAPI spec.
+type Endpoint struct {
+	Method      string
+	Path        string
+	OperationID string
+}
+
+func (e Endpoint) String() string { return fmt.Sprintf("%s %s", e.Method, e.Path) }
+
+type spec struct {
+	Paths map[string]map[string]struct {
+		OperationID string `json:"operationId"`
+	} `json:"paths"`
+}
+
+var httpMethods = map[string]bool{
+	"get": true, "post": true, "put": true, "patch": true, "delete": true,
+}
+
+// parseEndpoints reads every operation out of an OpenAPI document.
+func parseEndpoints(data []byte) ([]Endpoint, error) {
+	var s spec
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("parsing OpenAPI spec: %w", err)
+	}
+
+	var endpoints []Endpoint
+	for path, item := range s.Paths {
+		for method, op := range item {
+			if !httpMethods[strings.ToLower(method)] {
+				continue
+			}
+			if op.OperationID == "" {
+				return nil, fmt.Errorf("%s %s has no operationId, which this check keys on",
+					strings.ToUpper(method), path)
+			}
+			endpoints = append(endpoints, Endpoint{
+				Method:      strings.ToUpper(method),
+				Path:        path,
+				OperationID: op.OperationID,
+			})
+		}
+	}
+	sort.Slice(endpoints, func(i, j int) bool {
+		if endpoints[i].Path != endpoints[j].Path {
+			return endpoints[i].Path < endpoints[j].Path
+		}
+		return endpoints[i].Method < endpoints[j].Method
+	})
+	return endpoints, nil
+}
+
+// operationGoName converts an operationId to the identifier oapi-codegen gives
+// its client method: connect_link_status -> ConnectLinkStatus. Leading
+// underscores mark the API's private operations and survive as nothing.
+func operationGoName(operationID string) string {
+	var b strings.Builder
+	for _, word := range strings.Split(operationID, "_") {
+		if word == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(word[:1]))
+		b.WriteString(word[1:])
+	}
+	return b.String()
+}
+
+// readCommandSources concatenates the hand-written command implementations.
+// Generated flag files and tests are left out: a call in either proves nothing
+// about what the CLI actually offers.
+func readCommandSources(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", dir, err)
+	}
+
+	var b strings.Builder
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") || strings.HasSuffix(name, ".gen.go") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return "", fmt.Errorf("reading %s: %w", name, err)
+		}
+		b.Write(data)
+		b.WriteString("\n")
+	}
+	return b.String(), nil
+}
+
+// callsGeneratedClient reports whether a command invokes the generated client
+// method for an operation. Both spellings count: multipart endpoints are called
+// through the WithBody variant.
+func callsGeneratedClient(source string, e Endpoint) bool {
+	name := operationGoName(e.OperationID)
+	return strings.Contains(source, name+"WithResponse(") ||
+		strings.Contains(source, name+"WithBodyWithResponse(")
+}
+
+// Verdict is how an endpoint that no command calls is accounted for.
+type Verdict string
+
+const (
+	// VerdictManual: a command reaches it without the generated client, by
+	// building the request itself.
+	VerdictManual Verdict = "manual"
+	// VerdictSkip: deliberately not exposed by the CLI.
+	VerdictSkip Verdict = "skip"
+)
+
+// Exception is one line of the coverage manifest.
+type Exception struct {
+	Verdict Verdict
+	Method  string
+	Path    string
+	Reason  string
+	Line    int
+}
+
+func (e Exception) key() string { return e.Method + " " + e.Path }
+
+// parseManifest reads scripts/endpoint-coverage.txt. Each line is
+//
+//	<verdict> <METHOD> <path> # <reason>
+//
+// The reason is required: an unexplained exception is how a gap becomes
+// permanent without anybody deciding that it should.
+func parseManifest(data []byte, filename string) ([]Exception, error) {
+	var exceptions []Exception
+	seen := map[string]int{}
+
+	for i, raw := range strings.Split(string(data), "\n") {
+		lineNo := i + 1
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		body, reason, hasReason := strings.Cut(line, "#")
+		fields := strings.Fields(body)
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("%s:%d: expected `<verdict> <METHOD> <path> # reason`, got %q",
+				filename, lineNo, line)
+		}
+		verdict := Verdict(fields[0])
+		if verdict != VerdictManual && verdict != VerdictSkip {
+			return nil, fmt.Errorf("%s:%d: unknown verdict %q, want %q or %q",
+				filename, lineNo, fields[0], VerdictManual, VerdictSkip)
+		}
+		reason = strings.TrimSpace(reason)
+		if !hasReason || reason == "" {
+			return nil, fmt.Errorf("%s:%d: %s %s has no reason after `#`",
+				filename, lineNo, fields[1], fields[2])
+		}
+
+		e := Exception{
+			Verdict: verdict,
+			Method:  strings.ToUpper(fields[1]),
+			Path:    fields[2],
+			Reason:  reason,
+			Line:    lineNo,
+		}
+		if first, dup := seen[e.key()]; dup {
+			return nil, fmt.Errorf("%s:%d: %s is already listed on line %d",
+				filename, lineNo, e.key(), first)
+		}
+		seen[e.key()] = lineNo
+		exceptions = append(exceptions, e)
+	}
+	return exceptions, nil
+}
+
+// checkEndpoints compares the live API against the CLI and its manifest.
+//
+// It reports three failures, and the second is the one this exists for: an
+// endpoint the API grew that nobody has decided about. The map of generated
+// flags could only ever catch entries that had gone stale, never an endpoint
+// that was never wired at all.
+func checkEndpoints(endpoints []Endpoint, source string, exceptions []Exception) []string {
+	byKey := map[string]Exception{}
+	for _, e := range exceptions {
+		byKey[e.key()] = e
+	}
+
+	var problems []string
+	live := map[string]bool{}
+
+	for _, e := range endpoints {
+		live[e.String()] = true
+		exception, listed := byKey[e.String()]
+		covered := callsGeneratedClient(source, e)
+
+		switch {
+		case covered && listed && exception.Verdict == VerdictSkip:
+			problems = append(problems, fmt.Sprintf(
+				"%s is listed as `skip` on line %d but a command now calls it — drop the line",
+				e, exception.Line))
+		case !covered && !listed:
+			problems = append(problems, fmt.Sprintf(
+				"%s (%s) is on the API but no CLI command calls it.\n"+
+					"      Add a command, or record the decision in scripts/endpoint-coverage.txt:\n"+
+					"        skip %s %s # why the CLI does not expose it",
+				e, e.OperationID, e.Method, e.Path))
+		}
+	}
+
+	for _, exception := range exceptions {
+		if !live[exception.key()] {
+			problems = append(problems, fmt.Sprintf(
+				"%s is listed on line %d but the API no longer serves it — the path was "+
+					"probably renamed, so remove or update the line",
+				exception.key(), exception.Line))
+		}
+	}
+
+	sort.Strings(problems)
+	return problems
+}
+
+// fetchSpec downloads an OpenAPI document.
+func fetchSpec(url string, timeout time.Duration) ([]byte, error) {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching %s: %s", url, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/scripts/checkcoverage/main.go
+++ b/scripts/checkcoverage/main.go
@@ -1,0 +1,157 @@
+// Command checkcoverage guards the two ways the CLI drifts out of step with
+// everything around it.
+//
+//	endpoints  every operation the API serves is either reachable from a
+//	           command or recorded as a deliberate omission
+//	skills     every command a user can run is mentioned in notte-skills
+//
+// Both read the live source of truth rather than a checked-in copy, so both
+// need the network. Without -strict a fetch failure is a warning and the check
+// passes: a pre-commit hook has to work on a train. CI runs with -strict, which
+// turns the same failure into an error.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nottelabs/notte-cli/internal/cmd"
+)
+
+const (
+	defaultSpecURL  = "https://us-staging.notte.cc/openapi.json"
+	defaultManifest = "scripts/endpoint-coverage.txt"
+	commandDir      = "internal/cmd"
+	fetchTimeout    = 30 * time.Second
+)
+
+func main() {
+	var (
+		which      = flag.String("check", "all", "which check to run: endpoints, skills, or all")
+		specURL    = flag.String("spec", envOr("NOTTE_API_URL", "")+"/openapi.json", "OpenAPI spec URL")
+		manifest   = flag.String("manifest", defaultManifest, "path to the endpoint coverage manifest")
+		skillsDir  = flag.String("skills-dir", "", "read notte-skills from this directory instead of GitHub")
+		strict     = flag.Bool("strict", false, "treat an unreachable source of truth as a failure")
+		repoRoot   = flag.String("root", "", "repository root (defaults to the working directory)")
+		exitStatus = 0
+	)
+	flag.Parse()
+
+	if *specURL == "/openapi.json" {
+		*specURL = defaultSpecURL
+	}
+	root := *repoRoot
+	if root == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			fail("cannot determine the working directory: %v", err)
+		}
+		root = wd
+	}
+
+	if *which == "all" || *which == "endpoints" {
+		if !runEndpointCheck(root, *specURL, *manifest, *strict) {
+			exitStatus = 1
+		}
+	}
+	if *which == "all" || *which == "skills" {
+		if !runSkillCheck(*skillsDir, *strict) {
+			exitStatus = 1
+		}
+	}
+
+	os.Exit(exitStatus)
+}
+
+func runEndpointCheck(root, specURL, manifest string, strict bool) bool {
+	data, err := fetchSpec(specURL, fetchTimeout)
+	if err != nil {
+		return degrade(strict, "endpoint coverage", err)
+	}
+
+	endpoints, err := parseEndpoints(data)
+	if err != nil {
+		fail("%v", err)
+	}
+
+	source, err := readCommandSources(filepath.Join(root, commandDir))
+	if err != nil {
+		fail("%v", err)
+	}
+
+	manifestPath := filepath.Join(root, manifest)
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		fail("reading %s: %v", manifest, err)
+	}
+	exceptions, err := parseManifest(manifestData, manifest)
+	if err != nil {
+		fail("%v", err)
+	}
+
+	problems := checkEndpoints(endpoints, source, exceptions)
+	return report("endpoint coverage",
+		fmt.Sprintf("%d endpoints, %d recorded exceptions", len(endpoints), len(exceptions)),
+		problems)
+}
+
+func runSkillCheck(skillsDir string, strict bool) bool {
+	var (
+		files map[string]string
+		err   error
+	)
+	if skillsDir != "" {
+		files, err = readLocalSkills(skillsDir)
+	} else {
+		files, err = fetchSkills(skillsTarball, fetchTimeout)
+	}
+	if err != nil {
+		return degrade(strict, "skill coverage", err)
+	}
+
+	commands := leafCommands(cmd.RootCommand())
+	problems := checkSkills(commands, files)
+	return report("skill coverage",
+		fmt.Sprintf("%d commands against %d skill files", len(commands), len(files)),
+		problems)
+}
+
+// degrade decides what an unreachable source of truth means. Offline, a
+// pre-commit hook that blocks the commit is worse than one that says so.
+func degrade(strict bool, name string, err error) bool {
+	if strict {
+		fmt.Fprintf(os.Stderr, "✗ %s: %v\n", name, err)
+		return false
+	}
+	fmt.Fprintf(os.Stderr, "⚠ %s skipped: %v\n", name, err)
+	return true
+}
+
+func report(name, summary string, problems []string) bool {
+	if len(problems) == 0 {
+		fmt.Printf("✓ %s: %s\n", name, summary)
+		return true
+	}
+	fmt.Fprintf(os.Stderr, "\n✗ %s: %d problem(s) across %s\n\n", name, len(problems), summary)
+	for _, p := range problems {
+		fmt.Fprintf(os.Stderr, "  · %s\n", p)
+	}
+	fmt.Fprintln(os.Stderr)
+	return false
+}
+
+func fail(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "Error: "+format+"\n", args...)
+	os.Exit(2)
+}
+
+func envOr(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/scripts/checkcoverage/main.go
+++ b/scripts/checkcoverage/main.go
@@ -53,6 +53,14 @@ func main() {
 		root = wd
 	}
 
+	// A misspelled -check used to run nothing and exit 0, which is the worst
+	// answer a guard can give: it reports success without having looked.
+	switch *which {
+	case "all", "endpoints", "skills":
+	default:
+		fail("unknown -check %q: want endpoints, skills, or all", *which)
+	}
+
 	if *which == "all" || *which == "endpoints" {
 		if !runEndpointCheck(root, *specURL, *manifest, *strict) {
 			exitStatus = 1

--- a/scripts/checkcoverage/skills.go
+++ b/scripts/checkcoverage/skills.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// skillsTarball is the notte-skills repository, which documents the CLI for
+	// agents. A tarball rather than a clone: one request, no git, no checkout to
+	// keep in sync.
+	skillsTarball = "https://codeload.github.com/nottelabs/notte-skills/tar.gz/refs/heads/main"
+	// skillsRoot is the directory inside that repository holding the skills.
+	skillsRoot = "plugins/notte/skills/"
+)
+
+// commandPath renders a command the way someone writes it in prose:
+// "notte functions rollback".
+func commandPath(c *cobra.Command) string {
+	var parts []string
+	for cur := c; cur != nil; cur = cur.Parent() {
+		parts = append([]string{cur.Name()}, parts...)
+	}
+	return strings.Join(parts, " ")
+}
+
+// leafCommands lists every command a user can actually run.
+//
+// Hidden commands are left out: they are deliberately undocumented, so
+// requiring documentation for them would be a contradiction. So are cobra's own
+// help and completion, which belong to cobra rather than to this CLI.
+func leafCommands(root *cobra.Command) []string {
+	var leaves []string
+
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		if c.Hidden || c.Name() == "help" || c.Name() == "completion" {
+			return
+		}
+		children := c.Commands()
+		runnable := false
+		for _, child := range children {
+			if !child.Hidden && child.Name() != "help" && child.Name() != "completion" {
+				runnable = true
+				walk(child)
+			}
+		}
+		if !runnable && c != root {
+			leaves = append(leaves, commandPath(c))
+		}
+	}
+	walk(root)
+
+	sort.Strings(leaves)
+	return leaves
+}
+
+// fetchSkills downloads the skills repository and returns every documentation
+// file under skillsRoot, keyed by path.
+func fetchSkills(url string, timeout time.Duration) (map[string]string, error) {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("fetching %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetching %s: %s", url, resp.Status)
+	}
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("decompressing skills archive: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+
+	files := map[string]string{}
+	reader := tar.NewReader(gz)
+	for {
+		header, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading skills archive: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		// Drop the "notte-skills-main/" prefix the archive wraps everything in.
+		name := header.Name
+		if i := strings.Index(name, "/"); i >= 0 {
+			name = name[i+1:]
+		}
+		if !strings.HasPrefix(name, skillsRoot) {
+			continue
+		}
+		content, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s from skills archive: %w", name, err)
+		}
+		files[name] = string(content)
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files under %s in the skills archive: has the layout moved?", skillsRoot)
+	}
+	return files, nil
+}
+
+// readLocalSkills reads the same files from a directory, for running the check
+// against a working copy of notte-skills instead of its main branch.
+func readLocalSkills(dir string) (map[string]string, error) {
+	files := map[string]string{}
+	root := filepath.Join(dir, filepath.FromSlash(skillsRoot))
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			return relErr
+		}
+		files[filepath.ToSlash(rel)] = string(data)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reading skills from %s: %w", dir, err)
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no skill files under %s", root)
+	}
+	return files, nil
+}
+
+// mentions reports whether the skills document a command anywhere.
+//
+// The match is on the command path with flexible whitespace, so a line broken
+// across a continuation still counts, and it deliberately does not require the
+// mention to be in any particular file: which skill covers which command is an
+// editorial decision, and this check only cares that one of them does.
+func mentions(files map[string]string, command string) bool {
+	pattern := regexp.MustCompile(`\b` + strings.Join(splitEscaped(command), `\s+`) + `\b`)
+	for _, content := range files {
+		if pattern.MatchString(content) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitEscaped(command string) []string {
+	parts := strings.Fields(command)
+	for i, p := range parts {
+		parts[i] = regexp.QuoteMeta(p)
+	}
+	return parts
+}
+
+// checkSkills reports every command the skills never mention.
+func checkSkills(commands []string, files map[string]string) []string {
+	var problems []string
+	for _, command := range commands {
+		if !mentions(files, command) {
+			problems = append(problems, fmt.Sprintf(
+				"`%s` is not mentioned anywhere in %s.\n"+
+					"      Document it in the notte-skills repository, or hide the command if it is not for users.",
+				command, skillsRoot))
+		}
+	}
+	return problems
+}

--- a/scripts/endpoint-coverage.txt
+++ b/scripts/endpoint-coverage.txt
@@ -1,0 +1,68 @@
+# Endpoints the CLI does not reach through the generated client.
+#
+# Every operation the API serves has to be accounted for: either a command calls
+# its generated client method - which needs no line here, the checker sees the
+# call - or it is listed below with a reason. `make check-endpoints` fails on an
+# endpoint that is neither, so an operation the API grows cannot go unnoticed
+# the way `functions configure`, `rollback` and `health` did.
+#
+#   <verdict> <METHOD> <path> # <reason>
+#
+#   manual  a command reaches it, but builds the request itself
+#   skip    deliberately not exposed by the CLI
+#
+# A line whose path the API no longer serves is also a failure: that is how six
+# entries in the flag generator's endpoint map came to point at nothing.
+
+# --- reached by hand-written requests ---------------------------------------
+manual POST /functions/{function_id}/runs/start # notte functions run builds the body itself to send function_id and variables
+manual POST /sessions/{session_id}/page/screenshot # notte page screenshot writes the image bytes out rather than decoding JSON
+manual GET  /storage/uploads/{filename} # notte files download streams to disk
+manual POST /storage/{session_id}/downloads/{filename} # notte files upload streams from disk
+
+# --- removed from the CLI ----------------------------------------------------
+skip GET    /agents # agents were removed from the CLI in #64
+skip POST   /agents/start # agents were removed from the CLI in #64
+skip GET    /agents/{agent_id} # agents were removed from the CLI in #64
+skip DELETE /agents/{agent_id}/stop # agents were removed from the CLI in #64
+skip GET    /agents/{agent_id}/workflow/code # agents were removed from the CLI in #64
+
+# --- superseded by a session-scoped equivalent -------------------------------
+skip POST /scrape # use notte page scrape, which runs in a session
+skip POST /scrape_from_html # use notte page scrape, which runs in a session
+skip POST /prompts/improve # console-only prompt tooling
+skip POST /prompts/nudge # console-only prompt tooling
+
+# --- browser-first flows the CLI has no shape for ----------------------------
+skip POST   /managed-auth/connect-links # connect links are created and consumed in a browser
+skip POST   /managed-auth/connect-links/context # private endpoint serving the connect-link page
+skip POST   /managed-auth/connect-links/mailboxes # private endpoint serving the connect-link page
+skip POST   /managed-auth/connect-links/mailboxes/connect # private endpoint serving the connect-link page
+skip POST   /managed-auth/connect-links/mailboxes/sync # private endpoint serving the connect-link page
+skip GET    /managed-auth/connect-links/status # private endpoint serving the connect-link page
+skip POST   /managed-auth/connect-links/submit # private endpoint serving the connect-link page
+skip GET    /mailboxes # mailboxes are managed from the console, not the CLI
+skip POST   /mailboxes/connect-token # mailboxes are managed from the console, not the CLI
+skip POST   /mailboxes/sync # mailboxes are managed from the console, not the CLI
+skip GET    /mailboxes/{mailbox_id} # mailboxes are managed from the console, not the CLI
+skip PATCH  /mailboxes/{mailbox_id} # mailboxes are managed from the console, not the CLI
+skip DELETE /mailboxes/{mailbox_id} # mailboxes are managed from the console, not the CLI
+
+# --- excluded from code generation, so no client method exists ---------------
+# See scripts/excluded-endpoints.txt, which strips these before oapi-codegen runs.
+skip POST   /vaults/{vault_id}/card # excluded from codegen: credit-card handling is console-only
+skip GET    /vaults/{vault_id}/card # excluded from codegen: credit-card handling is console-only
+skip DELETE /vaults/{vault_id}/card # excluded from codegen: credit-card handling is console-only
+
+# --- infrastructure, not a user-facing operation -----------------------------
+skip GET  /ready # load-balancer probe
+skip POST /anything/start # anything.notte.cc entry point, not a CLI workflow
+
+# --- not exposed yet ---------------------------------------------------------
+# Each of these is a gap someone should close or rule out; listing them is the
+# point of this file, not an endorsement.
+skip PATCH /personas/{persona_id} # no `personas update` command yet
+skip POST  /profiles/{profile_id}/cookies # no `profiles cookies-set` command yet
+skip GET   /profiles/{profile_id}/cookies # no `profiles cookies` command yet
+skip POST  /profiles/{profile_id}/duplicate # `profiles duplicate` is proposed in #53
+skip GET   /usage/logs # no `usage logs` command yet


### PR DESCRIPTION
> **Merge order:** `check-skills` fails on this branch until nottelabs/notte-skills#42 merges. That PR documents the six commands this check finds missing — three of which this repo shipped in #84. The red run is the check working on its first outing, not a fault in it.

## Why

Two surprises in a row came from the same shape of gap: something existed outside this repository and nothing here noticed.

- `functions configure`, `rollback` and `health` were on the API for months with no command. The flag generator's endpoint map could only ever catch entries that had gone *stale*, never an endpoint nobody wired at all.
- Once those commands existed, they shipped undocumented — the skills repo still describes a CLI without them.

Both are now checks that run in pre-commit and CI.

## `make check-endpoints`

Reads the API's spec and the command sources. An endpoint counts as covered when a command calls its generated client method — no list to maintain, the call is the evidence. Anything else has to appear in [`scripts/endpoint-coverage.txt`](scripts/endpoint-coverage.txt) with a reason:

```
manual POST /functions/{function_id}/runs/start # notte functions run builds the body itself
skip   GET  /mailboxes                          # mailboxes are managed from the console
```

Today that's **94 endpoints and 36 recorded exceptions**, and writing them down is most of the value — the file is now the inventory of what the CLI deliberately doesn't do, including five gaps nobody had actually decided about (`personas update`, `profiles cookies`/`duplicate`, `usage logs`).

It fails in **three** directions:

| | |
|---|---|
| An endpoint no command calls and no line explains | the motivating case |
| A line whose endpoint the API no longer serves | exactly how six entries in the flag generator's map came to point at nothing |
| A `skip` contradicted by a command that now calls it | so the file can't quietly become false |

## `make check-skills`

Walks the cobra tree and requires every non-hidden command to be mentioned somewhere under `plugins/notte/skills/` in nottelabs/notte-skills. Hidden commands are exempt by construction — they're deliberately undocumented, so demanding prose for them would contradict the reason they're hidden. A mention in *any* file counts: which skill covers which command is an editorial decision this check has no business making.

Run it against a working copy before pushing the docs:

```bash
go run ./scripts/checkcoverage -check skills -skills-dir ../notte-skills -strict
```

## Network

Both read a live source of truth. Without `-strict` an unreachable source is a warning and the check passes — a pre-commit hook has to work on a train. CI runs both with `-strict`, so nothing merges on a skipped check.

## Verification

- Endpoint check passes against the live spec: `✓ 94 endpoints, 36 recorded exceptions`
- Injected a fake `POST /widgets/new` into the spec → correctly failed, naming the endpoint and printing the manifest line to add
- Offline: warns and exits 0; with `-strict` exits 1
- Skill check reports exactly the six undocumented commands, `notte functions rollback` among them; passes against the #42 working copy
- Unit tests cover both checkers, including the stale-line and contradicted-skip cases and a `notte search` / `notte searching` prefix guard

## One thing to know

`lefthook` reads `lefthook.yml`; the `.lefthook.yml` sitting beside it is **dead config** (`lefthook dump` confirms which is live). Edits to the wrong one silently do nothing. I added the hooks to the live file and left the other alone rather than delete something this change didn't need to touch — but it's a trap worth clearing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)