### PR TITLE
chore: regenerate API client from latest OpenAPI spec

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -2036,6 +2036,7 @@ type LlmModel string
 type MailboxConnectRequest struct {
 	AllowedOrigin      string                         `json:"allowed_origin"`
 	ErrorRedirectUri   string                         `json:"error_redirect_uri"`
+	MailboxId          *string                        `json:"mailbox_id,omitempty"`
 	Provider           *MailboxConnectRequestProvider `json:"provider,omitempty"`
 	SuccessRedirectUri string                         `json:"success_redirect_uri"`
 }


### PR DESCRIPTION
Automated regeneration of the generated API client (`internal/api`, `internal/cmd/*_flags.gen.go`) from the latest OpenAPI spec.

**Last regenerated:** 2026-08-31 23:26 UTC