### PR TITLE
Add function download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ notte functions list [--page N] [--page-size N] [--include-deleted]  # List func
 notte functions create --file workflow.py  # Create a new function
 notte functions show                  # View current function details
 notte functions show --function-id <id>  # View specific function details (different from current function)
+notte functions download workflow.py [--version <version>]  # Download current function code to disk
 notte functions create --file workflow.py --response-format @schema.json  # ... with its response documented
 notte functions update --file workflow.py  # Update current function code
 notte functions update --file workflow.py --response-format @schema.json  # ... and re-document its response

--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -25,6 +25,7 @@ var (
 	functionRunVariablesJSON string   // Variables as JSON string
 	functionRunNoStream      bool     // Opt out of log streaming
 	functionSecretValue      string
+	functionDownloadVersion  string
 )
 
 // GetCurrentFunctionID returns the function ID from flag, env var, or file (in priority order)
@@ -110,6 +111,13 @@ var functionsShowCmd = &cobra.Command{
 	Short: "Show function details",
 	Args:  cobra.NoArgs,
 	RunE:  runFunctionShow,
+}
+
+var functionsDownloadCmd = &cobra.Command{
+	Use:   "download <file-path>",
+	Short: "Download function code to disk",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFunctionDownload,
 }
 
 var functionsUpdateCmd = &cobra.Command{
@@ -260,6 +268,7 @@ func init() {
 
 	functionsCmd.AddCommand(functionsCreateCmd)
 	functionsCmd.AddCommand(functionsShowCmd)
+	functionsCmd.AddCommand(functionsDownloadCmd)
 	functionsCmd.AddCommand(functionsUpdateCmd)
 	functionsCmd.AddCommand(functionsConfigureCmd)
 	functionsCmd.AddCommand(functionsRollbackCmd)
@@ -287,6 +296,10 @@ func init() {
 
 	// Show command flags
 	functionsShowCmd.Flags().StringVar(&functionID, "function-id", "", "Function ID (uses current function if not specified)")
+
+	// Download command flags
+	functionsDownloadCmd.Flags().StringVar(&functionID, "function-id", "", "Function ID (uses current function if not specified)")
+	functionsDownloadCmd.Flags().StringVar(&functionDownloadVersion, "version", "", "Function version (defaults to latest)")
 
 	// Update command flags
 	functionsUpdateCmd.Flags().StringVar(&functionID, "function-id", "", "Function ID (uses current function if not specified)")
@@ -457,6 +470,47 @@ func runFunctionShow(cmd *cobra.Command, args []string) error {
 	}
 
 	return GetFormatter().Print(resp.JSON200)
+}
+
+func runFunctionDownload(cmd *cobra.Command, args []string) error {
+	if err := RequireFunctionID(); err != nil {
+		return err
+	}
+
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := GetContextWithTimeout(cmd.Context())
+	defer cancel()
+
+	params := &api.FunctionDownloadUrlParams{}
+	if functionDownloadVersion != "" {
+		params.Version = &functionDownloadVersion
+	}
+	resp, err := client.Client().FunctionDownloadUrlWithResponse(ctx, functionID, params)
+	if err != nil {
+		return fmt.Errorf("API request failed: %w", err)
+	}
+	if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return err
+	}
+	if resp.JSON200 == nil || resp.JSON200.Url == "" {
+		return errors.New("no download URL in response")
+	}
+
+	outputPath := args[0]
+	if err := downloadFileWithContext(ctx, resp.JSON200.Url, outputPath); err != nil {
+		return fmt.Errorf("failed to download function: %w", err)
+	}
+
+	return PrintResult(fmt.Sprintf("Function downloaded successfully: %s", outputPath), map[string]any{
+		"function_id": functionID,
+		"path":        outputPath,
+		"version":     functionDownloadVersion,
+		"success":     true,
+	})
 }
 
 func runFunctionUpdate(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -473,6 +473,11 @@ func runFunctionShow(cmd *cobra.Command, args []string) error {
 }
 
 func runFunctionDownload(cmd *cobra.Command, args []string) error {
+	outputPath := args[0]
+	if !strings.HasSuffix(outputPath, ".py") {
+		return errors.New("file path must end with .py")
+	}
+
 	if err := RequireFunctionID(); err != nil {
 		return err
 	}
@@ -500,15 +505,18 @@ func runFunctionDownload(cmd *cobra.Command, args []string) error {
 		return errors.New("no download URL in response")
 	}
 
-	outputPath := args[0]
 	if err := downloadFileWithContext(ctx, resp.JSON200.Url, outputPath); err != nil {
 		return fmt.Errorf("failed to download function: %w", err)
+	}
+	downloadedVersion := functionDownloadVersion
+	if downloadedVersion == "" {
+		downloadedVersion = resp.JSON200.LatestVersion
 	}
 
 	return PrintResult(fmt.Sprintf("Function downloaded successfully: %s", outputPath), map[string]any{
 		"function_id": functionID,
 		"path":        outputPath,
-		"version":     functionDownloadVersion,
+		"version":     downloadedVersion,
 		"success":     true,
 	})
 }

--- a/internal/cmd/functions_test.go
+++ b/internal/cmd/functions_test.go
@@ -412,6 +412,58 @@ func TestRunFunctionDownload_WithVersion(t *testing.T) {
 	}
 }
 
+func TestRunFunctionDownload_ReportsLatestVersion(t *testing.T) {
+	server := setupFunctionTest(t)
+	fileServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("def run():\n\treturn None\n"))
+	}))
+	t.Cleanup(fileServer.Close)
+
+	response := `{"function_id":"` + functionIDTest + `","latest_version":"v2","status":"active","created_at":"2020-01-01T00:00:00Z","updated_at":"2020-01-01T00:00:00Z","versions":["v1","v2"],"url":` + strconv.Quote(fileServer.URL) + `}`
+	server.AddResponse("/functions/"+functionIDTest, http.StatusOK, response)
+
+	origVersion := functionDownloadVersion
+	origFormat := outputFormat
+	functionDownloadVersion = ""
+	outputFormat = "json"
+	t.Cleanup(func() {
+		functionDownloadVersion = origVersion
+		outputFormat = origFormat
+	})
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	outputPath := filepath.Join(t.TempDir(), "function.py")
+	stdout, _ := testutil.CaptureOutput(func() {
+		if err := runFunctionDownload(cmd, []string{outputPath}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	var result struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if result.Version != "v2" {
+		t.Fatalf("reported version = %q, want %q", result.Version, "v2")
+	}
+	if requests := server.Requests("/functions/" + functionIDTest); len(requests) != 1 || requests[0].Query != "" {
+		t.Fatalf("latest download sent an unexpected query: %+v", requests)
+	}
+}
+
+func TestRunFunctionDownload_RequiresPythonPath(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := runFunctionDownload(cmd, []string{"function.txt"})
+	if err == nil || err.Error() != "file path must end with .py" {
+		t.Fatalf("error = %v, want file extension error", err)
+	}
+}
+
 func TestRunFunctionUpdate(t *testing.T) {
 	server := setupFunctionTest(t)
 	server.AddResponse("/functions/"+functionIDTest, 200, functionJSON())

--- a/internal/cmd/functions_test.go
+++ b/internal/cmd/functions_test.go
@@ -3,8 +3,11 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -366,6 +369,46 @@ func TestRunFunctionShow(t *testing.T) {
 
 	if stdout == "" {
 		t.Error("expected output, got empty string")
+	}
+}
+
+func TestRunFunctionDownload_WithVersion(t *testing.T) {
+	server := setupFunctionTest(t)
+	const functionCode = "def run():\n\treturn 'downloaded'\n"
+	fileServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(functionCode))
+	}))
+	t.Cleanup(fileServer.Close)
+
+	response := `{"function_id":"` + functionIDTest + `","latest_version":"v2","status":"active","created_at":"2020-01-01T00:00:00Z","updated_at":"2020-01-01T00:00:00Z","versions":["v1","v2"],"url":` + strconv.Quote(fileServer.URL) + `}`
+	server.AddResponse("/functions/"+functionIDTest, http.StatusOK, response)
+
+	origVersion := functionDownloadVersion
+	functionDownloadVersion = "v1"
+	t.Cleanup(func() { functionDownloadVersion = origVersion })
+
+	outputPath := filepath.Join(t.TempDir(), "function.py")
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	if err := runFunctionDownload(cmd, []string{outputPath}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("failed to read downloaded function: %v", err)
+	}
+	if string(content) != functionCode {
+		t.Fatalf("downloaded content = %q, want %q", string(content), functionCode)
+	}
+
+	requests := server.Requests("/functions/" + functionIDTest)
+	if len(requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(requests))
+	}
+	if requests[0].Query != "version=v1" {
+		t.Fatalf("query = %q, want %q", requests[0].Query, "version=v1")
 	}
 }
 

--- a/tests/integration/functions_test.go
+++ b/tests/integration/functions_test.go
@@ -112,6 +112,42 @@ func TestFunctionsCreateThenDelete(t *testing.T) {
 	t.Log("Function create then delete test completed successfully")
 }
 
+func TestFunctionsDownloadVersion(t *testing.T) {
+	tmpFile := createTempFunctionFile(t)
+	result := runCLI(t, "functions", "create", "--file", tmpFile, "--name", "download-integration-test")
+	requireSuccess(t, result)
+
+	var createResp struct {
+		FunctionID    string `json:"function_id"`
+		LatestVersion string `json:"latest_version"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &createResp); err != nil {
+		t.Fatalf("Failed to parse create response: %v", err)
+	}
+	if createResp.FunctionID == "" || createResp.LatestVersion == "" {
+		t.Fatalf("Create response is missing function ID or version: %+v", createResp)
+	}
+	defer cleanupFunction(t, createResp.FunctionID)
+
+	outputPath := filepath.Join(t.TempDir(), "downloaded-function.py")
+	result = runCLI(t, "functions", "download", outputPath,
+		"--function-id", createResp.FunctionID,
+		"--version", createResp.LatestVersion)
+	requireSuccess(t, result)
+
+	downloaded, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("Failed to read downloaded function: %v", err)
+	}
+	original, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Failed to read original function: %v", err)
+	}
+	if !bytes.Equal(downloaded, original) {
+		t.Fatalf("Downloaded function does not match uploaded function\nwant: %q\ngot:  %q", original, downloaded)
+	}
+}
+
 func TestFunctionSecretsLifecycle(t *testing.T) {
 	secretName := "INTEGRATION_SECRET_" + strings.NewReplacer("-", "_", ":", "_", ".", "_").Replace(time.Now().UTC().Format(time.RFC3339Nano))
 	secretValue := "integration-secret-value"


### PR DESCRIPTION
## Summary
- add `notte functions download <file-path>`
- support downloading a specific function version with `--version`
- require Python (`.py`) destination paths
- report the resolved latest version when `--version` is omitted
- reuse atomic, context-aware file downloads
- document the command and add unit plus live integration coverage
- update the notte-skills submodule; skill documentation PR: nottelabs/notte-skills#43

## Testing
- `go test ./...`
- `go run ./scripts/checkcoverage -check skills -strict -skills-dir notte-skills`
- `go test -c -tags=integration -o /tmp/notte-cli-integration.test ./tests/integration`

The live integration suite was not run locally because `NOTTE_API_KEY` is unavailable in the workspace. The CLI skill-coverage CI check depends on nottelabs/notte-skills#43 merging because the strict check reads the notte-skills `main` branch.