### PR TITLE
chore: regenerate API client from latest OpenAPI spec

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -1499,6 +1499,9 @@ type FunctionListItemResponse struct {
 	// Description The description of the workflow
 	Description *string `json:"description,omitempty"`
 
+	// Domain The site this function drives, used to group endpoints in the console. Null when the function never named a site.
+	Domain *string `json:"domain,omitempty"`
+
 	// FunctionId The ID of the function
 	FunctionId string `json:"function_id"`
 
@@ -1538,7 +1541,10 @@ type FunctionListItemResponse struct {
 
 // FunctionMetadataUpdateRequest defines model for FunctionMetadataUpdateRequest.
 type FunctionMetadataUpdateRequest struct {
+	Description  *string `json:"description,omitempty"`
+	Domain       *string `json:"domain,omitempty"`
 	Instructions *string `json:"instructions,omitempty"`
+	Name         *string `json:"name,omitempty"`
 	SelfHealing  *bool   `json:"self_healing,omitempty"`
 }
 
@@ -1549,6 +1555,9 @@ type FunctionResponse struct {
 
 	// Description The description of the workflow
 	Description *string `json:"description,omitempty"`
+
+	// Domain The site this function drives, used to group endpoints in the console. Null when the function never named a site.
+	Domain *string `json:"domain,omitempty"`
 
 	// FunctionId The ID of the function
 	FunctionId string `json:"function_id"`
@@ -1698,6 +1707,9 @@ type FunctionWithLinkResponse struct {
 
 	// Description The description of the workflow
 	Description *string `json:"description,omitempty"`
+
+	// Domain The site this function drives, used to group endpoints in the console. Null when the function never named a site.
+	Domain *string `json:"domain,omitempty"`
 
 	// FunctionId The ID of the function
 	FunctionId string `json:"function_id"`

--- a/internal/cmd/functionconfigure_flags.gen.go
+++ b/internal/cmd/functionconfigure_flags.gen.go
@@ -9,8 +9,14 @@ import (
 
 // FunctionConfigure command flags
 var (
+	FunctionConfigureDescription string
+
+	FunctionConfigureDomain string
+
 	// Notes for whoever calls this function: how long a run takes, what the variables mean, what it trips over
 	FunctionConfigureInstructions string
+
+	FunctionConfigureName string
 
 	// Let an agent repair the function when a run fails
 	FunctionConfigureSelfHealing bool
@@ -18,7 +24,10 @@ var (
 
 // RegisterFunctionConfigureFlags registers all flags for FunctionConfigure command
 func RegisterFunctionConfigureFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&FunctionConfigureDescription, "description", "", "description")
+	cmd.Flags().StringVar(&FunctionConfigureDomain, "domain", "", "domain")
 	cmd.Flags().StringVar(&FunctionConfigureInstructions, "run-instructions", "", "Notes for whoever calls this function: how long a run takes, what the variables mean, what it trips over")
+	cmd.Flags().StringVar(&FunctionConfigureName, "name", "", "name")
 	cmd.Flags().BoolVar(&FunctionConfigureSelfHealing, "self-healing", false, "Let an agent repair the function when a run fails")
 }
 
@@ -26,8 +35,20 @@ func RegisterFunctionConfigureFlags(cmd *cobra.Command) {
 func BuildFunctionConfigureRequest(cmd *cobra.Command) (*api.FunctionMetadataUpdateRequest, error) {
 	body := &api.FunctionMetadataUpdateRequest{}
 
+	if FunctionConfigureDescription != "" {
+		body.Description = &FunctionConfigureDescription
+	}
+
+	if FunctionConfigureDomain != "" {
+		body.Domain = &FunctionConfigureDomain
+	}
+
 	if FunctionConfigureInstructions != "" {
 		body.Instructions = &FunctionConfigureInstructions
+	}
+
+	if FunctionConfigureName != "" {
+		body.Name = &FunctionConfigureName
 	}
 
 	if cmd.Flags().Changed("self-healing") {


### PR DESCRIPTION
Automated regeneration of the generated API client (`internal/api`, `internal/cmd/*_flags.gen.go`) from the latest OpenAPI spec.

**Last regenerated:** 2026-09-02 10:31 UTC