### PR TITLE
Allow functions configure to set name, description, and domain alone

### DIFF
--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -129,13 +129,13 @@ var functionsUpdateCmd = &cobra.Command{
 
 var functionsConfigureCmd = &cobra.Command{
 	Use:   "configure",
-	Short: "Set usage notes and self-healing",
+	Short: "Update function metadata",
 	Long: "Update a function's metadata.\n\n" +
+		"Pass any of --name, --description, --domain, --run-instructions, or --self-healing. " +
+		"Only the flags you pass are sent; omitted fields are left unchanged.\n\n" +
 		"--run-instructions is documentation for whoever calls the function - how long a " +
 		"run takes, what each variable is for, which sites it trips over. It is not " +
-		"input to the self-healing agent.\n\n" +
-		"Only the flags you pass are sent, so setting instructions leaves self-healing " +
-		"as it was, and vice versa.",
+		"input to the self-healing agent.",
 	Args: cobra.NoArgs,
 	RunE: runFunctionConfigure,
 }
@@ -565,14 +565,30 @@ func runFunctionConfigure(cmd *cobra.Command, args []string) error {
 
 	// An empty PATCH is accepted by the API and changes nothing, which reads as
 	// success for a command that did not do what the caller meant.
-	if !cmd.Flags().Changed("run-instructions") && !cmd.Flags().Changed("self-healing") {
-		return errors.New("nothing to configure: pass --run-instructions, --self-healing, or both")
+	stringFlags := []struct {
+		name  string
+		value string
+	}{
+		{"name", FunctionConfigureName},
+		{"description", FunctionConfigureDescription},
+		{"domain", FunctionConfigureDomain},
+		{"run-instructions", FunctionConfigureInstructions},
 	}
-	// `--run-instructions ""` is refused rather than sent. The generated builder
-	// omits an empty string, so it would otherwise travel as far as an empty
-	// PATCH: accepted, 200, nothing changed, and the caller told it worked.
-	if cmd.Flags().Changed("run-instructions") && FunctionConfigureInstructions == "" {
-		return errors.New("--run-instructions cannot be empty")
+	anyChanged := cmd.Flags().Changed("self-healing")
+	for _, f := range stringFlags {
+		if !cmd.Flags().Changed(f.name) {
+			continue
+		}
+		anyChanged = true
+		// Empty strings are refused rather than sent. The generated builder
+		// omits them, so they would otherwise travel as an empty PATCH:
+		// accepted, 200, nothing changed, and the caller told it worked.
+		if f.value == "" {
+			return fmt.Errorf("--%s cannot be empty", f.name)
+		}
+	}
+	if !anyChanged {
+		return errors.New("nothing to configure: pass --name, --description, --domain, --run-instructions, and/or --self-healing")
 	}
 
 	client, err := GetClient()

--- a/internal/cmd/functionsextra_test.go
+++ b/internal/cmd/functionsextra_test.go
@@ -18,6 +18,9 @@ func configureCmd(t *testing.T) *cobra.Command {
 	RegisterFunctionConfigureFlags(cmd)
 	cmd.SetContext(context.Background())
 	t.Cleanup(func() {
+		FunctionConfigureName = ""
+		FunctionConfigureDescription = ""
+		FunctionConfigureDomain = ""
 		FunctionConfigureInstructions = ""
 		FunctionConfigureSelfHealing = false
 	})
@@ -112,7 +115,7 @@ func TestFunctionConfigure_RefusesToSendNothing(t *testing.T) {
 
 	err := runFunctionConfigure(configureCmd(t), nil)
 	if err == nil {
-		t.Fatal("expected an error when neither flag is passed")
+		t.Fatal("expected an error when no configure flags are passed")
 	}
 	if !strings.Contains(err.Error(), "nothing to configure") {
 		t.Fatalf("unexpected error: %v", err)
@@ -122,27 +125,78 @@ func TestFunctionConfigure_RefusesToSendNothing(t *testing.T) {
 	}
 }
 
+// Metadata fields added by the OpenAPI regen must be sendable on their own;
+// otherwise configure only works when paired with the older flags.
+func TestFunctionConfigure_SendsMetadataFieldsAlone(t *testing.T) {
+	for _, tc := range []struct {
+		flag  string
+		value string
+		field string
+	}{
+		{flag: "name", value: "checkout", field: "name"},
+		{flag: "description", value: "buys the cart", field: "description"},
+		{flag: "domain", value: "shop.example", field: "domain"},
+	} {
+		t.Run(tc.flag, func(t *testing.T) {
+			server := setupFunctionTest(t)
+			server.AddResponse("/functions/"+functionIDTest, 200, functionJSON())
+
+			origFormat := outputFormat
+			outputFormat = "json"
+			t.Cleanup(func() { outputFormat = origFormat })
+
+			cmd := configureCmd(t)
+			if err := cmd.Flags().Set(tc.flag, tc.value); err != nil {
+				t.Fatalf("setting --%s: %v", tc.flag, err)
+			}
+
+			testutil.CaptureOutput(func() {
+				if err := runFunctionConfigure(cmd, nil); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			body := requestBody(t, server.Requests("/functions/"+functionIDTest)[0])
+			if body[tc.field] != tc.value {
+				t.Errorf("%s = %v, want %q", tc.field, body[tc.field], tc.value)
+			}
+			for _, absent := range []string{"instructions", "self_healing", "name", "description", "domain"} {
+				if absent == tc.field {
+					continue
+				}
+				if _, present := body[absent]; present {
+					t.Errorf("%s was sent for a call that only passed --%s", absent, tc.flag)
+				}
+			}
+		})
+	}
+}
+
 // The generated builder sends an optional string only when it is non-empty, so
-// `--run-instructions ""` would reach the API as an empty PATCH: 200, nothing
-// changed, and the caller told it worked. Refused up front instead.
-func TestFunctionConfigure_RejectsEmptyInstructions(t *testing.T) {
-	server := setupFunctionTest(t)
-	server.AddResponse("/functions/"+functionIDTest, 200, functionJSON())
+// `--flag ""` would reach the API as an empty PATCH: 200, nothing changed, and
+// the caller told it worked. Refused up front instead.
+func TestFunctionConfigure_RejectsEmptyStringFlags(t *testing.T) {
+	for _, flag := range []string{"name", "description", "domain", "run-instructions"} {
+		t.Run(flag, func(t *testing.T) {
+			server := setupFunctionTest(t)
+			server.AddResponse("/functions/"+functionIDTest, 200, functionJSON())
 
-	cmd := configureCmd(t)
-	if err := cmd.Flags().Set("run-instructions", ""); err != nil {
-		t.Fatalf("setting --run-instructions: %v", err)
-	}
+			cmd := configureCmd(t)
+			if err := cmd.Flags().Set(flag, ""); err != nil {
+				t.Fatalf("setting --%s: %v", flag, err)
+			}
 
-	err := runFunctionConfigure(cmd, nil)
-	if err == nil {
-		t.Fatal("expected an error for --run-instructions \"\"")
-	}
-	if !strings.Contains(err.Error(), "cannot be empty") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(server.Requests("/functions/"+functionIDTest)) != 0 {
-		t.Error("an empty --run-instructions still reached the API")
+			err := runFunctionConfigure(cmd, nil)
+			if err == nil {
+				t.Fatalf("expected an error for --%s \"\"", flag)
+			}
+			if !strings.Contains(err.Error(), "cannot be empty") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(server.Requests("/functions/"+functionIDTest)) != 0 {
+				t.Errorf("an empty --%s still reached the API", flag)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/functionsextra_test.go
+++ b/internal/cmd/functionsextra_test.go
@@ -156,7 +156,7 @@ func TestFunctionConfigure_SendsMetadataFieldsAlone(t *testing.T) {
 				}
 			})
 
-			body := requestBody(t, server.Requests("/functions/"+functionIDTest)[0])
+			body := requestBody(t, server.Requests("/functions/" + functionIDTest)[0])
 			if body[tc.field] != tc.value {
 				t.Errorf("%s = %v, want %q", tc.field, body[tc.field], tc.value)
 			}

--- a/tests/integration/functions_test.go
+++ b/tests/integration/functions_test.go
@@ -509,8 +509,7 @@ func TestFunctionsConfigureMetadata(t *testing.T) {
 
 	result = runCLI(t, "functions", "configure",
 		"--function-id", functionID,
-		"--run-instructions", "retry the login step",
-		"--self-healing")
+		"--run-instructions", "retry the login step")
 	requireSuccess(t, result)
 
 	result = runCLI(t, "functions", "show", "--function-id", functionID)
@@ -519,8 +518,15 @@ func TestFunctionsConfigureMetadata(t *testing.T) {
 	if ptrVal(meta.Instructions) != "retry the login step" {
 		t.Fatalf("instructions after configure = %q", ptrVal(meta.Instructions))
 	}
-	if meta.SelfHealing == nil || !*meta.SelfHealing {
-		t.Fatalf("self_healing after configure = %v, want true", meta.SelfHealing)
+
+	// CLI-created functions have no agent thread, so the API refuses self-healing.
+	result = runCLI(t, "functions", "configure",
+		"--function-id", functionID,
+		"--self-healing")
+	requireFailure(t, result)
+	combined := result.Stdout + result.Stderr
+	if !containsString(combined, "self_healing") && !containsString(combined, "thread") {
+		t.Fatalf("expected API rejection of self-healing on a CLI function, got stdout=%q stderr=%q", result.Stdout, result.Stderr)
 	}
 
 	// Empty PATCH and empty string values must fail before hitting a no-op success.

--- a/tests/integration/functions_test.go
+++ b/tests/integration/functions_test.go
@@ -426,6 +426,119 @@ func TestFunctionsUpdate(t *testing.T) {
 	t.Logf("Updated function: %s (new version: %s, total versions: %d)", functionID, updateResp.LatestVersion, len(updateResp.Versions))
 }
 
+func TestFunctionsConfigureMetadata(t *testing.T) {
+	tmpFile := createTempFunctionFile(t)
+
+	result := runCLI(t, "functions", "create", "--file", tmpFile, "--name", "configure-metadata-source")
+	requireSuccess(t, result)
+
+	var createResp struct {
+		FunctionID string `json:"function_id"`
+	}
+	if err := json.Unmarshal([]byte(result.Stdout), &createResp); err != nil {
+		t.Fatalf("Failed to parse create response: %v", err)
+	}
+	functionID := createResp.FunctionID
+	if functionID == "" {
+		t.Fatal("No function ID returned from create command")
+	}
+	defer cleanupFunction(t, functionID)
+
+	type functionMeta struct {
+		FunctionID   string  `json:"function_id"`
+		Name         *string `json:"name"`
+		Description  *string `json:"description"`
+		Domain       *string `json:"domain"`
+		Instructions *string `json:"instructions"`
+		SelfHealing  *bool   `json:"self_healing"`
+	}
+	parseShow := func(stdout string) functionMeta {
+		t.Helper()
+		var meta functionMeta
+		if err := json.Unmarshal([]byte(stdout), &meta); err != nil {
+			t.Fatalf("Failed to parse function show response: %v\nstdout: %s", err, stdout)
+		}
+		return meta
+	}
+	ptrVal := func(p *string) string {
+		if p == nil {
+			return ""
+		}
+		return *p
+	}
+
+	// Each metadata field must be sendable alone against the live endpoint.
+	result = runCLI(t, "functions", "configure",
+		"--function-id", functionID,
+		"--name", "configure-metadata-renamed")
+	requireSuccess(t, result)
+
+	result = runCLI(t, "functions", "show", "--function-id", functionID)
+	requireSuccess(t, result)
+	meta := parseShow(result.Stdout)
+	if ptrVal(meta.Name) != "configure-metadata-renamed" {
+		t.Fatalf("name after --name configure = %q, want configure-metadata-renamed", ptrVal(meta.Name))
+	}
+
+	result = runCLI(t, "functions", "configure",
+		"--function-id", functionID,
+		"--description", "integration metadata description")
+	requireSuccess(t, result)
+
+	result = runCLI(t, "functions", "show", "--function-id", functionID)
+	requireSuccess(t, result)
+	meta = parseShow(result.Stdout)
+	if ptrVal(meta.Description) != "integration metadata description" {
+		t.Fatalf("description after --description configure = %q", ptrVal(meta.Description))
+	}
+	if ptrVal(meta.Name) != "configure-metadata-renamed" {
+		t.Fatalf("name changed after --description-only configure: %q", ptrVal(meta.Name))
+	}
+
+	result = runCLI(t, "functions", "configure",
+		"--function-id", functionID,
+		"--domain", "shop.example")
+	requireSuccess(t, result)
+
+	result = runCLI(t, "functions", "show", "--function-id", functionID)
+	requireSuccess(t, result)
+	meta = parseShow(result.Stdout)
+	if ptrVal(meta.Domain) != "shop.example" {
+		t.Fatalf("domain after --domain configure = %q, want shop.example", ptrVal(meta.Domain))
+	}
+
+	result = runCLI(t, "functions", "configure",
+		"--function-id", functionID,
+		"--run-instructions", "retry the login step",
+		"--self-healing")
+	requireSuccess(t, result)
+
+	result = runCLI(t, "functions", "show", "--function-id", functionID)
+	requireSuccess(t, result)
+	meta = parseShow(result.Stdout)
+	if ptrVal(meta.Instructions) != "retry the login step" {
+		t.Fatalf("instructions after configure = %q", ptrVal(meta.Instructions))
+	}
+	if meta.SelfHealing == nil || !*meta.SelfHealing {
+		t.Fatalf("self_healing after configure = %v, want true", meta.SelfHealing)
+	}
+
+	// Empty PATCH and empty string values must fail before hitting a no-op success.
+	result = runCLI(t, "functions", "configure", "--function-id", functionID)
+	requireFailure(t, result)
+	if !containsString(result.Stderr, "nothing to configure") && !containsString(result.Stdout, "nothing to configure") {
+		t.Fatalf("expected nothing-to-configure error, got stdout=%q stderr=%q", result.Stdout, result.Stderr)
+	}
+
+	result = runCLI(t, "functions", "configure", "--function-id", functionID, "--name", "")
+	requireFailure(t, result)
+	if !containsString(result.Stderr, "cannot be empty") && !containsString(result.Stdout, "cannot be empty") {
+		t.Fatalf("expected empty-name error, got stdout=%q stderr=%q", result.Stdout, result.Stderr)
+	}
+
+	t.Log("Function configure metadata path exercised against live API")
+}
+
 func TestFunctionsShowNonexistent(t *testing.T) {
 	// Try to show a non-existent function
 	result := runCLI(t, "functions", "show", "--function-id", "00000000-0000-0000-0000-000000000000")


### PR DESCRIPTION
## Summary
- After #91 regenerated `--name`, `--description`, and `--domain` on `notte functions configure`, the hand-written guard still required `--run-instructions` or `--self-healing`, so the new flags could not be used alone.
- Accept any of the metadata flags, reject empty string values the same way as `--run-instructions`, and update the command help text.
- Add coverage for sending each new field alone and for empty-string rejection.

## Test plan
- [x] `go test ./internal/cmd/ -run 'TestFunctionConfigure_' -count=1`
- [ ] `notte functions configure --function-id <id> --name checkout` succeeds without other flags
- [ ] `notte functions configure --function-id <id> --domain shop.example --description "..."` PATCHes only those fields
- [ ] `notte functions configure --function-id <id>` still errors with "nothing to configure"
- [ ] `notte functions configure --function-id <id> --name ""` errors with "cannot be empty"


Made with [Cursor](https://cursor.com)