### PR TITLE
feat(personas): expose public and internal emails

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -2337,11 +2337,14 @@ type PersonaCreateRequest struct {
 
 // PersonaResponse defines model for PersonaResponse.
 type PersonaResponse struct {
-	// Email Email of the persona
+	// Email Public, human-readable email address of the persona
 	Email string `json:"email"`
 
 	// FirstName First name of the persona
 	FirstName string `json:"first_name"`
+
+	// InternalEmail Internal UUID-backed mailbox address of the persona
+	InternalEmail string `json:"internal_email"`
 
 	// LastName Last name of the persona
 	LastName string  `json:"last_name"`

--- a/internal/cmd/personas_test.go
+++ b/internal/cmd/personas_test.go
@@ -30,11 +30,11 @@ func setupPersonaTest(t *testing.T) *testutil.MockServer {
 }
 
 func personaJSON(id string) string {
-	return `{"persona_id":"` + id + `","email":"test@example.com","first_name":"Test","last_name":"User","status":"active"}`
+	return `{"persona_id":"` + id + `","email":"test.user@mail-sand.com","internal_email":"` + id + `@mail-sand.com","first_name":"Test","last_name":"User","status":"active"}`
 }
 
 func personaResponseJSON() string {
-	return `{"persona_id":"` + personaIDTest + `","email":"test@example.com","first_name":"Test","last_name":"User","status":"active"}`
+	return personaJSON(personaIDTest)
 }
 
 func TestRunPersonasList_Success(t *testing.T) {
@@ -63,6 +63,12 @@ func TestRunPersonasList_Success(t *testing.T) {
 
 	if stdout == "" {
 		t.Error("expected output, got empty string")
+	}
+	if !strings.Contains(stdout, `"email":"test.user@mail-sand.com"`) {
+		t.Errorf("expected public email in output, got %q", stdout)
+	}
+	if !strings.Contains(stdout, `"internal_email":"persona_1@mail-sand.com"`) {
+		t.Errorf("expected internal email in output, got %q", stdout)
 	}
 }
 


### PR DESCRIPTION
## Summary

- regenerate the persona response model with the public `email` and UUID-backed `internal_email` fields
- preserve both fields in JSON output from `notte personas list`, `create`, and `show`
- cover the public and internal addresses in the persona command test

Depends on nottelabs/monorepo#2520 for the API response contract.

## Testing

- `go test ./internal/cmd ./internal/api`
