### PR TITLE
chore: regenerate API client from latest OpenAPI spec

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -1561,6 +1561,9 @@ type FunctionResponse struct {
 	ReferenceWorkflowId *string   `json:"reference_workflow_id,omitempty"`
 	RequiredSecrets     *[]string `json:"required_secrets,omitempty"`
 
+	// ResponseFormat JSON Schema of the value run() returns, or null when the author never documented one.
+	ResponseFormat *map[string]interface{} `json:"response_format,omitempty"`
+
 	// ScheduleCron Cron expression the function runs on, or null if it is not scheduled.
 	ScheduleCron *string `json:"schedule_cron,omitempty"`
 
@@ -1712,6 +1715,9 @@ type FunctionWithLinkResponse struct {
 	// ReferenceWorkflowId The ID of the reference workflow (i.e wether the workflow was forked from another workflow or not)
 	ReferenceWorkflowId *string   `json:"reference_workflow_id,omitempty"`
 	RequiredSecrets     *[]string `json:"required_secrets,omitempty"`
+
+	// ResponseFormat JSON Schema of the value run() returns, or null when the author never documented one.
+	ResponseFormat *map[string]interface{} `json:"response_format,omitempty"`
 
 	// ScheduleCron Cron expression the function runs on, or null if it is not scheduled.
 	ScheduleCron *string `json:"schedule_cron,omitempty"`
@@ -1924,6 +1930,7 @@ type GotoAction struct {
 	Description *string `json:"description,omitempty"`
 	Type        *string `json:"type,omitempty"`
 	Url         string  `json:"url"`
+	WaitUntil   *string `json:"wait_until,omitempty"`
 }
 
 // GotoNewTabAction defines model for GotoNewTabAction.

--- a/internal/api/client_gen_test.go
+++ b/internal/api/client_gen_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestGotoActionUnionRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		roundTrip func(GotoAction) ([]byte, GotoAction, error)
+	}{
+		{
+			name: "action space actions",
+			roundTrip: func(input GotoAction) ([]byte, GotoAction, error) {
+				var union ActionSpace_Actions_Item
+				if err := union.FromGotoAction(input); err != nil {
+					return nil, GotoAction{}, err
+				}
+				encoded, err := json.Marshal(union)
+				if err != nil {
+					return nil, GotoAction{}, err
+				}
+				var decoded ActionSpace_Actions_Item
+				if err := json.Unmarshal(encoded, &decoded); err != nil {
+					return nil, GotoAction{}, err
+				}
+				output, err := decoded.AsGotoAction()
+				return encoded, output, err
+			},
+		},
+		{
+			name: "action space browser actions",
+			roundTrip: func(input GotoAction) ([]byte, GotoAction, error) {
+				var union ActionSpace_BrowserActions_Item
+				if err := union.FromGotoAction(input); err != nil {
+					return nil, GotoAction{}, err
+				}
+				encoded, err := json.Marshal(union)
+				if err != nil {
+					return nil, GotoAction{}, err
+				}
+				var decoded ActionSpace_BrowserActions_Item
+				if err := json.Unmarshal(encoded, &decoded); err != nil {
+					return nil, GotoAction{}, err
+				}
+				output, err := decoded.AsGotoAction()
+				return encoded, output, err
+			},
+		},
+		{
+			name: "API execution response action",
+			roundTrip: func(input GotoAction) ([]byte, GotoAction, error) {
+				var union ApiExecutionResponse_Action
+				if err := union.FromGotoAction(input); err != nil {
+					return nil, GotoAction{}, err
+				}
+				encoded, err := json.Marshal(union)
+				if err != nil {
+					return nil, GotoAction{}, err
+				}
+				var decoded ApiExecutionResponse_Action
+				if err := json.Unmarshal(encoded, &decoded); err != nil {
+					return nil, GotoAction{}, err
+				}
+				output, err := decoded.AsGotoAction()
+				return encoded, output, err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			waitUntil := "load"
+			encoded, output, err := tt.roundTrip(GotoAction{
+				Url:       "https://example.com",
+				WaitUntil: &waitUntil,
+			})
+			if err != nil {
+				t.Fatalf("round trip goto action: %v", err)
+			}
+
+			var object map[string]interface{}
+			if err := json.Unmarshal(encoded, &object); err != nil {
+				t.Fatalf("unmarshal encoded action: %v", err)
+			}
+			if got := object["type"]; got != "goto" {
+				t.Fatalf("type = %v, want goto", got)
+			}
+			if output.Type == nil || *output.Type != "goto" {
+				t.Fatalf("round-tripped type = %v, want goto", output.Type)
+			}
+			if got := output.Url; got != "https://example.com" {
+				t.Fatalf("round-tripped url = %v, want https://example.com", got)
+			}
+			if output.WaitUntil == nil || *output.WaitUntil != "load" {
+				t.Fatalf("round-tripped wait_until = %v, want load", output.WaitUntil)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Automated regeneration of the generated API client (`internal/api`, `internal/cmd/*_flags.gen.go`) from the latest OpenAPI spec.

**Last regenerated:** 2026-09-07 16:04 UTC