### PR TITLE
chore: regenerate API client from latest OpenAPI spec

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -426,6 +426,12 @@ const (
 	Zw ProxyGeolocationCountry = "zw"
 )
 
+// Defines values for RunFunctionRequestRuntime.
+const (
+	Extended RunFunctionRequestRuntime = "extended"
+	Standard RunFunctionRequestRuntime = "standard"
+)
+
 // Defines values for SecretNamespace.
 const (
 	FunctionEnv SecretNamespace = "function_env"
@@ -2419,6 +2425,28 @@ type ProfileResponse struct {
 	UpdatedAt FlexibleTime `json:"updated_at"`
 }
 
+// ProxyCredentialRequest defines model for ProxyCredentialRequest.
+type ProxyCredentialRequest struct {
+	// City Evomi city id or display name, e.g. `new.york`. Wins over country.
+	City *string `json:"city,omitempty"`
+
+	// Country ISO 3166-1 alpha-2 country code, e.g. `us`.
+	Country *string `json:"country,omitempty"`
+}
+
+// ProxyCredentialResponse defines model for ProxyCredentialResponse.
+type ProxyCredentialResponse struct {
+	ExpiresAt FlexibleTime `json:"expires_at"`
+	Password  string       `json:"password"`
+
+	// ProxyUrlPlain `http://user:pass@host:3128`, for clients that cannot.
+	ProxyUrlPlain string `json:"proxy_url_plain"`
+
+	// ProxyUrlTls `https://user:pass@host:443`, for clients that do TLS to the proxy.
+	ProxyUrlTls string `json:"proxy_url_tls"`
+	Username    string `json:"username"`
+}
+
 // ProxyGeolocationCountry defines model for ProxyGeolocationCountry.
 type ProxyGeolocationCountry string
 
@@ -2443,6 +2471,9 @@ type RootModelAny = interface{}
 
 // RunFunctionRequest defines model for RunFunctionRequest.
 type RunFunctionRequest struct {
+	// Runtime standard uses Lambda; extended uses the configured AgentCore runtime.
+	Runtime *RunFunctionRequestRuntime `json:"runtime,omitempty"`
+
 	// Stream Whether to stream logs, or only return final response
 	Stream *bool `json:"stream,omitempty"`
 
@@ -2452,6 +2483,9 @@ type RunFunctionRequest struct {
 	// WorkflowId The ID of the function to run
 	WorkflowId string `json:"workflow_id"`
 }
+
+// RunFunctionRequestRuntime standard uses Lambda; extended uses the configured AgentCore runtime.
+type RunFunctionRequestRuntime string
 
 // RuntimePackage defines model for RuntimePackage.
 type RuntimePackage struct {
@@ -3281,6 +3315,7 @@ type ListFunctionRunsByFunctionIdParams struct {
 // FunctionRunStartParams defines parameters for FunctionRunStart.
 type FunctionRunStartParams struct {
 	XNotteApiKey        string  `json:"x-notte-api-key"`
+	XDbPreview          *string `json:"x-db-preview,omitempty"`
 	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
@@ -3517,6 +3552,12 @@ type ProfileCookiesSetParams struct {
 
 // ProfileDuplicateParams defines parameters for ProfileDuplicate.
 type ProfileDuplicateParams struct {
+	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
+	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
+}
+
+// MintProxyCredentialsParams defines parameters for MintProxyCredentials.
+type MintProxyCredentialsParams struct {
 	XNotteRequestOrigin *string `json:"x-notte-request-origin,omitempty"`
 	XNotteSdkVersion    *string `json:"x-notte-sdk-version,omitempty"`
 }
@@ -3869,6 +3910,9 @@ type ProfileCookiesSetJSONRequestBody = ProfileCookiesImportRequest
 
 // ProfileDuplicateJSONRequestBody defines body for ProfileDuplicate for application/json ContentType.
 type ProfileDuplicateJSONRequestBody = ProfileDuplicateRequest
+
+// MintProxyCredentialsJSONRequestBody defines body for MintProxyCredentials for application/json ContentType.
+type MintProxyCredentialsJSONRequestBody = ProxyCredentialRequest
 
 // SearchWebJSONRequestBody defines body for SearchWeb for application/json ContentType.
 type SearchWebJSONRequestBody = SearchRequest
@@ -9652,6 +9696,11 @@ type ClientInterface interface {
 
 	ProfileDuplicate(ctx context.Context, profileId string, params *ProfileDuplicateParams, body ProfileDuplicateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// MintProxyCredentialsWithBody request with any body
+	MintProxyCredentialsWithBody(ctx context.Context, params *MintProxyCredentialsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	MintProxyCredentials(ctx context.Context, params *MintProxyCredentialsParams, body MintProxyCredentialsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ReadyCheck request
 	ReadyCheck(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -10596,6 +10645,30 @@ func (c *Client) ProfileDuplicateWithBody(ctx context.Context, profileId string,
 
 func (c *Client) ProfileDuplicate(ctx context.Context, profileId string, params *ProfileDuplicateParams, body ProfileDuplicateJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewProfileDuplicateRequest(c.Server, profileId, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) MintProxyCredentialsWithBody(ctx context.Context, params *MintProxyCredentialsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMintProxyCredentialsRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) MintProxyCredentials(ctx context.Context, params *MintProxyCredentialsParams, body MintProxyCredentialsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewMintProxyCredentialsRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -12621,26 +12694,37 @@ func NewFunctionRunStartRequestWithBody(server string, functionId string, params
 
 		req.Header.Set("x-notte-api-key", headerParam0)
 
-		if params.XNotteRequestOrigin != nil {
+		if params.XDbPreview != nil {
 			var headerParam1 string
 
-			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-db-preview", runtime.ParamLocationHeader, *params.XDbPreview)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("x-notte-request-origin", headerParam1)
+			req.Header.Set("x-db-preview", headerParam1)
+		}
+
+		if params.XNotteRequestOrigin != nil {
+			var headerParam2 string
+
+			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-request-origin", headerParam2)
 		}
 
 		if params.XNotteSdkVersion != nil {
-			var headerParam2 string
+			var headerParam3 string
 
-			headerParam2, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
+			headerParam3, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
 			if err != nil {
 				return nil, err
 			}
 
-			req.Header.Set("x-notte-sdk-version", headerParam2)
+			req.Header.Set("x-notte-sdk-version", headerParam3)
 		}
 
 	}
@@ -14857,6 +14941,72 @@ func NewProfileDuplicateRequestWithBody(server string, profileId string, params 
 	}
 
 	operationPath := fmt.Sprintf("/profiles/%s/duplicate", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.XNotteRequestOrigin != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "x-notte-request-origin", runtime.ParamLocationHeader, *params.XNotteRequestOrigin)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-request-origin", headerParam0)
+		}
+
+		if params.XNotteSdkVersion != nil {
+			var headerParam1 string
+
+			headerParam1, err = runtime.StyleParamWithLocation("simple", false, "x-notte-sdk-version", runtime.ParamLocationHeader, *params.XNotteSdkVersion)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("x-notte-sdk-version", headerParam1)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewMintProxyCredentialsRequest calls the generic MintProxyCredentials builder with application/json body
+func NewMintProxyCredentialsRequest(server string, params *MintProxyCredentialsParams, body MintProxyCredentialsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewMintProxyCredentialsRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewMintProxyCredentialsRequestWithBody generates requests for MintProxyCredentials with any type of body
+func NewMintProxyCredentialsRequestWithBody(server string, params *MintProxyCredentialsParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/proxies/gateway/credentials")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -17957,6 +18107,11 @@ type ClientWithResponsesInterface interface {
 
 	ProfileDuplicateWithResponse(ctx context.Context, profileId string, params *ProfileDuplicateParams, body ProfileDuplicateJSONRequestBody, reqEditors ...RequestEditorFn) (*ProfileDuplicateResult, error)
 
+	// MintProxyCredentialsWithBodyWithResponse request with any body
+	MintProxyCredentialsWithBodyWithResponse(ctx context.Context, params *MintProxyCredentialsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MintProxyCredentialsResult, error)
+
+	MintProxyCredentialsWithResponse(ctx context.Context, params *MintProxyCredentialsParams, body MintProxyCredentialsJSONRequestBody, reqEditors ...RequestEditorFn) (*MintProxyCredentialsResult, error)
+
 	// ReadyCheckWithResponse request
 	ReadyCheckWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ReadyCheckResult, error)
 
@@ -19225,6 +19380,29 @@ func (r ProfileDuplicateResult) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ProfileDuplicateResult) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type MintProxyCredentialsResult struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ProxyCredentialResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r MintProxyCredentialsResult) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r MintProxyCredentialsResult) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -20633,6 +20811,23 @@ func (c *ClientWithResponses) ProfileDuplicateWithResponse(ctx context.Context, 
 		return nil, err
 	}
 	return ParseProfileDuplicateResult(rsp)
+}
+
+// MintProxyCredentialsWithBodyWithResponse request with arbitrary body returning *MintProxyCredentialsResult
+func (c *ClientWithResponses) MintProxyCredentialsWithBodyWithResponse(ctx context.Context, params *MintProxyCredentialsParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MintProxyCredentialsResult, error) {
+	rsp, err := c.MintProxyCredentialsWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMintProxyCredentialsResult(rsp)
+}
+
+func (c *ClientWithResponses) MintProxyCredentialsWithResponse(ctx context.Context, params *MintProxyCredentialsParams, body MintProxyCredentialsJSONRequestBody, reqEditors ...RequestEditorFn) (*MintProxyCredentialsResult, error) {
+	rsp, err := c.MintProxyCredentials(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseMintProxyCredentialsResult(rsp)
 }
 
 // ReadyCheckWithResponse request returning *ReadyCheckResult
@@ -22649,6 +22844,39 @@ func ParseProfileDuplicateResult(rsp *http.Response) (*ProfileDuplicateResult, e
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ProfileResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseMintProxyCredentialsResult parses an HTTP response from a MintProxyCredentialsWithResponse call
+func ParseMintProxyCredentialsResult(rsp *http.Response) (*MintProxyCredentialsResult, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &MintProxyCredentialsResult{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ProxyCredentialResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/scripts/endpoint-coverage.txt
+++ b/scripts/endpoint-coverage.txt
@@ -59,6 +59,7 @@ skip DELETE /vaults/{vault_id}/card # excluded from codegen: credit-card handlin
 # --- infrastructure, not a user-facing operation -----------------------------
 skip GET  /ready # load-balancer probe
 skip POST /anything/start # anything.notte.cc entry point, not a CLI workflow
+skip POST /proxies/gateway/credentials # internal function-runner endpoint for short-lived gateway credentials
 
 # --- not exposed yet ---------------------------------------------------------
 # Each of these is a gap someone should close or rule out; listing them is the


### PR DESCRIPTION
Regenerate the generated API client (`internal/api`, `internal/cmd/*_flags.gen.go`) from the latest staging OpenAPI spec.

The new `POST /proxies/gateway/credentials` operation is intentionally recorded as infrastructure-only: function runners call it to mint short-lived proxy-gateway credentials, so it is not exposed as a CLI command.

Verification:
- `make check`
- `make check-endpoints`
- `make build`
- `go test -race -short ./...`