### PR TITLE
feat: add --runtime to notte functions run

### DIFF
--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -24,6 +24,7 @@ var (
 	functionRunVariables     []string // Variables as key=value pairs
 	functionRunVariablesJSON string   // Variables as JSON string
 	functionRunNoStream      bool     // Opt out of log streaming
+	functionRunRuntime       string   // Which execution runtime to run on
 	functionSecretValue      string
 	functionDownloadVersion  string
 )
@@ -326,6 +327,10 @@ func init() {
 	// a positive flag would be an opt-in to something already on. Same shape,
 	// and the same reasoning, as --no-solve-captchas on sessions start.
 	functionsRunCmd.Flags().BoolVar(&functionRunNoStream, "no-stream", false, "Return only the final response instead of streaming logs")
+	functionsRunCmd.Flags().StringVar(&functionRunRuntime, "runtime", "", fmt.Sprintf("Execution runtime: %s (Lambda) or %s (the configured AgentCore runtime). Server default when unset", api.Standard, api.Extended))
+	_ = functionsRunCmd.RegisterFlagCompletionFunc("runtime", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return []string{string(api.Standard), string(api.Extended)}, cobra.ShellCompDirectiveNoFileComp
+	})
 
 	// Runs command flags
 	functionsRunsCmd.Flags().StringVar(&functionID, "function-id", "", "Function ID (uses current function if not specified)")
@@ -762,6 +767,19 @@ func runFunctionRun(cmd *cobra.Command, args []string) error {
 	// unconditionally would freeze today's server-side behaviour into the client.
 	if functionRunNoStream {
 		requestBody["stream"] = false
+	}
+	// Same reasoning for omitting it when unset: the server picks the runtime,
+	// and sending its current choice back would pin it. The valid values are
+	// spelled out here rather than left to the API so a typo costs a message
+	// instead of a 422 - at the price of needing an edit here if the spec grows
+	// a third runtime.
+	if functionRunRuntime != "" {
+		switch api.RunFunctionRequestRuntime(functionRunRuntime) {
+		case api.Standard, api.Extended:
+			requestBody["runtime"] = functionRunRuntime
+		default:
+			return fmt.Errorf("invalid --runtime %q: expected %s or %s", functionRunRuntime, api.Standard, api.Extended)
+		}
 	}
 
 	bodyJSON, err := json.Marshal(requestBody)

--- a/internal/cmd/functionsextra_test.go
+++ b/internal/cmd/functionsextra_test.go
@@ -382,3 +382,80 @@ func TestFunctionRun_SendsStreamOnlyWithNoStream(t *testing.T) {
 		})
 	}
 }
+
+func TestFunctionRun_SendsRuntimeOnlyWhenSet(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		runtime string
+		want    any
+	}{
+		{name: "default omits runtime", runtime: "", want: nil},
+		{name: "--runtime standard is sent", runtime: "standard", want: "standard"},
+		{name: "--runtime extended is sent", runtime: "extended", want: "extended"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := setupFunctionTest(t)
+			server.AddResponse("/functions/"+functionIDTest+"/runs/start", 200, functionRunJSON())
+
+			origFormat := outputFormat
+			origRuntime := functionRunRuntime
+			outputFormat = "json"
+			functionRunRuntime = tc.runtime
+			t.Cleanup(func() {
+				outputFormat = origFormat
+				functionRunRuntime = origRuntime
+			})
+
+			cmd := &cobra.Command{}
+			cmd.SetContext(context.Background())
+
+			testutil.CaptureOutput(func() {
+				if err := runFunctionRun(cmd, nil); err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			})
+
+			requests := server.Requests("/functions/" + functionIDTest + "/runs/start")
+			if len(requests) != 1 {
+				t.Fatalf("got %d requests, want 1", len(requests))
+			}
+			body := requestBody(t, requests[0])
+			got, present := body["runtime"]
+			if tc.want == nil {
+				if present {
+					t.Errorf("runtime was sent as %v without --runtime", got)
+				}
+				return
+			}
+			if !present {
+				t.Fatal("runtime was not sent despite --runtime")
+			}
+			if got != tc.want {
+				t.Errorf("runtime = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFunctionRun_RejectsUnknownRuntime(t *testing.T) {
+	server := setupFunctionTest(t)
+	server.AddResponse("/functions/"+functionIDTest+"/runs/start", 200, functionRunJSON())
+
+	origRuntime := functionRunRuntime
+	functionRunRuntime = "lambda"
+	t.Cleanup(func() { functionRunRuntime = origRuntime })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := runFunctionRun(cmd, nil)
+	if err == nil {
+		t.Fatal("expected an error for an unknown runtime")
+	}
+	if !strings.Contains(err.Error(), "invalid --runtime") {
+		t.Errorf("error = %q, want it to mention invalid --runtime", err)
+	}
+	if got := server.Requests("/functions/" + functionIDTest + "/runs/start"); len(got) != 0 {
+		t.Errorf("sent %d requests despite an invalid runtime, want 0", len(got))
+	}
+}


### PR DESCRIPTION
## What

Adds `--runtime standard|extended` to `notte functions run`.

## Why

The regenerated spec in #97 grew a `runtime` field on `RunFunctionRequest`:

```go
// Runtime standard uses Lambda; extended uses the configured AgentCore runtime.
Runtime *RunFunctionRequestRuntime `json:"runtime,omitempty"`
```

But `functions run` bypasses the generated client and hand-builds its request body (`internal/cmd/functions.go`, the `manual POST /functions/{function_id}/runs/start` entry in `endpoint-coverage.txt`), so the field was unreachable from the CLI — regenerating alone never surfaces it. `functions run` also has no `*_flags.gen.go`, so the flag generator won't pick it up on a future regen either.

## How

- Sent only when the user passes it, matching `--no-stream`: the server picks the runtime otherwise, and transmitting its current choice would pin today's behaviour into the client.
- An unknown value is rejected locally (`invalid --runtime "lambda": expected standard or extended`) rather than becoming a 422. The two values reference the generated `api.Standard` / `api.Extended` constants, but the *set* is hand-written — if the spec grows a third runtime, the switch needs an edit. Flagged in a comment at the site.
- Shell completion suggests both values.

## Testing

- `TestFunctionRun_SendsRuntimeOnlyWhenSet` — omit / standard / extended
- `TestFunctionRun_RejectsUnknownRuntime` — asserts no request is sent on a bad value
- `go test ./...`, `make check-endpoints`, `make check-skills`, `make lint` all clean on top of main.

## Note for reviewers

Unrelated but adjacent: the hand-built body sends `"function_id"`, while the spec's `RunFunctionRequest` declares `workflow_id`. Either the API accepts both or the field is ignored and the path ID is what counts. Deliberately not touched here — worth confirming before more fields go into that map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)