### PR TITLE
Validate the API key against the configured API

### DIFF
--- a/internal/auth/console_test.go
+++ b/internal/auth/console_test.go
@@ -1,0 +1,79 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/nottelabs/notte-cli/internal/config"
+)
+
+func TestConsoleURLFollowsTheAPIEnvironment(t *testing.T) {
+	// The bug this covers: only NOTTE_API_URL was set, the console defaulted to
+	// production regardless, and login stored a production key under the name of
+	// whichever environment NOTTE_API_URL pointed at.
+	tests := []struct {
+		name   string
+		apiURL string
+		want   string
+	}{
+		{"prod default", "https://api.notte.cc", "https://console.notte.cc"},
+		{"prod alias", "https://us-prod.notte.cc", "https://console.notte.cc"},
+		{"staging", "https://us-staging.notte.cc", "https://staging-console.notte.cc"},
+		{"staging with path", "https://us-staging.notte.cc/v1", "https://staging-console.notte.cc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(config.EnvConsoleURL, "")
+			t.Setenv(config.EnvAPIURL, tt.apiURL)
+
+			if got := ConsoleURL(); got != tt.want {
+				t.Errorf("ConsoleURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConsoleURLPrefersTheExplicitOverride(t *testing.T) {
+	// A local or otherwise unlisted console has to remain reachable, and an
+	// explicit value must not be second-guessed from the API URL.
+	t.Setenv(config.EnvAPIURL, "https://us-staging.notte.cc")
+	t.Setenv(config.EnvConsoleURL, "http://localhost:3000")
+
+	if got := ConsoleURL(); got != "http://localhost:3000" {
+		t.Errorf("ConsoleURL() = %q, want the explicit override", got)
+	}
+}
+
+func TestConsoleURLFallsBackForUnknownEnvironments(t *testing.T) {
+	// No console is guessed for an environment that has none recorded. The
+	// resulting mismatch is caught downstream, where the key is validated
+	// against the configured API.
+	for _, apiURL := range []string{
+		"https://us-dev.notte.cc",
+		"http://localhost:8080",
+		"https://my-api.example.com",
+	} {
+		t.Setenv(config.EnvConsoleURL, "")
+		t.Setenv(config.EnvAPIURL, apiURL)
+
+		if got := ConsoleURL(); got != config.DefaultConsoleURL {
+			t.Errorf("ConsoleURL() with API %q = %q, want the default", apiURL, got)
+		}
+	}
+}
+
+func TestConsoleAuthURLTargetsTheDerivedConsole(t *testing.T) {
+	// End of the chain: the link the sign-in page renders has to point at the
+	// console the environment resolves to, not the compiled-in default.
+	t.Setenv(config.EnvConsoleURL, "")
+	t.Setenv(config.EnvAPIURL, "https://us-staging.notte.cc")
+
+	server := NewSetupServer()
+	server.baseURL = "http://127.0.0.1:12345"
+
+	got := server.GetConsoleAuthURL()
+	const want = "https://staging-console.notte.cc/auth/cli"
+	if len(got) < len(want) || got[:len(want)] != want {
+		t.Errorf("GetConsoleAuthURL() = %q, want it to start with %q", got, want)
+	}
+}

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -35,6 +35,39 @@ func ResolveEnvLabel(apiURL string) string {
 	return host
 }
 
+// consoleByEnvLabel maps an environment to the console that issues its keys.
+//
+// Only environments whose console is known are listed. Guessing one would
+// recreate the problem this exists to solve: an unlisted environment falls back
+// to the default rather than to a plausible-looking hostname that may belong to
+// something else.
+var consoleByEnvLabel = map[string]string{
+	"prod":    config.DefaultConsoleURL,
+	"staging": "https://staging-console.notte.cc",
+}
+
+// ConsoleURL returns the console to sign in through.
+//
+// NOTTE_CONSOLE_URL wins when set. Otherwise the console is derived from the
+// API being used, because the two have to agree: the console hands back one of
+// its own API keys, and login stores it under the environment NOTTE_API_URL
+// names. Defaulting to production regardless meant that pointing only
+// NOTTE_API_URL at another environment sent the browser to the production
+// console and filed a production key under that environment's name.
+//
+// An environment with no known console falls back to the default. That
+// combination no longer passes silently: the key is validated against the
+// configured API, which rejects a key issued by a different one.
+func ConsoleURL() string {
+	if u := os.Getenv(config.EnvConsoleURL); u != "" {
+		return u
+	}
+	if u, ok := consoleByEnvLabel[ResolveEnvLabel(GetCurrentAPIURL())]; ok {
+		return u
+	}
+	return config.DefaultConsoleURL
+}
+
 // KeyringKeyForEnv returns the env-qualified keyring key for the given label.
 func KeyringKeyForEnv(envLabel string) string {
 	return KeyringKey + ":" + envLabel

--- a/internal/auth/server.go
+++ b/internal/auth/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"net"
@@ -15,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nottelabs/notte-cli/internal/api"
 	"github.com/nottelabs/notte-cli/internal/config"
 )
 
@@ -167,32 +167,10 @@ func (s *SetupServer) handleValidate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Test the API key by making a health check request
-	client, err := api.NewClient(req.APIKey)
-	if err != nil {
+	if err := ValidateAPIKey(r.Context(), req.APIKey); err != nil {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"success": false,
-			"error":   fmt.Sprintf("Invalid API key: %v", err),
-		})
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	resp, err := client.Client().HealthCheckWithResponse(ctx)
-	if err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"success": false,
-			"error":   fmt.Sprintf("Connection failed: %v", err),
-		})
-		return
-	}
-
-	if resp.StatusCode() != 200 {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"success": false,
-			"error":   fmt.Sprintf("API error: %s", resp.Status()),
+			"error":   err.Error(),
 		})
 		return
 	}
@@ -227,31 +205,10 @@ func (s *SetupServer) handleSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate the API key first
-	client, err := api.NewClient(req.APIKey)
-	if err != nil {
+	if err := ValidateAPIKey(r.Context(), req.APIKey); err != nil {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"success": false,
-			"error":   fmt.Sprintf("Invalid API key: %v", err),
-		})
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-	defer cancel()
-
-	resp, err := client.Client().HealthCheckWithResponse(ctx)
-	if err != nil {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"success": false,
-			"error":   fmt.Sprintf("Connection failed: %v", err),
-		})
-		return
-	}
-
-	if resp.StatusCode() != 200 {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"success": false,
-			"error":   fmt.Sprintf("API error: %s", resp.Status()),
+			"error":   err.Error(),
 		})
 		return
 	}
@@ -351,32 +308,16 @@ func (s *SetupServer) handleCallback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Validate the API key
-		client, err := api.NewClient(req.Token)
-		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{
+		// Validate the API key. A rejected key is the caller's problem (400);
+		// anything else means we could not reach the API to find out (502).
+		if err := ValidateAPIKey(r.Context(), req.Token); err != nil {
+			status := http.StatusBadGateway
+			if errors.Is(err, ErrInvalidAPIKey) {
+				status = http.StatusBadRequest
+			}
+			writeJSON(w, status, map[string]any{
 				"success": false,
-				"error":   fmt.Sprintf("Invalid API key: %v", err),
-			})
-			return
-		}
-
-		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
-		defer cancel()
-
-		resp, err := client.Client().HealthCheckWithResponse(ctx)
-		if err != nil {
-			writeJSON(w, http.StatusBadGateway, map[string]any{
-				"success": false,
-				"error":   fmt.Sprintf("Connection failed: %v", err),
-			})
-			return
-		}
-
-		if resp.StatusCode() != 200 {
-			writeJSON(w, http.StatusBadGateway, map[string]any{
-				"success": false,
-				"error":   fmt.Sprintf("API error: %s", resp.Status()),
+				"error":   err.Error(),
 			})
 			return
 		}

--- a/internal/auth/server.go
+++ b/internal/auth/server.go
@@ -15,8 +15,6 @@ import (
 	"runtime"
 	"sync"
 	"time"
-
-	"github.com/nottelabs/notte-cli/internal/config"
 )
 
 // SetupResult contains the result of a browser-based setup
@@ -129,7 +127,7 @@ func (s *SetupServer) handleSetup(w http.ResponseWriter, r *http.Request) {
 
 // GetConsoleAuthURL builds the console authentication URL with callback and state
 func (s *SetupServer) GetConsoleAuthURL() string {
-	consoleURL := config.GetConsoleURL()
+	consoleURL := ConsoleURL()
 	callbackURL := s.baseURL + "/callback"
 
 	authURL, err := url.Parse(consoleURL + "/auth/cli")

--- a/internal/auth/validate.go
+++ b/internal/auth/validate.go
@@ -1,0 +1,57 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/nottelabs/notte-cli/internal/api"
+)
+
+// ErrInvalidAPIKey means the API answered and rejected the key, as opposed to
+// not answering at all. Callers use it to tell a bad credential (which the user
+// can fix by getting another key) from an unreachable API (which they cannot).
+var ErrInvalidAPIKey = errors.New("the API rejected this key")
+
+const validateTimeout = 10 * time.Second
+
+// ValidateAPIKey reports whether a key can actually be used.
+//
+// Checked against an endpoint that requires authentication. /health does not:
+// it answers 200 with no credential at all, so validating against it only ever
+// proved the API was reachable, and any string at all was accepted and stored
+// as a working key.
+//
+// The request goes to the configured API, not the default one. Login stores the
+// key under the environment named by NOTTE_API_URL, so validating somewhere else
+// can accept a key that does not work where it is about to be saved.
+//
+// Client options are accepted so callers (and tests) can adjust the retry
+// policy; production call sites pass none and get the default.
+func ValidateAPIKey(ctx context.Context, apiKey string, opts ...api.NotteClientOption) error {
+	client, err := api.NewClientWithURL(apiKey, GetCurrentAPIURL(), "", opts...)
+	if err != nil {
+		// Only returned for a malformed or empty key, which is a bad
+		// credential rather than a transport problem.
+		return fmt.Errorf("%w: %v", ErrInvalidAPIKey, err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, validateTimeout)
+	defer cancel()
+
+	resp, err := client.Client().GetUsageWithResponse(ctx, &api.GetUsageParams{})
+	if err != nil {
+		return fmt.Errorf("connection failed: %w", err)
+	}
+
+	switch code := resp.StatusCode(); code {
+	case http.StatusOK:
+		return nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return ErrInvalidAPIKey
+	default:
+		return fmt.Errorf("API error: %s", resp.Status())
+	}
+}

--- a/internal/auth/validate_test.go
+++ b/internal/auth/validate_test.go
@@ -59,14 +59,24 @@ func TestValidateAPIKeyUsesConfiguredAPI(t *testing.T) {
 	if stub.hits != 1 {
 		t.Fatalf("configured API received %d requests, want 1", stub.hits)
 	}
-	if stub.auth == "" {
-		t.Error("request carried no Authorization header, so the key was never checked")
+	// The key has to actually be presented; a request without it proves nothing
+	// about the key, which is how validating against /health passed for any
+	// string at all.
+	if want := "Bearer sk-notte-test"; stub.auth != want {
+		t.Errorf("Authorization header = %q, want %q", stub.auth, want)
 	}
 }
 
 func TestValidateAPIKeyRequiresAnAuthenticatedEndpoint(t *testing.T) {
-	// /health answers 200 without a credential, so validating against it
-	// accepted anything. Whatever endpoint is used must be one that 401s.
+	// The endpoint is pinned rather than merely checked against /health: any
+	// other unauthenticated endpoint would reintroduce the bug just as well,
+	// and a negative assertion against one path would not notice.
+	//
+	// If this ever needs to change, the replacement has to be an endpoint that
+	// answers 401 to an unknown key. /health does not - it answers 200 with no
+	// credential at all, which is what let any string validate.
+	const authenticatedPath = "/usage"
+
 	stub := newAPIStub(t, http.StatusOK, `{}`)
 	t.Setenv(config.EnvAPIURL, stub.server.URL)
 
@@ -74,8 +84,8 @@ func TestValidateAPIKeyRequiresAnAuthenticatedEndpoint(t *testing.T) {
 		t.Fatalf("ValidateAPIKey() = %v, want nil", err)
 	}
 
-	if stub.path == "/health" {
-		t.Errorf("validated against %s, which does not require authentication", stub.path)
+	if stub.path != authenticatedPath {
+		t.Errorf("validated against %q, want %q", stub.path, authenticatedPath)
 	}
 }
 

--- a/internal/auth/validate_test.go
+++ b/internal/auth/validate_test.go
@@ -1,0 +1,135 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nottelabs/notte-cli/internal/api"
+	"github.com/nottelabs/notte-cli/internal/config"
+)
+
+// The retries the client does by default are correct in production and pure
+// wall-clock here, where every response is deterministic.
+func noRetry() api.NotteClientOption {
+	return api.WithRetryConfig(&api.RetryConfig{
+		MaxRetries:     0,
+		InitialBackoff: time.Millisecond,
+		MaxBackoff:     time.Millisecond,
+	})
+}
+
+// apiStub stands in for the Notte API and records what reached it.
+type apiStub struct {
+	server *httptest.Server
+	path   string
+	auth   string
+	hits   int
+}
+
+func newAPIStub(t *testing.T, status int, body string) *apiStub {
+	t.Helper()
+	stub := &apiStub{}
+	stub.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		stub.hits++
+		stub.path = r.URL.Path
+		stub.auth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(stub.server.Close)
+	return stub
+}
+
+func TestValidateAPIKeyUsesConfiguredAPI(t *testing.T) {
+	// The bug this covers: validation went to the compiled-in default API
+	// regardless of NOTTE_API_URL, so `auth login` against one environment was
+	// checked against another.
+	stub := newAPIStub(t, http.StatusOK, `{}`)
+	t.Setenv(config.EnvAPIURL, stub.server.URL)
+
+	if err := ValidateAPIKey(context.Background(), "sk-notte-test"); err != nil {
+		t.Fatalf("ValidateAPIKey() = %v, want nil", err)
+	}
+
+	if stub.hits != 1 {
+		t.Fatalf("configured API received %d requests, want 1", stub.hits)
+	}
+	if stub.auth == "" {
+		t.Error("request carried no Authorization header, so the key was never checked")
+	}
+}
+
+func TestValidateAPIKeyRequiresAnAuthenticatedEndpoint(t *testing.T) {
+	// /health answers 200 without a credential, so validating against it
+	// accepted anything. Whatever endpoint is used must be one that 401s.
+	stub := newAPIStub(t, http.StatusOK, `{}`)
+	t.Setenv(config.EnvAPIURL, stub.server.URL)
+
+	if err := ValidateAPIKey(context.Background(), "sk-notte-test"); err != nil {
+		t.Fatalf("ValidateAPIKey() = %v, want nil", err)
+	}
+
+	if stub.path == "/health" {
+		t.Errorf("validated against %s, which does not require authentication", stub.path)
+	}
+}
+
+func TestValidateAPIKeyRejectsBadKey(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		stub := newAPIStub(t, status, `{"detail":"nope"}`)
+		t.Setenv(config.EnvAPIURL, stub.server.URL)
+
+		err := ValidateAPIKey(context.Background(), "sk-notte-bad", noRetry())
+		if !errors.Is(err, ErrInvalidAPIKey) {
+			t.Errorf("status %d: ValidateAPIKey() = %v, want ErrInvalidAPIKey", status, err)
+		}
+	}
+}
+
+func TestValidateAPIKeyDoesNotBlameTheKeyForServerErrors(t *testing.T) {
+	// A 500 must not tell the user their key is invalid and send them off to
+	// rotate a key that was fine.
+	stub := newAPIStub(t, http.StatusInternalServerError, `{}`)
+	t.Setenv(config.EnvAPIURL, stub.server.URL)
+
+	err := ValidateAPIKey(context.Background(), "sk-notte-test", noRetry())
+	if err == nil {
+		t.Fatal("ValidateAPIKey() = nil, want an error")
+	}
+	if errors.Is(err, ErrInvalidAPIKey) {
+		t.Errorf("ValidateAPIKey() = %v, want a non-credential error", err)
+	}
+}
+
+func TestValidateAPIKeyReportsUnreachableAPI(t *testing.T) {
+	stub := newAPIStub(t, http.StatusOK, `{}`)
+	url := stub.server.URL
+	stub.server.Close() // nothing is listening now
+	t.Setenv(config.EnvAPIURL, url)
+
+	err := ValidateAPIKey(context.Background(), "sk-notte-test", noRetry())
+	if err == nil {
+		t.Fatal("ValidateAPIKey() = nil, want an error")
+	}
+	if errors.Is(err, ErrInvalidAPIKey) {
+		t.Errorf("ValidateAPIKey() = %v, want a connection error, not a credential one", err)
+	}
+}
+
+func TestValidateAPIKeyRejectsEmptyKey(t *testing.T) {
+	stub := newAPIStub(t, http.StatusOK, `{}`)
+	t.Setenv(config.EnvAPIURL, stub.server.URL)
+
+	err := ValidateAPIKey(context.Background(), "")
+	if !errors.Is(err, ErrInvalidAPIKey) {
+		t.Errorf("ValidateAPIKey(\"\") = %v, want ErrInvalidAPIKey", err)
+	}
+	if stub.hits != 0 {
+		t.Errorf("empty key still reached the API %d times", stub.hits)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,11 +125,3 @@ func (c *Config) SaveToPath(path string) error {
 
 	return os.WriteFile(path, data, 0o600)
 }
-
-// GetConsoleURL returns the console URL from env var or default
-func GetConsoleURL() string {
-	if url := os.Getenv(EnvConsoleURL); url != "" {
-		return url
-	}
-	return DefaultConsoleURL
-}

--- a/tests/integration/auth_test.go
+++ b/tests/integration/auth_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+)
+
+// TestAuth_APIRejectsInvalidKey pins the contract sign-in validation relies on:
+// the endpoint it checks a key against must actually reject a bad one.
+//
+// Validation used to run against /health, which answers 200 with no credential
+// at all, so every string validated successfully and was stored as a working
+// key. Unit tests can only assert this against a stub. If the real endpoint
+// ever stopped requiring authentication, the bug would return with every unit
+// test still green - this is the test that would notice.
+func TestAuth_APIRejectsInvalidKey(t *testing.T) {
+	t.Setenv("NOTTE_API_KEY", "sk-notte-not-a-real-key-000000000000")
+
+	result := runCLI(t, "usage")
+	requireFailure(t, result)
+
+	// The failure has to be about the credential. A generic transport error
+	// would satisfy requireFailure while telling us nothing about whether the
+	// key was checked.
+	output := result.Stderr + result.Stdout
+	if !containsString(output, "401") &&
+		!containsString(output, "auth") &&
+		!containsString(output, "Auth") &&
+		!containsString(output, "key") {
+		t.Errorf("expected an authentication failure, got: %s", output)
+	}
+
+	t.Logf("invalid key correctly rejected: %s", output)
+}
+
+// TestAuth_ValidKeyIsAccepted is the other half: the same endpoint answers a
+// real key, so validation does not reject keys that are fine.
+func TestAuth_ValidKeyIsAccepted(t *testing.T) {
+	result := runCLI(t, "usage")
+	requireSuccess(t, result)
+}

--- a/tests/integration/console_url_test.go
+++ b/tests/integration/console_url_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/nottelabs/notte-cli/internal/auth"
+	"github.com/nottelabs/notte-cli/internal/config"
+)
+
+// TestConsoleURL_MappedConsolesExist checks the consoles sign-in derives from
+// the API environment are real.
+//
+// The mapping is hostnames written down in the CLI. Unit tests only assert the
+// CLI returns the string it was told to; nothing there notices if a console is
+// renamed or retired, and the symptom would be `notte auth login` opening a
+// browser at a dead address with no error from the CLI itself.
+func TestConsoleURL_MappedConsolesExist(t *testing.T) {
+	// Representative API URLs for each environment the mapping covers. Driving
+	// it through ConsoleURL rather than a copy of the table means a newly
+	// mapped environment is covered here as soon as it is added.
+	apiURLs := []string{
+		"https://api.notte.cc",
+		"https://us-staging.notte.cc",
+	}
+
+	seen := map[string]bool{}
+	for _, apiURL := range apiURLs {
+		t.Setenv(config.EnvConsoleURL, "")
+		t.Setenv(config.EnvAPIURL, apiURL)
+		seen[auth.ConsoleURL()] = true
+	}
+
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+		// Sign-in redirects through an identity provider, which is a healthy
+		// response here. Following it would test that provider instead.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	for consoleURL := range seen {
+		t.Run(consoleURL, func(t *testing.T) {
+			target := consoleURL + "/auth/cli"
+			resp, err := client.Get(target)
+			if err != nil {
+				t.Fatalf("GET %s: %v", target, err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			// Deliberately narrow. The page is behind sign-in and may answer a
+			// redirect, a challenge or a rate limit depending on where this
+			// runs; a 404 is the one answer that means the CLI is pointing
+			// somewhere that no longer serves this flow.
+			if resp.StatusCode == http.StatusNotFound {
+				t.Errorf("GET %s returned 404, so this console no longer serves CLI sign-in", target)
+			}
+			t.Logf("GET %s -> %d", target, resp.StatusCode)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`notte auth login` validated the API key it received in two ways that did not check anything:

- **Against the wrong API.** Validation went through `api.NewClient()`, which hardcodes `DefaultBaseURL` (`https://api.notte.cc`). `NOTTE_API_URL` was ignored. Login then stored the key under the environment that `NOTTE_API_URL` *does* name, so a key could be validated in one environment and saved as another's.
- **Against an endpoint that needs no credential.** `/health` answers `200` with no `Authorization` header at all, and `200` with a nonsense one. So validation only proved the API was reachable. Any string was accepted and written to the keyring as a working key, and the "Test" button on the sign-in page reported success for it.

## Change

`ValidateAPIKey` sends the request to the configured API and to an endpoint that requires authentication, so a rejected key is actually reported as rejected.

The three copies of the validate-then-report block in `server.go` now share it. A rejected key (`401`/`403`) is distinguished from an unreachable or erroring API, so the callback handler can keep answering `400` for a bad credential and `502` when it could not find out - and a transient `500` no longer tells someone their key is invalid and sends them off to rotate a key that was fine.

## Testing

New unit tests cover the request reaching the configured API rather than the default, an authenticated endpoint being used, `401`/`403` mapping to a credential error, and `500`/unreachable mapping to something else.

Verified against a live API: a bogus key now returns `the API rejected this key`. Before this change the same key validated successfully and was stored.

`go vet`, `golangci-lint` and `go test -race -short ./...` are clean.
