### PR TITLE
Derive the console URL from the API environment

### DIFF
--- a/internal/auth/console_test.go
+++ b/internal/auth/console_test.go
@@ -1,0 +1,79 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/nottelabs/notte-cli/internal/config"
+)
+
+func TestConsoleURLFollowsTheAPIEnvironment(t *testing.T) {
+	// The bug this covers: only NOTTE_API_URL was set, the console defaulted to
+	// production regardless, and login stored a production key under the name of
+	// whichever environment NOTTE_API_URL pointed at.
+	tests := []struct {
+		name   string
+		apiURL string
+		want   string
+	}{
+		{"prod default", "https://api.notte.cc", "https://console.notte.cc"},
+		{"prod alias", "https://us-prod.notte.cc", "https://console.notte.cc"},
+		{"staging", "https://us-staging.notte.cc", "https://staging-console.notte.cc"},
+		{"staging with path", "https://us-staging.notte.cc/v1", "https://staging-console.notte.cc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(config.EnvConsoleURL, "")
+			t.Setenv(config.EnvAPIURL, tt.apiURL)
+
+			if got := ConsoleURL(); got != tt.want {
+				t.Errorf("ConsoleURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConsoleURLPrefersTheExplicitOverride(t *testing.T) {
+	// A local or otherwise unlisted console has to remain reachable, and an
+	// explicit value must not be second-guessed from the API URL.
+	t.Setenv(config.EnvAPIURL, "https://us-staging.notte.cc")
+	t.Setenv(config.EnvConsoleURL, "http://localhost:3000")
+
+	if got := ConsoleURL(); got != "http://localhost:3000" {
+		t.Errorf("ConsoleURL() = %q, want the explicit override", got)
+	}
+}
+
+func TestConsoleURLFallsBackForUnknownEnvironments(t *testing.T) {
+	// No console is guessed for an environment that has none recorded. The
+	// resulting mismatch is caught downstream, where the key is validated
+	// against the configured API.
+	for _, apiURL := range []string{
+		"https://us-dev.notte.cc",
+		"http://localhost:8080",
+		"https://my-api.example.com",
+	} {
+		t.Setenv(config.EnvConsoleURL, "")
+		t.Setenv(config.EnvAPIURL, apiURL)
+
+		if got := ConsoleURL(); got != config.DefaultConsoleURL {
+			t.Errorf("ConsoleURL() with API %q = %q, want the default", apiURL, got)
+		}
+	}
+}
+
+func TestConsoleAuthURLTargetsTheDerivedConsole(t *testing.T) {
+	// End of the chain: the link the sign-in page renders has to point at the
+	// console the environment resolves to, not the compiled-in default.
+	t.Setenv(config.EnvConsoleURL, "")
+	t.Setenv(config.EnvAPIURL, "https://us-staging.notte.cc")
+
+	server := NewSetupServer()
+	server.baseURL = "http://127.0.0.1:12345"
+
+	got := server.GetConsoleAuthURL()
+	const want = "https://staging-console.notte.cc/auth/cli"
+	if len(got) < len(want) || got[:len(want)] != want {
+		t.Errorf("GetConsoleAuthURL() = %q, want it to start with %q", got, want)
+	}
+}

--- a/internal/auth/env.go
+++ b/internal/auth/env.go
@@ -35,6 +35,39 @@ func ResolveEnvLabel(apiURL string) string {
 	return host
 }
 
+// consoleByEnvLabel maps an environment to the console that issues its keys.
+//
+// Only environments whose console is known are listed. Guessing one would
+// recreate the problem this exists to solve: an unlisted environment falls back
+// to the default rather than to a plausible-looking hostname that may belong to
+// something else.
+var consoleByEnvLabel = map[string]string{
+	"prod":    config.DefaultConsoleURL,
+	"staging": "https://staging-console.notte.cc",
+}
+
+// ConsoleURL returns the console to sign in through.
+//
+// NOTTE_CONSOLE_URL wins when set. Otherwise the console is derived from the
+// API being used, because the two have to agree: the console hands back one of
+// its own API keys, and login stores it under the environment NOTTE_API_URL
+// names. Defaulting to production regardless meant that pointing only
+// NOTTE_API_URL at another environment sent the browser to the production
+// console and filed a production key under that environment's name.
+//
+// An environment with no known console falls back to the default. That
+// combination no longer passes silently: the key is validated against the
+// configured API, which rejects a key issued by a different one.
+func ConsoleURL() string {
+	if u := os.Getenv(config.EnvConsoleURL); u != "" {
+		return u
+	}
+	if u, ok := consoleByEnvLabel[ResolveEnvLabel(GetCurrentAPIURL())]; ok {
+		return u
+	}
+	return config.DefaultConsoleURL
+}
+
 // KeyringKeyForEnv returns the env-qualified keyring key for the given label.
 func KeyringKeyForEnv(envLabel string) string {
 	return KeyringKey + ":" + envLabel

--- a/internal/auth/server.go
+++ b/internal/auth/server.go
@@ -15,8 +15,6 @@ import (
 	"runtime"
 	"sync"
 	"time"
-
-	"github.com/nottelabs/notte-cli/internal/config"
 )
 
 // SetupResult contains the result of a browser-based setup
@@ -129,7 +127,7 @@ func (s *SetupServer) handleSetup(w http.ResponseWriter, r *http.Request) {
 
 // GetConsoleAuthURL builds the console authentication URL with callback and state
 func (s *SetupServer) GetConsoleAuthURL() string {
-	consoleURL := config.GetConsoleURL()
+	consoleURL := ConsoleURL()
 	callbackURL := s.baseURL + "/callback"
 
 	authURL, err := url.Parse(consoleURL + "/auth/cli")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,11 +125,3 @@ func (c *Config) SaveToPath(path string) error {
 
 	return os.WriteFile(path, data, 0o600)
 }
-
-// GetConsoleURL returns the console URL from env var or default
-func GetConsoleURL() string {
-	if url := os.Getenv(EnvConsoleURL); url != "" {
-		return url
-	}
-	return DefaultConsoleURL
-}

--- a/tests/integration/console_url_test.go
+++ b/tests/integration/console_url_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/nottelabs/notte-cli/internal/auth"
+	"github.com/nottelabs/notte-cli/internal/config"
+)
+
+// TestConsoleURL_MappedConsolesExist checks the consoles sign-in derives from
+// the API environment are real.
+//
+// The mapping is hostnames written down in the CLI. Unit tests only assert the
+// CLI returns the string it was told to; nothing there notices if a console is
+// renamed or retired, and the symptom would be `notte auth login` opening a
+// browser at a dead address with no error from the CLI itself.
+func TestConsoleURL_MappedConsolesExist(t *testing.T) {
+	// Representative API URLs for each environment the mapping covers. Driving
+	// it through ConsoleURL rather than a copy of the table means a newly
+	// mapped environment is covered here as soon as it is added.
+	apiURLs := []string{
+		"https://api.notte.cc",
+		"https://us-staging.notte.cc",
+	}
+
+	seen := map[string]bool{}
+	for _, apiURL := range apiURLs {
+		t.Setenv(config.EnvConsoleURL, "")
+		t.Setenv(config.EnvAPIURL, apiURL)
+		seen[auth.ConsoleURL()] = true
+	}
+
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+		// Sign-in redirects through an identity provider, which is a healthy
+		// response here. Following it would test that provider instead.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	for consoleURL := range seen {
+		t.Run(consoleURL, func(t *testing.T) {
+			target := consoleURL + "/auth/cli"
+			resp, err := client.Get(target)
+			if err != nil {
+				t.Fatalf("GET %s: %v", target, err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			// Deliberately narrow. The page is behind sign-in and may answer a
+			// redirect, a challenge or a rate limit depending on where this
+			// runs; a 404 is the one answer that means the CLI is pointing
+			// somewhere that no longer serves this flow.
+			if resp.StatusCode == http.StatusNotFound {
+				t.Errorf("GET %s returned 404, so this console no longer serves CLI sign-in", target)
+			}
+			t.Logf("GET %s -> %d", target, resp.StatusCode)
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #99.

## Problem

The console to sign in through was selected only by `NOTTE_CONSOLE_URL`, defaulting to production otherwise. `NOTTE_API_URL` had no influence on it.

So pointing the CLI at another environment the obvious way:

```
export NOTTE_API_URL=https://us-staging.notte.cc
notte auth login
```

opened the **production** console, which handed back a production API key, which login then stored under the name of the environment `NOTTE_API_URL` pointed at. The two variables have to agree, and nothing said so.

## Change

When `NOTTE_CONSOLE_URL` is not set, the console is derived from the API in use. An explicit value still wins, so a local console stays reachable.

Only environments whose console is known are mapped. An unlisted one keeps the existing default rather than being sent to a guessed hostname that may belong to something else - and with #99 that combination no longer passes silently, because the key is validated against the configured API and a key from a different one is rejected.

## Testing

New tests cover the console following the API for each known environment, the explicit override winning over derivation, unknown environments falling back rather than guessing, and the link the sign-in page renders pointing at the derived console.

`internal/config.GetConsoleURL` is removed; resolution now lives next to the environment mapping it depends on, and it had no other callers.

`go vet`, `golangci-lint` and `go test -race -short ./...` are clean.
