### PR TITLE
chore: regenerate API client from latest OpenAPI spec

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -110,6 +110,18 @@ const (
 	UserUpload      FileSource = "user_upload"
 )
 
+// Defines values for FunctionListItemResponseDefaultRuntime.
+const (
+	FunctionListItemResponseDefaultRuntimeExtended FunctionListItemResponseDefaultRuntime = "extended"
+	FunctionListItemResponseDefaultRuntimeStandard FunctionListItemResponseDefaultRuntime = "standard"
+)
+
+// Defines values for FunctionResponseDefaultRuntime.
+const (
+	FunctionResponseDefaultRuntimeExtended FunctionResponseDefaultRuntime = "extended"
+	FunctionResponseDefaultRuntimeStandard FunctionResponseDefaultRuntime = "standard"
+)
+
 // Defines values for FunctionRunListItemResponseStatus.
 const (
 	FunctionRunListItemResponseStatusActive FunctionRunListItemResponseStatus = "active"
@@ -139,6 +151,12 @@ const (
 	NodeSdk   FunctionSource = "node-sdk"
 	PythonSdk FunctionSource = "python-sdk"
 	RestApi   FunctionSource = "rest-api"
+)
+
+// Defines values for FunctionWithLinkResponseDefaultRuntime.
+const (
+	Extended FunctionWithLinkResponseDefaultRuntime = "extended"
+	Standard FunctionWithLinkResponseDefaultRuntime = "standard"
 )
 
 // Defines values for GetFunctionRunResponseStatus.
@@ -424,12 +442,6 @@ const (
 	Za ProxyGeolocationCountry = "za"
 	Zm ProxyGeolocationCountry = "zm"
 	Zw ProxyGeolocationCountry = "zw"
-)
-
-// Defines values for RunFunctionRequestRuntime.
-const (
-	Extended RunFunctionRequestRuntime = "extended"
-	Standard RunFunctionRequestRuntime = "standard"
 )
 
 // Defines values for SecretNamespace.
@@ -1482,7 +1494,8 @@ type FrameData struct {
 // FunctionListItemResponse defines model for FunctionListItemResponse.
 type FunctionListItemResponse struct {
 	// CreatedAt The creation time of the workflow
-	CreatedAt FlexibleTime `json:"created_at"`
+	CreatedAt      time.Time                               `json:"created_at"`
+	DefaultRuntime *FunctionListItemResponseDefaultRuntime `json:"default_runtime,omitempty"`
 
 	// Description The description of the workflow
 	Description *string `json:"description,omitempty"`
@@ -1527,12 +1540,16 @@ type FunctionListItemResponse struct {
 	WorkflowId *string  `json:"workflow_id,omitempty"`
 }
 
+// FunctionListItemResponseDefaultRuntime defines model for FunctionListItemResponse.DefaultRuntime.
+type FunctionListItemResponseDefaultRuntime string
+
 // FunctionMetadataUpdateRequest defines model for FunctionMetadataUpdateRequest.
 type FunctionMetadataUpdateRequest struct {
-	Description  *string `json:"description,omitempty"`
-	Domain       *string `json:"domain,omitempty"`
-	Instructions *string `json:"instructions,omitempty"`
-	Name         *string `json:"name,omitempty"`
+	DefaultRuntime *string `json:"default_runtime,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	Domain         *string `json:"domain,omitempty"`
+	Instructions   *string `json:"instructions,omitempty"`
+	Name           *string `json:"name,omitempty"`
 
 	// ResponseFormat JSON Schema of run()'s return value, computed by the caller from its pydantic model
 	ResponseFormat *map[string]interface{} `json:"response_format,omitempty"`
@@ -1542,7 +1559,8 @@ type FunctionMetadataUpdateRequest struct {
 // FunctionResponse defines model for FunctionResponse.
 type FunctionResponse struct {
 	// CreatedAt The creation time of the workflow
-	CreatedAt FlexibleTime `json:"created_at"`
+	CreatedAt      time.Time                       `json:"created_at"`
+	DefaultRuntime *FunctionResponseDefaultRuntime `json:"default_runtime,omitempty"`
 
 	// Description The description of the workflow
 	Description *string `json:"description,omitempty"`
@@ -1601,6 +1619,9 @@ type FunctionResponse struct {
 	Versions   []string `json:"versions"`
 	WorkflowId *string  `json:"workflow_id,omitempty"`
 }
+
+// FunctionResponseDefaultRuntime defines model for FunctionResponse.DefaultRuntime.
+type FunctionResponseDefaultRuntime string
 
 // FunctionRollbackRequest defines model for FunctionRollbackRequest.
 type FunctionRollbackRequest struct {
@@ -1697,7 +1718,8 @@ type FunctionSource string
 // FunctionWithLinkResponse defines model for FunctionWithLinkResponse.
 type FunctionWithLinkResponse struct {
 	// CreatedAt The creation time of the workflow
-	CreatedAt FlexibleTime `json:"created_at"`
+	CreatedAt      time.Time                               `json:"created_at"`
+	DefaultRuntime *FunctionWithLinkResponseDefaultRuntime `json:"default_runtime,omitempty"`
 
 	// Description The description of the workflow
 	Description *string `json:"description,omitempty"`
@@ -1759,6 +1781,9 @@ type FunctionWithLinkResponse struct {
 	Versions   []string `json:"versions"`
 	WorkflowId *string  `json:"workflow_id,omitempty"`
 }
+
+// FunctionWithLinkResponseDefaultRuntime defines model for FunctionWithLinkResponse.DefaultRuntime.
+type FunctionWithLinkResponseDefaultRuntime string
 
 // GetCookiesResponse defines model for GetCookiesResponse.
 type GetCookiesResponse struct {
@@ -2471,8 +2496,8 @@ type RootModelAny = interface{}
 
 // RunFunctionRequest defines model for RunFunctionRequest.
 type RunFunctionRequest struct {
-	// Runtime standard uses Lambda; extended uses the configured AgentCore runtime.
-	Runtime *RunFunctionRequestRuntime `json:"runtime,omitempty"`
+	// Runtime Override the saved function runtime; omit to inherit its default
+	Runtime *string `json:"runtime,omitempty"`
 
 	// Stream Whether to stream logs, or only return final response
 	Stream *bool `json:"stream,omitempty"`
@@ -2483,9 +2508,6 @@ type RunFunctionRequest struct {
 	// WorkflowId The ID of the function to run
 	WorkflowId string `json:"workflow_id"`
 }
-
-// RunFunctionRequestRuntime standard uses Lambda; extended uses the configured AgentCore runtime.
-type RunFunctionRequestRuntime string
 
 // RuntimePackage defines model for RuntimePackage.
 type RuntimePackage struct {

--- a/internal/cmd/functionconfigure_flags.gen.go
+++ b/internal/cmd/functionconfigure_flags.gen.go
@@ -13,6 +13,8 @@ import (
 
 // FunctionConfigure command flags
 var (
+	FunctionConfigureDefaultRuntime string
+
 	FunctionConfigureDescription string
 
 	FunctionConfigureDomain string
@@ -31,6 +33,7 @@ var (
 
 // RegisterFunctionConfigureFlags registers all flags for FunctionConfigure command
 func RegisterFunctionConfigureFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&FunctionConfigureDefaultRuntime, "default-runtime", "", "default-runtime")
 	cmd.Flags().StringVar(&FunctionConfigureDescription, "description", "", "description")
 	cmd.Flags().StringVar(&FunctionConfigureDomain, "domain", "", "domain")
 	cmd.Flags().StringVar(&FunctionConfigureInstructions, "run-instructions", "", "Notes for whoever calls this function: how long a run takes, what the variables mean, what it trips over")
@@ -42,6 +45,10 @@ func RegisterFunctionConfigureFlags(cmd *cobra.Command) {
 // BuildFunctionConfigureRequest builds the API request from CLI flags
 func BuildFunctionConfigureRequest(cmd *cobra.Command) (*api.FunctionMetadataUpdateRequest, error) {
 	body := &api.FunctionMetadataUpdateRequest{}
+
+	if FunctionConfigureDefaultRuntime != "" {
+		body.DefaultRuntime = &FunctionConfigureDefaultRuntime
+	}
 
 	if FunctionConfigureDescription != "" {
 		body.Description = &FunctionConfigureDescription

--- a/internal/cmd/functionconfigure_flags.gen.go
+++ b/internal/cmd/functionconfigure_flags.gen.go
@@ -13,6 +13,7 @@ import (
 
 // FunctionConfigure command flags
 var (
+	// Runtime this function's runs use unless a run overrides it: standard or extended
 	FunctionConfigureDefaultRuntime string
 
 	FunctionConfigureDescription string
@@ -33,7 +34,7 @@ var (
 
 // RegisterFunctionConfigureFlags registers all flags for FunctionConfigure command
 func RegisterFunctionConfigureFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&FunctionConfigureDefaultRuntime, "default-runtime", "", "default-runtime")
+	cmd.Flags().StringVar(&FunctionConfigureDefaultRuntime, "default-runtime", "", "Runtime this function's runs use unless a run overrides it: standard or extended")
 	cmd.Flags().StringVar(&FunctionConfigureDescription, "description", "", "description")
 	cmd.Flags().StringVar(&FunctionConfigureDomain, "domain", "", "domain")
 	cmd.Flags().StringVar(&FunctionConfigureInstructions, "run-instructions", "", "Notes for whoever calls this function: how long a run takes, what the variables mean, what it trips over")

--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -132,11 +132,13 @@ var functionsConfigureCmd = &cobra.Command{
 	Use:   "configure",
 	Short: "Update function metadata",
 	Long: "Update a function's metadata.\n\n" +
-		"Pass any of --name, --description, --domain, --run-instructions, --response-format, or --self-healing. " +
+		"Pass any of --name, --description, --domain, --run-instructions, --default-runtime, --response-format, or --self-healing. " +
 		"Only the flags you pass are sent; omitted fields are left unchanged.\n\n" +
 		"--run-instructions is documentation for whoever calls the function - how long a " +
 		"run takes, what each variable is for, which sites it trips over. It is not " +
 		"input to the self-healing agent.\n\n" +
+		"--default-runtime is the runtime every run of this function uses unless that run " +
+		"passes `functions run --runtime`.\n\n" +
 		"--response-format is the JSON Schema of what run() returns (inline JSON, @file, or - for stdin).",
 	Args: cobra.NoArgs,
 	RunE: runFunctionConfigure,
@@ -327,9 +329,9 @@ func init() {
 	// a positive flag would be an opt-in to something already on. Same shape,
 	// and the same reasoning, as --no-solve-captchas on sessions start.
 	functionsRunCmd.Flags().BoolVar(&functionRunNoStream, "no-stream", false, "Return only the final response instead of streaming logs")
-	functionsRunCmd.Flags().StringVar(&functionRunRuntime, "runtime", "", fmt.Sprintf("Execution runtime: %s (Lambda) or %s (the configured AgentCore runtime). Server default when unset", api.Standard, api.Extended))
+	functionsRunCmd.Flags().StringVar(&functionRunRuntime, "runtime", "", fmt.Sprintf("Run on %s for this run only, overriding the function's default-runtime", strings.Join(runtimeValues, " or ")))
 	_ = functionsRunCmd.RegisterFlagCompletionFunc("runtime", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-		return []string{string(api.Standard), string(api.Extended)}, cobra.ShellCompDirectiveNoFileComp
+		return runtimeValues, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	// Runs command flags
@@ -564,6 +566,28 @@ func runFunctionUpdate(cmd *cobra.Command, args []string) error {
 	return GetFormatter().Print(resp.JSON200)
 }
 
+// runtimeValues are the runtimes a function can execute on. The request bodies
+// type `runtime` and `default_runtime` as plain strings, so the set is taken
+// from the enum the responses still carry. Prefixed constants on purpose: the
+// unprefixed `Standard`/`Extended` pair has already been reassigned to a
+// different type by one regeneration, which a rename would catch but a silent
+// retyping would not.
+var runtimeValues = []string{
+	string(api.FunctionResponseDefaultRuntimeStandard),
+	string(api.FunctionResponseDefaultRuntimeExtended),
+}
+
+// validateRuntime rejects an unknown runtime locally so a typo costs a message
+// rather than a 422. The cost is an edit here if the API grows a third runtime.
+func validateRuntime(flagName, value string) error {
+	for _, v := range runtimeValues {
+		if value == v {
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid --%s %q: expected %s", flagName, value, strings.Join(runtimeValues, " or "))
+}
+
 func runFunctionConfigure(cmd *cobra.Command, args []string) error {
 	if err := RequireFunctionID(); err != nil {
 		return err
@@ -579,6 +603,7 @@ func runFunctionConfigure(cmd *cobra.Command, args []string) error {
 		{"description", FunctionConfigureDescription},
 		{"domain", FunctionConfigureDomain},
 		{"run-instructions", FunctionConfigureInstructions},
+		{"default-runtime", FunctionConfigureDefaultRuntime},
 	}
 	anyChanged := cmd.Flags().Changed("self-healing") || cmd.Flags().Changed("response-format")
 	for _, f := range stringFlags {
@@ -594,7 +619,12 @@ func runFunctionConfigure(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if !anyChanged {
-		return errors.New("nothing to configure: pass --name, --description, --domain, --run-instructions, --response-format, and/or --self-healing")
+		return errors.New("nothing to configure: pass --name, --description, --domain, --run-instructions, --default-runtime, --response-format, and/or --self-healing")
+	}
+	if cmd.Flags().Changed("default-runtime") {
+		if err := validateRuntime("default-runtime", FunctionConfigureDefaultRuntime); err != nil {
+			return err
+		}
 	}
 
 	client, err := GetClient()
@@ -768,18 +798,13 @@ func runFunctionRun(cmd *cobra.Command, args []string) error {
 	if functionRunNoStream {
 		requestBody["stream"] = false
 	}
-	// Same reasoning for omitting it when unset: the server picks the runtime,
-	// and sending its current choice back would pin it. The valid values are
-	// spelled out here rather than left to the API so a typo costs a message
-	// instead of a 422 - at the price of needing an edit here if the spec grows
-	// a third runtime.
+	// Omitted unless asked: the run now inherits the function's saved
+	// default_runtime, and sending that value back would pin it.
 	if functionRunRuntime != "" {
-		switch api.RunFunctionRequestRuntime(functionRunRuntime) {
-		case api.Standard, api.Extended:
-			requestBody["runtime"] = functionRunRuntime
-		default:
-			return fmt.Errorf("invalid --runtime %q: expected %s or %s", functionRunRuntime, api.Standard, api.Extended)
+		if err := validateRuntime("runtime", functionRunRuntime); err != nil {
+			return err
 		}
+		requestBody["runtime"] = functionRunRuntime
 	}
 
 	bodyJSON, err := json.Marshal(requestBody)

--- a/internal/cmd/functionsextra_test.go
+++ b/internal/cmd/functionsextra_test.go
@@ -23,6 +23,7 @@ func configureCmd(t *testing.T) *cobra.Command {
 		FunctionConfigureDomain = ""
 		FunctionConfigureInstructions = ""
 		FunctionConfigureResponseFormat = ""
+		FunctionConfigureDefaultRuntime = ""
 		FunctionConfigureSelfHealing = false
 	})
 	return cmd
@@ -456,6 +457,58 @@ func TestFunctionRun_RejectsUnknownRuntime(t *testing.T) {
 		t.Errorf("error = %q, want it to mention invalid --runtime", err)
 	}
 	if got := server.Requests("/functions/" + functionIDTest + "/runs/start"); len(got) != 0 {
+		t.Errorf("sent %d requests despite an invalid runtime, want 0", len(got))
+	}
+}
+
+// --default-runtime is the whole point of a call that passes only it, so the
+// "nothing to configure" guard has to count it as a change.
+func TestFunctionConfigure_SendsDefaultRuntimeAlone(t *testing.T) {
+	server := setupFunctionTest(t)
+	server.AddResponse("/functions/"+functionIDTest, 200, functionJSON())
+
+	origFormat := outputFormat
+	outputFormat = "json"
+	t.Cleanup(func() { outputFormat = origFormat })
+
+	cmd := configureCmd(t)
+	if err := cmd.Flags().Set("default-runtime", "extended"); err != nil {
+		t.Fatalf("setting --default-runtime: %v", err)
+	}
+
+	testutil.CaptureOutput(func() {
+		if err := runFunctionConfigure(cmd, nil); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	requests := server.Requests("/functions/" + functionIDTest)
+	if len(requests) != 1 {
+		t.Fatalf("got %d requests, want 1", len(requests))
+	}
+	body := requestBody(t, requests[0])
+	if body["default_runtime"] != "extended" {
+		t.Errorf("default_runtime = %v, want extended", body["default_runtime"])
+	}
+}
+
+func TestFunctionConfigure_RejectsUnknownDefaultRuntime(t *testing.T) {
+	server := setupFunctionTest(t)
+	server.AddResponse("/functions/"+functionIDTest, 200, functionJSON())
+
+	cmd := configureCmd(t)
+	if err := cmd.Flags().Set("default-runtime", "lambda"); err != nil {
+		t.Fatalf("setting --default-runtime: %v", err)
+	}
+
+	err := runFunctionConfigure(cmd, nil)
+	if err == nil {
+		t.Fatal("expected an error for an unknown default runtime")
+	}
+	if !strings.Contains(err.Error(), "invalid --default-runtime") {
+		t.Errorf("error = %q, want it to mention invalid --default-runtime", err)
+	}
+	if got := server.Requests("/functions/" + functionIDTest); len(got) != 0 {
 		t.Errorf("sent %d requests despite an invalid runtime, want 0", len(got))
 	}
 }

--- a/scripts/gen-flags/types.go
+++ b/scripts/gen-flags/types.go
@@ -132,6 +132,11 @@ var FieldDescriptionOverrides = map[string]map[string]string{
 	"FunctionConfigure": {
 		"instructions": "Notes for whoever calls this function: how long a run takes, what the variables mean, what it trips over",
 		"self_healing": "Let an agent repair the function when a run fails",
+		// Typed as a plain string in the spec, so it arrives with no
+		// description and no enum; without this the help would read
+		// "default-runtime". No backticks: cobra reads the first backticked
+		// span in a usage string as the flag's argument placeholder.
+		"default_runtime": "Runtime this function's runs use unless a run overrides it: standard or extended",
 	},
 }
 


### PR DESCRIPTION
Automated regeneration of the generated API client (`internal/api`, `internal/cmd/*_flags.gen.go`) from the latest OpenAPI spec.

**Last regenerated:** 2026-09-09 15:24 UTC