### PR TITLE
fix: stop the FlexibleTime substitution missing aligned fields

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/oapi-codegen/runtime"
 	openapi_types "github.com/oapi-codegen/runtime/types"
@@ -684,11 +683,11 @@ type ApiAgentStartRequest_ReasoningModel struct {
 type ApiExecutionResponse struct {
 	Action          ApiExecutionResponse_Action `json:"action"`
 	Data            *DataSpace                  `json:"data,omitempty"`
-	EndedAt         time.Time                   `json:"ended_at"`
+	EndedAt         FlexibleTime                `json:"ended_at"`
 	Exception       *string                     `json:"exception,omitempty"`
 	ExceptionDetail *SerializedError            `json:"exception_detail,omitempty"`
 	Message         string                      `json:"message"`
-	StartedAt       time.Time                   `json:"started_at"`
+	StartedAt       FlexibleTime                `json:"started_at"`
 	Success         bool                        `json:"success"`
 }
 
@@ -945,10 +944,10 @@ type CompletionAction struct {
 
 // ConnectLinkContext defines model for ConnectLinkContext.
 type ConnectLinkContext struct {
-	AttemptsRemaining int       `json:"attempts_remaining"`
-	Domain            string    `json:"domain"`
-	ExpiresAt         time.Time `json:"expires_at"`
-	LogoColor         string    `json:"logo_color"`
+	AttemptsRemaining int          `json:"attempts_remaining"`
+	Domain            string       `json:"domain"`
+	ExpiresAt         FlexibleTime `json:"expires_at"`
+	LogoColor         string       `json:"logo_color"`
 
 	// RequiresMailbox Whether the connector reads its second factor from email, so the page must ask which inbox the code will arrive in.
 	RequiresMailbox bool `json:"requires_mailbox"`
@@ -1000,8 +999,8 @@ type ConnectLinkCreateResponse struct {
 	ConnectLinkId string `json:"connect_link_id"`
 
 	// ConnectUrl Send your end user here.
-	ConnectUrl string    `json:"connect_url"`
-	ExpiresAt  time.Time `json:"expires_at"`
+	ConnectUrl string       `json:"connect_url"`
+	ExpiresAt  FlexibleTime `json:"expires_at"`
 
 	// Token Returned once and never again - only its hash is stored.
 	Token string `json:"token"`
@@ -1494,7 +1493,7 @@ type FrameData struct {
 // FunctionListItemResponse defines model for FunctionListItemResponse.
 type FunctionListItemResponse struct {
 	// CreatedAt The creation time of the workflow
-	CreatedAt      time.Time                               `json:"created_at"`
+	CreatedAt      FlexibleTime                            `json:"created_at"`
 	DefaultRuntime *FunctionListItemResponseDefaultRuntime `json:"default_runtime,omitempty"`
 
 	// Description The description of the workflow
@@ -1559,7 +1558,7 @@ type FunctionMetadataUpdateRequest struct {
 // FunctionResponse defines model for FunctionResponse.
 type FunctionResponse struct {
 	// CreatedAt The creation time of the workflow
-	CreatedAt      time.Time                       `json:"created_at"`
+	CreatedAt      FlexibleTime                    `json:"created_at"`
 	DefaultRuntime *FunctionResponseDefaultRuntime `json:"default_runtime,omitempty"`
 
 	// Description The description of the workflow
@@ -1641,7 +1640,7 @@ type FunctionRunListItemResponse struct {
 	Local         *bool                             `json:"local,omitempty"`
 	SessionId     *string                           `json:"session_id,omitempty"`
 	Status        FunctionRunListItemResponseStatus `json:"status"`
-	UpdatedAt     time.Time                         `json:"updated_at"`
+	UpdatedAt     FlexibleTime                      `json:"updated_at"`
 	WorkflowId    *string                           `json:"workflow_id,omitempty"`
 	WorkflowRunId *string                           `json:"workflow_run_id,omitempty"`
 }
@@ -1718,7 +1717,7 @@ type FunctionSource string
 // FunctionWithLinkResponse defines model for FunctionWithLinkResponse.
 type FunctionWithLinkResponse struct {
 	// CreatedAt The creation time of the workflow
-	CreatedAt      time.Time                               `json:"created_at"`
+	CreatedAt      FlexibleTime                            `json:"created_at"`
 	DefaultRuntime *FunctionWithLinkResponseDefaultRuntime `json:"default_runtime,omitempty"`
 
 	// Description The description of the workflow
@@ -2238,11 +2237,11 @@ type NudgePromptResponse struct {
 
 // Observation defines model for Observation.
 type Observation struct {
-	EndedAt    time.Time        `json:"ended_at"`
+	EndedAt    FlexibleTime     `json:"ended_at"`
 	Metadata   SnapshotMetadata `json:"metadata"`
 	Screenshot Screenshot       `json:"screenshot"`
 	Space      ActionSpace      `json:"space"`
-	StartedAt  time.Time        `json:"started_at"`
+	StartedAt  FlexibleTime     `json:"started_at"`
 }
 
 // ObserveRequest defines model for ObserveRequest.
@@ -2700,7 +2699,7 @@ type SecretListResponse struct {
 
 // SecretMetadata defines model for SecretMetadata.
 type SecretMetadata struct {
-	CreatedAt  time.Time       `json:"created_at"`
+	CreatedAt  FlexibleTime    `json:"created_at"`
 	Id         string          `json:"id"`
 	KeyHint    string          `json:"key_hint"`
 	LastUsedAt *string         `json:"last_used_at,omitempty"`
@@ -3014,7 +3013,7 @@ type UpdateFunctionRunResponse struct {
 	// FunctionRunId The ID of the function run
 	FunctionRunId string                           `json:"function_run_id"`
 	Status        *UpdateFunctionRunResponseStatus `json:"status,omitempty"`
-	UpdatedAt     time.Time                        `json:"updated_at"`
+	UpdatedAt     FlexibleTime                     `json:"updated_at"`
 	WorkflowId    *string                          `json:"workflow_id,omitempty"`
 	WorkflowRunId *string                          `json:"workflow_run_id,omitempty"`
 }
@@ -3071,9 +3070,9 @@ type UploadFileActionOutput_Selector struct {
 
 // UsageLog defines model for UsageLog.
 type UsageLog struct {
-	CreatedAt  time.Time `json:"created_at"`
-	DurationMs int       `json:"duration_ms"`
-	Endpoint   string    `json:"endpoint"`
+	CreatedAt  FlexibleTime `json:"created_at"`
+	DurationMs int          `json:"duration_ms"`
+	Endpoint   string       `json:"endpoint"`
 }
 
 // UsageResponse defines model for UsageResponse.
@@ -3125,10 +3124,10 @@ type ValidationError_Loc_Item struct {
 
 // Vault defines model for Vault.
 type Vault struct {
-	CreatedAt  time.Time `json:"created_at"`
-	ForPersona *bool     `json:"for_persona,omitempty"`
-	Name       string    `json:"name"`
-	VaultId    string    `json:"vault_id"`
+	CreatedAt  FlexibleTime `json:"created_at"`
+	ForPersona *bool        `json:"for_persona,omitempty"`
+	Name       string       `json:"name"`
+	VaultId    string       `json:"vault_id"`
 }
 
 // VaultCreateRequest defines model for VaultCreateRequest.

--- a/internal/api/timestamps_gen_test.go
+++ b/internal/api/timestamps_gen_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Every timestamp on a generated response has to survive a payload without
+// timezone info, which is what FlexibleTime is for. Asserting it here rather
+// than only in generate.sh keeps the guarantee where a reader of the decoding
+// code will find it: the substitution that applies FlexibleTime matched a
+// single space between a field and its type, so a spec change that widened
+// gofmt's alignment padding beside `created_at` silently dropped these three
+// back to time.Time, and only a decode against a real response would have
+// caught it.
+func TestGeneratedTimestampsAcceptMissingTimezone(t *testing.T) {
+	t.Parallel()
+
+	const naive = `"2026-09-09T15:04:05"`
+
+	tests := []struct {
+		name    string
+		payload string
+		decode  func([]byte) (interface{ IsZero() bool }, error)
+	}{
+		{
+			name:    "FunctionResponse.created_at",
+			payload: `{"created_at":` + naive + `}`,
+			decode: func(b []byte) (interface{ IsZero() bool }, error) {
+				var v FunctionResponse
+				err := json.Unmarshal(b, &v)
+				return v.CreatedAt, err
+			},
+		},
+		{
+			name:    "FunctionListItemResponse.created_at",
+			payload: `{"created_at":` + naive + `}`,
+			decode: func(b []byte) (interface{ IsZero() bool }, error) {
+				var v FunctionListItemResponse
+				err := json.Unmarshal(b, &v)
+				return v.CreatedAt, err
+			},
+		},
+		{
+			name:    "FunctionWithLinkResponse.created_at",
+			payload: `{"created_at":` + naive + `}`,
+			decode: func(b []byte) (interface{ IsZero() bool }, error) {
+				var v FunctionWithLinkResponse
+				err := json.Unmarshal(b, &v)
+				return v.CreatedAt, err
+			},
+		},
+		{
+			name:    "FunctionRunListItemResponse.updated_at",
+			payload: `{"updated_at":` + naive + `}`,
+			decode: func(b []byte) (interface{ IsZero() bool }, error) {
+				var v FunctionRunListItemResponse
+				err := json.Unmarshal(b, &v)
+				return v.UpdatedAt, err
+			},
+		},
+		{
+			name:    "Vault.created_at",
+			payload: `{"created_at":` + naive + `}`,
+			decode: func(b []byte) (interface{ IsZero() bool }, error) {
+				var v Vault
+				err := json.Unmarshal(b, &v)
+				return v.CreatedAt, err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := tc.decode([]byte(tc.payload))
+			if err != nil {
+				t.Fatalf("decoding %s: %v", tc.payload, err)
+			}
+			if got.IsZero() {
+				t.Errorf("%s decoded to the zero time", tc.name)
+			}
+		})
+	}
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/nottelabs/notte-cli/internal/api"
 )
 
 type testData struct {
@@ -495,5 +498,43 @@ func TestNewFormatter(t *testing.T) {
 				t.Errorf("NewFormatter(%q) = %s, want %s", tt.format, got, tt.wantType)
 			}
 		})
+	}
+}
+
+// A timestamp is a value to print, not a struct to descend into. Before the
+// Stringer check, time.Time reached only unexported fields and printed a bare
+// "CreatedAt:", and FlexibleTime - which embeds it - added an empty "Time:"
+// underneath, so every timestamp the CLI showed in text form came out blank.
+func TestTextFormatter_Print_Timestamps(t *testing.T) {
+	var buf bytes.Buffer
+	f := &TextFormatter{Writer: &buf}
+
+	moment := time.Date(2026, 9, 9, 15, 4, 5, 0, time.UTC)
+	err := f.Print(struct {
+		Name      string
+		CreatedAt api.FlexibleTime
+		PlainAt   time.Time
+	}{
+		Name:      "checkout",
+		CreatedAt: api.FlexibleTime{Time: moment},
+		PlainAt:   moment,
+	})
+	if err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	got := buf.String()
+	if strings.Contains(got, "Time:") {
+		t.Errorf("descended into the timestamp instead of printing it:\n%s", got)
+	}
+	for _, field := range []string{"CreatedAt", "PlainAt"} {
+		for _, line := range strings.Split(got, "\n") {
+			if !strings.HasPrefix(strings.TrimSpace(line), field+":") {
+				continue
+			}
+			if !strings.Contains(line, "2026-09-09") {
+				t.Errorf("%s rendered as %q, want the timestamp", field, line)
+			}
+		}
 	}
 }

--- a/internal/output/text.go
+++ b/internal/output/text.go
@@ -98,6 +98,18 @@ func (f *TextFormatter) printStructWithIndent(data any, indent string) error {
 			fieldValue = fieldValue.Elem()
 		}
 
+		// A struct that renders itself is a value, not a level of nesting.
+		// Timestamps are the case that matters: descending into time.Time
+		// reaches only unexported fields and prints a bare "CreatedAt:", and
+		// FlexibleTime adds an empty "Time:" underneath it, so every timestamp
+		// the CLI shows in text form came out blank.
+		if fieldValue.Kind() == reflect.Struct {
+			if s, ok := fieldValue.Interface().(fmt.Stringer); ok {
+				_, _ = fmt.Fprintf(w, "%s\t%v\n", label, s.String())
+				continue
+			}
+		}
+
 		// Handle nested structs recursively
 		if fieldValue.Kind() == reflect.Struct {
 			_, _ = fmt.Fprintln(w, label)

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -147,7 +147,13 @@ fi
 # spec that reintroduces one - a time.Duration in a params struct, say - has to
 # keep it. Comment lines are dropped first so prose mentioning the package does
 # not read as a use.
-if ! grep -vE '^[[:space:]]*//' "$OUTPUT_DIR/client.gen.go" | grep -qE '(^|[^A-Za-z_])time\.[A-Za-z]'; then
+#
+# Deliberately not `grep -q` here: it exits on the first match, and under
+# pipefail the SIGPIPE that kills the upstream grep becomes the pipeline's
+# status. A file that does use the package would then take the branch that
+# deletes its import, intermittently, depending on whether the first grep had
+# already finished writing. Reading all the input costs nothing on one file.
+if ! grep -vE '^[[:space:]]*//' "$OUTPUT_DIR/client.gen.go" | grep -E '(^|[^A-Za-z_])time\.[A-Za-z]' >/dev/null; then
   sed -i.bak '/^	"time"$/d' "$OUTPUT_DIR/client.gen.go"
 fi
 

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -120,9 +120,36 @@ sed -i.bak 's/^func NewClient(/func newGeneratedClient(/g' "$OUTPUT_DIR/client.g
 sed -i.bak 's/NewClient(server, opts\.\.\.)/newGeneratedClient(server, opts...)/g' "$OUTPUT_DIR/client.gen.go"
 
 # Replace time.Time with FlexibleTime in struct fields for flexible timestamp parsing
-# This handles API responses that don't include timezone info
-sed -i.bak 's/\(	[A-Za-z]*\) time\.Time /\1 FlexibleTime /g' "$OUTPUT_DIR/client.gen.go"
-sed -i.bak 's/\(	[A-Za-z]*\) \*time\.Time /\1 *FlexibleTime /g' "$OUTPUT_DIR/client.gen.go"
+# This handles API responses that don't include timezone info.
+#
+# The gap between the field name and its type is one space in a struct whose
+# names happen to be the same length and gofmt's alignment padding otherwise, so
+# both are matched: `  *` rather than a single space, and rather than GNU sed's
+# `\+`, which BSD sed on macOS reads as a literal plus. Matching only one space
+# is how FunctionResponse.created_at silently lost FlexibleTime when the spec
+# grew a longer field beside it. gofmt below restores the alignment.
+sed -i.bak 's/\(	[A-Za-z]*\)  *time\.Time /\1 FlexibleTime /g' "$OUTPUT_DIR/client.gen.go"
+sed -i.bak 's/\(	[A-Za-z]*\)  *\*time\.Time /\1 *FlexibleTime /g' "$OUTPUT_DIR/client.gen.go"
+
+# A timestamp the substitution above missed parses only RFC3339, so a response
+# without timezone info fails to decode and the command dies on a field it was
+# only going to print. That failure reaches a user, not this script, so fail
+# here instead: a new spelling of a time field should stop the regeneration.
+if REMAINING=$(grep -nE '^	[A-Za-z]+ +\*?time\.Time' "$OUTPUT_DIR/client.gen.go"); then
+  echo "Error: struct fields still typed time.Time after the FlexibleTime substitution:" >&2
+  echo "$REMAINING" >&2
+  echo "Widen the sed patterns above to cover them." >&2
+  exit 1
+fi
+
+# With every timestamp now a FlexibleTime, nothing in the file refers to the
+# time package and Go refuses to compile an unused import. Conditional because a
+# spec that reintroduces one - a time.Duration in a params struct, say - has to
+# keep it. Comment lines are dropped first so prose mentioning the package does
+# not read as a use.
+if ! grep -vE '^[[:space:]]*//' "$OUTPUT_DIR/client.gen.go" | grep -qE '(^|[^A-Za-z_])time\.[A-Za-z]'; then
+  sed -i.bak '/^	"time"$/d' "$OUTPUT_DIR/client.gen.go"
+fi
 
 # Add omitempty to pointer fields that don't have it (optional fields shouldn't serialize as null)
 sed -i.bak -E 's/(\*[^`]+`json:"[^",]+)"`/\1,omitempty"`/g' "$OUTPUT_DIR/client.gen.go"

--- a/tests/integration/timestamps_test.go
+++ b/tests/integration/timestamps_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The bug this covers only exists against a real response: the generator
+// rewrites timestamps to FlexibleTime so a payload without timezone info still
+// decodes, and a substitution that missed a field left it as time.Time, which
+// fails on exactly that payload. A synthetic fixture proves the decoder, not
+// that the field the API populates is wired to it - so run the two commands
+// that print a function's created_at and look at what a user would see.
+func TestFunctionsListRendersCreatedAt(t *testing.T) {
+	result := runCLIText(t, "functions", "list")
+	requireSuccess(t, result)
+
+	if strings.Contains(result.Stdout, "Time:") {
+		t.Errorf("timestamp printed as a nested struct rather than a value:\n%s", result.Stdout)
+	}
+
+	// A date is the part worth asserting: the clock and zone vary by row, and
+	// pinning the layout would break on a formatting change that is not this
+	// bug.
+	date := regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "CreatedAt:") {
+			continue
+		}
+		if !date.MatchString(trimmed) {
+			t.Errorf("created_at rendered without a date: %q", trimmed)
+		}
+		return
+	}
+
+	t.Skip("no functions in this workspace to render a created_at for")
+}
+
+// `functions show` decodes FunctionResponse, a different generated type from
+// the one `functions list` returns, and it regressed alongside it.
+func TestFunctionShowDecodesCreatedAt(t *testing.T) {
+	list := runCLI(t, "functions", "list")
+	requireSuccess(t, list)
+
+	functionID := firstFunctionID(t, list.Stdout)
+	if functionID == "" {
+		t.Skip("no functions in this workspace to show")
+	}
+
+	result := runCLIText(t, "functions", "show", "--function-id", functionID)
+	requireSuccess(t, result)
+
+	if strings.Contains(result.Stdout, "Time:") {
+		t.Errorf("timestamp printed as a nested struct rather than a value:\n%s", result.Stdout)
+	}
+	if !regexp.MustCompile(`\d{4}-\d{2}-\d{2}`).MatchString(result.Stdout) {
+		t.Errorf("no timestamp in the output of functions show:\n%s", result.Stdout)
+	}
+}
+
+// firstFunctionID pulls an id out of `functions list -o json`, which returns
+// either a bare array or a paginated object depending on the workspace.
+func firstFunctionID(t *testing.T, stdout string) string {
+	t.Helper()
+
+	type item struct {
+		FunctionID string `json:"function_id"`
+	}
+
+	var items []item
+	if err := json.Unmarshal([]byte(stdout), &items); err != nil {
+		var paginated struct {
+			Items []item `json:"items"`
+		}
+		if err := json.Unmarshal([]byte(stdout), &paginated); err != nil {
+			t.Fatalf("parsing list response: %v", err)
+		}
+		items = paginated.Items
+	}
+
+	for _, it := range items {
+		if it.FunctionID != "" {
+			return it.FunctionID
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## The bug

`scripts/generate.sh` rewrites `time.Time` timestamps on generated types to `FlexibleTime`, which parses payloads without timezone info (added in `a271c54` to fix a real decode failure). The substitution matched **exactly one space** between the field name and its type:

```bash
sed -i.bak 's/\(	[A-Za-z]*\) time\.Time /\1 FlexibleTime /g'
```

So it only ever saw fields gofmt had not padded. When #102 added `default_runtime` beside `created_at`, gofmt widened the alignment:

```go
	CreatedAt      time.Time                               `json:"created_at"`
	DefaultRuntime *FunctionListItemResponseDefaultRuntime `json:"default_runtime,omitempty"`
```

and `FunctionResponse`, `FunctionListItemResponse` and `FunctionWithLinkResponse` silently dropped back to `time.Time` — nothing failed, the regen PR looked routine. A naive `created_at` now fails to decode, and `functions list` / `functions show` die on a field they were only going to print.

Eleven more fields (`Vault`, `SecretMetadata`, `UsageLog`, `Observation`, `ApiExecutionResponse`, …) had never been reached by the substitution at all, for the same reason.

## The fix

Match one-or-more spaces, spelled `  *` rather than GNU sed's `\+` — BSD sed on macOS reads `\+` as a literal plus, and this script runs on both. gofmt restores alignment afterwards.

All 14 affected fields are on **response** structs; none is a request body, so `FlexibleTime.MarshalJSON` never applies to anything the CLI sends. On output it encodes RFC3339Nano, and `null` instead of `0001-01-01T00:00:00Z` for a zero value — all 14 are required fields, so that case means the API omitted something required.

## Guards, so the next miss isn't silent

1. **Generation fails** on any struct field still typed `time.Time`. Verified by reverting the sed and re-running:
   ```
   exit=1
   Error: struct fields still typed time.Time after the FlexibleTime substitution:
   687:	EndedAt         time.Time                   `json:"ended_at"`
   ...
   ```
2. **A decode test** (`TestGeneratedTimestampsAcceptMissingTimezone`) asserts a naive timestamp survives on the three responses that regressed plus two that had never been converted — so `go test` catches it too, not just the generator.

## Incidental

With no timestamp left as `time.Time`, nothing referenced the `time` import and Go rejects an unused one. The generator now drops it when unused — conditionally, so a spec that reintroduces a real use (a `time.Duration` in a params struct) keeps it.

## Diff shape

`client.gen.go` is 23 lines changed: 14 field type changes, the rest gofmt realigning neighbours in the same struct blocks. No other generated content moved.

## Testing

`go test ./...`, `make check` (generated code reproducible), `make check-endpoints`, `make check-skills`, `make lint` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)