### PR TITLE
Fix long-running function timeouts and add --no-wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,13 +211,28 @@ notte functions health                # Runtime health: Python version, installe
 notte functions delete                # Delete current function
 notte functions fork                  # Fork current function to new version
 notte functions run                   # Execute current function
-notte functions run --no-stream       # ... returning only the final response, without streamed logs
+notte functions run --no-stream       # Poll until complete, returning final run metadata without log output
+notte functions run --no-wait          # Return the run ID after startup
+notte functions run-metadata --wait --run-id <id> [--wait-timeout 30m]  # Wait for an existing run
 notte functions runs [--page N] [--page-size N] [--running]  # List runs for current function (--running = in-flight only)
 notte functions run-stop --run-id <id>  # Stop a running function execution
 notte functions run-metadata --run-id <id>  # Get run logs and results
 notte functions schedule --cron "0 12 ? * * *"  # Schedule current function (six-field cron: daily at noon UTC)
 notte functions unschedule            # Remove schedule from current function
 ```
+
+Function runs print their ID and a tracking command to stderr as soon as the
+server creates the run. After the runner accepts the request, the CLI closes the
+response stream and polls metadata. `--timeout` applies to each API request;
+`--wait-timeout` limits the total wait (unlimited by default). `--no-wait` returns
+after startup so another command can wait separately.
+
+In JSON mode, stdout contains one object: the run ID and status with `--no-wait`,
+or final run metadata (including `status`, `logs`, and the stored `result` string)
+when waiting. Logs are printed to stderr as they become available in metadata;
+some runners persist logs only at completion. `--no-stream` suppresses those
+log messages. An interrupted or timed-out CLI does not cancel the server run:
+resume with `run-metadata --wait`, or explicitly stop it with `run-stop`.
 
 ### Personas, Profiles and Usage
 
@@ -250,7 +265,7 @@ notte functions configure --response-format @schema.json
 run takes, what each variable is for, which sites it trips over:
 
 ```bash
-notte functions configure --run-instructions "Takes ~3 min, so call it async. \
+notte functions configure --run-instructions "Takes ~3 min, so call it with --no-wait. \
 Hits a captcha on the login page every few runs. \
 \`query\` is the search term; \`max_items\` caps the results."
 ```

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -150,6 +150,10 @@ func (t *resilientTransport) doWithRetry(req *http.Request) (*http.Response, err
 	var err error
 
 	for attempt := 0; attempt <= t.retryConfig.MaxRetries; attempt++ {
+		if err := req.Context().Err(); err != nil {
+			return nil, err
+		}
+
 		// Clone request for each attempt
 		reqCopy := cloneRequest(req)
 
@@ -160,7 +164,7 @@ func (t *resilientTransport) doWithRetry(req *http.Request) (*http.Response, err
 				return nil, err
 			}
 			if attempt < t.retryConfig.MaxRetries {
-				time.Sleep(t.retryConfig.Backoff(attempt))
+				sleepWithContext(req.Context(), t.retryConfig.Backoff(attempt))
 				continue
 			}
 			return nil, err
@@ -176,7 +180,7 @@ func (t *resilientTransport) doWithRetry(req *http.Request) (*http.Response, err
 
 		// Sleep before retry
 		if attempt < t.retryConfig.MaxRetries {
-			time.Sleep(t.retryConfig.Backoff(attempt))
+			sleepWithContext(req.Context(), t.retryConfig.Backoff(attempt))
 		}
 	}
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -404,3 +404,63 @@ func TestDefaultContext(t *testing.T) {
 		t.Error("DefaultContext() should return context.Background()")
 	}
 }
+
+// A caller's deadline must interrupt both retry paths rather than waiting for
+// the full backoff and issuing more requests with an already-canceled context.
+func TestResilientTransport_DoWithRetry_InterruptsBackoff(t *testing.T) {
+	for _, networkError := range []bool{false, true} {
+		name := "server error"
+		if networkError {
+			name = "network error"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+			defer cancel()
+			calls := 0
+			rt := &resilientTransport{
+				retryConfig: &RetryConfig{MaxRetries: 2, InitialBackoff: time.Second, MaxBackoff: time.Second},
+				base: transportFunc(func(*http.Request) (*http.Response, error) {
+					calls++
+					if networkError {
+						return nil, errors.New("network unavailable")
+					}
+					return &http.Response{StatusCode: http.StatusServiceUnavailable, Body: io.NopCloser(strings.NewReader("unavailable"))}, nil
+				}),
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.test", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			start := time.Now()
+			_, err = rt.doWithRetry(req)
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("expected deadline error, got %v", err)
+			}
+			if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+				t.Fatalf("deadline failed to interrupt backoff: %s", elapsed)
+			}
+			if calls != 1 {
+				t.Fatalf("made %d requests, expected one before cancellation", calls)
+			}
+		})
+	}
+}
+
+func TestResilientTransport_DoWithRetry_AlreadyCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rt := &resilientTransport{
+		retryConfig: DefaultRetryConfig(),
+		base: transportFunc(func(*http.Request) (*http.Response, error) {
+			t.Error("canceled request reached the transport")
+			return nil, errors.New("unexpected request")
+		}),
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.doWithRetry(req); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation, got %v", err)
+	}
+}

--- a/internal/cmd/function_run.go
+++ b/internal/cmd/function_run.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nottelabs/notte-cli/internal/api"
+)
+
+const functionPollInterval = 2 * time.Second
+
+func functionWaitContext(cmd *cobra.Command) (context.Context, context.CancelFunc, error) {
+	var timeout time.Duration
+	if cmd.Flags().Lookup("wait-timeout") != nil {
+		timeout, _ = cmd.Flags().GetDuration("wait-timeout")
+	}
+	if timeout < 0 {
+		return nil, nil, errors.New("--wait-timeout must not be negative")
+	}
+	if timeout > 0 {
+		ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+		return ctx, cancel, nil
+	}
+	ctx, cancel := context.WithCancel(cmd.Context())
+	return ctx, cancel, nil
+}
+
+func functionRunHint(id, runID string) string {
+	return fmt.Sprintf("notte functions run-metadata --wait --function-id %s --run-id %s", id, runID)
+}
+
+func functionWaitError(id, runID string, err error) error {
+	return fmt.Errorf("stopped waiting for function run %s: %w; the CLI did not stop the function. Resume with `%s`", runID, err, functionRunHint(id, runID))
+}
+
+func startAndWaitFunction(cmd *cobra.Command, client *api.NotteClient, variables map[string]interface{}) error {
+	ctx, cancel, err := functionWaitContext(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	runID, result, err := startFunction(ctx, client, functionID, functionRunRuntime, variables)
+	if err != nil {
+		if runID != "" {
+			return fmt.Errorf("could not confirm startup of function run %s: %w; it may still be executing. Check it with `%s` before starting another run", runID, err, functionRunHint(functionID, runID))
+		}
+		return fmt.Errorf("function start request failed: %w; a run may have been created. Check `notte functions runs --function-id %s` before retrying", err, functionID)
+	}
+	// Older servers can return a complete JSON response directly.
+	if result != nil {
+		return GetFormatter().Print(result)
+	}
+	if functionRunNoWait {
+		return GetFormatter().Print(map[string]any{
+			"function_id":     functionID,
+			"function_run_id": runID,
+			"status":          "active",
+		})
+	}
+	return waitFunction(ctx, client, functionID, runID, functionRunNoStream, functionPollInterval)
+}
+
+// The start endpoint redirects to the runner with a pre-created run ID. The
+// runner executes independently, but stream:false holds the response until it
+// finishes. Request streaming even with --no-stream, wait for HTTP acceptance,
+// then close the connection and follow the durable run through metadata GETs.
+func startFunction(ctx context.Context, client *api.NotteClient, id, runtime string, variables map[string]interface{}) (runID string, result any, err error) {
+	ctx, cancel := GetContextWithTimeout(ctx)
+	defer cancel()
+	requestBody := map[string]any{"workflow_id": id, "variables": variables, "stream": true}
+	// Omit the override to inherit the function's saved default runtime.
+	if runtime != "" {
+		requestBody["runtime"] = runtime
+	}
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimRight(client.BaseURL(), "/")+"/functions/"+url.PathEscape(id)+"/runs/start", bytes.NewReader(body))
+	if err != nil {
+		return "", nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-notte-api-key", client.APIKey())
+
+	httpClient := *client.HTTPClient()
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if value := req.URL.Query().Get("function_run_id"); value != "" && runID == "" {
+			runID = value
+			// Always stderr: JSON stdout remains a single final response.
+			_, _ = fmt.Fprintf(os.Stderr, "Function run %s created. Track it with `%s`.\n", runID, functionRunHint(id, runID))
+		}
+		return nil
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return runID, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 || strings.Contains(resp.Header.Get("Content-Type"), "application/json") {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return runID, nil, err
+		}
+		if err := HandleAPIResponse(resp, body); err != nil {
+			return runID, nil, err
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return runID, nil, fmt.Errorf("invalid start response: %w", err)
+		}
+		if result == nil {
+			return runID, nil, errors.New("empty start response")
+		}
+		return runID, result, nil
+	}
+	if runID == "" {
+		return "", nil, errors.New("server did not provide a function_run_id in its startup redirect")
+	}
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "text/plain") && !strings.HasPrefix(contentType, "text/event-stream") {
+		return runID, nil, fmt.Errorf("unexpected runner content type %q", contentType)
+	}
+	// Do returns after response headers. Do not wait for a log event: a quiet
+	// function may not emit one until it finishes, recreating the same timeout.
+	// Execution errors and results are retrieved from durable run metadata.
+	return runID, nil, nil
+}
+
+func runFunctionRunWait(cmd *cobra.Command, args []string) error {
+	if err := RequireFunctionID(); err != nil {
+		return err
+	}
+	if functionRunID == "" {
+		return errors.New("--run-id is required")
+	}
+	ctx, cancel, err := functionWaitContext(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	client, err := GetClient()
+	if err != nil {
+		return err
+	}
+	noStream, _ := cmd.Flags().GetBool("no-stream")
+	return waitFunction(ctx, client, functionID, functionRunID, noStream, functionPollInterval)
+}
+
+func waitFunction(ctx context.Context, client *api.NotteClient, id, runID string, noStream bool, interval time.Duration) error {
+	logsPrinted := 0
+	for {
+		requestCtx, cancel := GetContextWithTimeout(ctx)
+		resp, err := client.Client().FunctionRunGetMetadataWithResponse(requestCtx, id, runID, &api.FunctionRunGetMetadataParams{})
+		cancel()
+		if err != nil {
+			return functionWaitError(id, runID, err)
+		}
+		if err := HandleAPIResponse(resp.HTTPResponse, resp.Body); err != nil {
+			return functionWaitError(id, runID, err)
+		}
+		run := resp.JSON200
+		if run == nil || run.FunctionRunId != runID || run.FunctionId != id {
+			return functionWaitError(id, runID, errors.New("missing or mismatched run metadata"))
+		}
+		if !noStream && run.Logs != nil {
+			for ; logsPrinted < len(*run.Logs); logsPrinted++ {
+				_, _ = fmt.Fprintln(os.Stderr, (*run.Logs)[logsPrinted])
+			}
+		}
+		switch run.Status {
+		case api.GetFunctionRunResponseStatusClosed, api.GetFunctionRunResponseStatusFailed:
+			return GetFormatter().Print(run)
+		case api.GetFunctionRunResponseStatusActive:
+		default:
+			return functionWaitError(id, runID, fmt.Errorf("unrecognized run status %q", run.Status))
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return functionWaitError(id, runID, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}

--- a/internal/cmd/function_run_test.go
+++ b/internal/cmd/function_run_test.go
@@ -1,0 +1,229 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/nottelabs/notte-cli/internal/api"
+	"github.com/nottelabs/notte-cli/internal/testutil"
+)
+
+func setupFunctionRunTest(t *testing.T) *cobra.Command {
+	t.Helper()
+	setupFunctionTest(t)
+	origFormat, origTimeout := outputFormat, requestTimeout
+	origNoWait, origNoStream := functionRunNoWait, functionRunNoStream
+	origVars, origJSON := functionRunVariables, functionRunVariablesJSON
+	outputFormat, requestTimeout = "json", 1
+	functionRunNoWait, functionRunNoStream = false, true
+	functionRunVariables, functionRunVariablesJSON = nil, `{"nested":{"ok":true}}`
+	t.Cleanup(func() {
+		outputFormat, requestTimeout = origFormat, origTimeout
+		functionRunNoWait, functionRunNoStream = origNoWait, origNoStream
+		functionRunVariables, functionRunVariablesJSON = origVars, origJSON
+	})
+	cmd := &cobra.Command{}
+	cmd.Flags().Duration("wait-timeout", 0, "")
+	cmd.Flags().Bool("no-stream", true, "")
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+func writeRunMetadata(w http.ResponseWriter, status string) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = fmt.Fprintf(w, `{"function_id":"fn_123","function_run_id":"run_123","status":%q,"logs":["first log"],"result":"{\"ok\":true}"}`, status)
+}
+
+// No response is kept open for the function's lifetime. The CLI must close the
+// runner stream before polling, and a total duration exceeding --timeout must
+// still succeed without ever starting a second run.
+func TestFunctionRun_DetachesAndPollsBeyondRequestTimeout(t *testing.T) {
+	cmd := setupFunctionRunTest(t)
+	var starts, polls atomic.Int32
+	disconnected := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/functions/fn_123/runs/start":
+			starts.Add(1)
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+			}
+			if body["stream"] != true || body["workflow_id"] != functionIDTest {
+				t.Errorf("invalid startup payload: %v", body)
+			}
+			if body["variables"].(map[string]any)["nested"].(map[string]any)["ok"] != true {
+				t.Error("lost nested variables")
+			}
+			http.Redirect(w, r, "/runner?function_run_id=run_123", http.StatusTemporaryRedirect)
+		case "/runner":
+			if r.Method != http.MethodPost || r.Header.Get("x-notte-api-key") != "test-key" {
+				t.Error("redirect lost method or authentication")
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			_, _ = fmt.Fprint(w, "data: {\"type\":\"log\",\"message\":\"started\"}\n\n")
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+			close(disconnected)
+		case "/functions/fn_123/runs/run_123":
+			select {
+			case <-disconnected:
+			case <-time.After(time.Second):
+				t.Error("runner stream still open during polling")
+			}
+			status := "active"
+			if polls.Add(1) == 2 {
+				status = "closed"
+			}
+			writeRunMetadata(w, status)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("NOTTE_API_URL", server.URL)
+	var runErr error
+	stdout, stderr := testutil.CaptureOutput(func() { runErr = runFunctionRun(cmd, nil) })
+	if runErr != nil {
+		t.Fatal(runErr)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("stdout must contain one JSON document: %s (%v)", stdout, err)
+	}
+	if result["status"] != "closed" || starts.Load() != 1 || polls.Load() != 2 {
+		t.Fatalf("result=%v starts=%d polls=%d", result, starts.Load(), polls.Load())
+	}
+	if !strings.Contains(stderr, "run_123") || !strings.Contains(stderr, "run-metadata --wait") || strings.Contains(stderr, "first log") {
+		t.Fatalf("missing run recovery hint or leaked --no-stream log: %s", stderr)
+	}
+}
+
+func TestFunctionRun_NoWaitReturnsWithoutPolling(t *testing.T) {
+	cmd := setupFunctionRunTest(t)
+	functionRunNoWait = true
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/functions/fn_123/runs/start":
+			http.Redirect(w, r, "/runner?function_run_id=run_123", http.StatusTemporaryRedirect)
+		case "/runner":
+			w.Header().Set("Content-Type", "text/event-stream")
+			// A quiet function sends no log events before completion. Startup
+			// must return on HTTP acceptance, without waiting for a body byte.
+			w.WriteHeader(http.StatusOK)
+			w.(http.Flusher).Flush()
+			<-r.Context().Done()
+		default:
+			t.Errorf("--no-wait must not poll: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	t.Setenv("NOTTE_API_URL", server.URL)
+	var runErr error
+	stdout, _ := testutil.CaptureOutput(func() { runErr = runFunctionRun(cmd, nil) })
+	if runErr != nil {
+		t.Fatal(runErr)
+	}
+	var result map[string]any
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil || result["function_run_id"] != functionRunIDTest {
+		t.Fatalf("missing --no-wait run ID: %s (%v)", stdout, err)
+	}
+}
+
+func TestFunctionRun_StartupErrorRetainsRunID(t *testing.T) {
+	for _, status := range []int{400, 429, 502} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			cmd := setupFunctionRunTest(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/functions/fn_123/runs/start" {
+					http.Redirect(w, r, "/runner?function_run_id=run_123", http.StatusTemporaryRedirect)
+					return
+				}
+				http.Error(w, "startup failed", status)
+			}))
+			defer server.Close()
+			t.Setenv("NOTTE_API_URL", server.URL)
+			var runErr error
+			testutil.CaptureOutput(func() { runErr = runFunctionRun(cmd, nil) })
+			if runErr == nil || !strings.Contains(runErr.Error(), "run_123") || !strings.Contains(runErr.Error(), "before starting another run") {
+				t.Fatalf("missing startup recovery: %v", runErr)
+			}
+		})
+	}
+}
+
+func TestFunctionRunWait_TimeoutDoesNotStopRun(t *testing.T) {
+	cmd := setupFunctionRunTest(t)
+	cmd.Flags().Bool("wait", true, "")
+	if err := cmd.Flags().Set("wait-timeout", "30ms"); err != nil {
+		t.Fatal(err)
+	}
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Method != http.MethodGet || r.URL.Path != "/functions/fn_123/runs/run_123" {
+			t.Errorf("wait must only read the existing run: %s %s", r.Method, r.URL.Path)
+		}
+		writeRunMetadata(w, "active")
+	}))
+	defer server.Close()
+	t.Setenv("NOTTE_API_URL", server.URL)
+	err := runFunctionRunMetadata(cmd, nil)
+	if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "CLI did not stop") || !strings.Contains(err.Error(), "run-metadata --wait --function-id fn_123 --run-id run_123") {
+		t.Fatalf("missing wait recovery: %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("requests = %d", requests.Load())
+	}
+}
+
+func TestFunctionRunWait_TerminalAndInvalidResponses(t *testing.T) {
+	for _, status := range []string{"closed", "failed", "unexpected"} {
+		t.Run(status, func(t *testing.T) {
+			setupFunctionRunTest(t)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { writeRunMetadata(w, status) }))
+			defer server.Close()
+			client, err := api.NewClientWithURL("test-key", server.URL, "test")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var runErr error
+			stdout, stderr := testutil.CaptureOutput(func() {
+				runErr = waitFunction(context.Background(), client, functionIDTest, functionRunIDTest, false, time.Millisecond)
+			})
+			if status == "unexpected" {
+				if runErr == nil || !strings.Contains(runErr.Error(), "unrecognized run status") {
+					t.Fatalf("unexpected status accepted: %v", runErr)
+				}
+				return
+			}
+			if runErr != nil || !strings.Contains(stdout, status) || strings.Count(stderr, "first log") != 1 {
+				t.Fatalf("stdout=%s stderr=%s err=%v", stdout, stderr, runErr)
+			}
+		})
+	}
+}
+
+func TestGetClient_HonorsRequestTimeout(t *testing.T) {
+	setupFunctionRunTest(t)
+	requestTimeout = 1800
+	client, err := GetClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.HTTPClient().Timeout != 30*time.Minute {
+		t.Fatalf("HTTP timeout = %s", client.HTTPClient().Timeout)
+	}
+}

--- a/internal/cmd/functions.go
+++ b/internal/cmd/functions.go
@@ -1,12 +1,9 @@
 package cmd
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +22,7 @@ var (
 	functionRunVariablesJSON string   // Variables as JSON string
 	functionRunNoStream      bool     // Opt out of log streaming
 	functionRunRuntime       string   // Which execution runtime to run on
+	functionRunNoWait        bool
 	functionSecretValue      string
 	functionDownloadVersion  string
 )
@@ -168,6 +166,7 @@ var functionsDeleteCmd = &cobra.Command{
 var functionsRunCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run the function",
+	Long:  "Start the function, print its run ID, and poll until it finishes.\nUse --no-wait to return after startup, then run-metadata --wait to wait separately.\n--timeout limits each API request, not the total execution time.\nInterrupting the CLI does not stop the function; use run-stop to cancel it.",
 	Args:  cobra.NoArgs,
 	RunE:  runFunctionRun,
 }
@@ -325,10 +324,13 @@ func init() {
 	functionsRunCmd.Flags().StringVar(&functionID, "function-id", "", "Function ID (uses current function if not specified)")
 	functionsRunCmd.Flags().StringArrayVar(&functionRunVariables, "var", []string{}, "Variable as key=value pair (can be used multiple times)")
 	functionsRunCmd.Flags().StringVar(&functionRunVariablesJSON, "vars", "", "Variables as JSON object string")
-	// An opt-out rather than a --stream toggle: the API streams by default, so
-	// a positive flag would be an opt-in to something already on. Same shape,
-	// and the same reasoning, as --no-solve-captchas on sessions start.
-	functionsRunCmd.Flags().BoolVar(&functionRunNoStream, "no-stream", false, "Return only the final response instead of streaming logs")
+	functionsRunCmd.Flags().BoolVar(&functionRunNoStream, "no-stream", false, "Suppress log output while waiting for the final run metadata")
+	functionsRunCmd.Flags().BoolVar(&functionRunNoWait, "no-wait", false, "Return the run ID after startup without waiting for completion")
+	for _, cmd := range []*cobra.Command{functionsRunCmd, functionsRunMetadataCmd} {
+		cmd.Flags().Duration("wait-timeout", 0, "Maximum time to wait for completion (e.g. 30m; 0 waits indefinitely)")
+	}
+	functionsRunMetadataCmd.Flags().Bool("wait", false, "Poll until the run finishes; --timeout applies to each request")
+	functionsRunMetadataCmd.Flags().Bool("no-stream", false, "Suppress log output while waiting for the final run metadata")
 	functionsRunCmd.Flags().StringVar(&functionRunRuntime, "runtime", "", fmt.Sprintf("Run on %s for this run only, overriding the function's default-runtime", strings.Join(runtimeValues, " or ")))
 	_ = functionsRunCmd.RegisterFlagCompletionFunc("runtime", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return runtimeValues, cobra.ShellCompDirectiveNoFileComp
@@ -765,9 +767,6 @@ func runFunctionRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	ctx, cancel := GetContextWithTimeout(cmd.Context())
-	defer cancel()
-
 	// Parse variables
 	variables := make(map[string]interface{})
 
@@ -776,6 +775,9 @@ func runFunctionRun(cmd *cobra.Command, args []string) error {
 		if err := json.Unmarshal([]byte(functionRunVariablesJSON), &variables); err != nil {
 			return fmt.Errorf("failed to parse --vars JSON: %w", err)
 		}
+	}
+	if variables == nil {
+		return errors.New("--vars must be a JSON object")
 	}
 
 	// Then, parse key=value pairs (these override JSON if there's a conflict)
@@ -787,62 +789,12 @@ func runFunctionRun(cmd *cobra.Command, args []string) error {
 		variables[parts[0]] = parts[1]
 	}
 
-	// The generated client doesn't support request body for FunctionRunStart,
-	// so we need to make a manual request with the function_id in the body
-	requestBody := map[string]interface{}{
-		"function_id": functionID,
-		"variables":   variables,
-	}
-	// Sent only when asked. The API's own default is true, so transmitting it
-	// unconditionally would freeze today's server-side behaviour into the client.
-	if functionRunNoStream {
-		requestBody["stream"] = false
-	}
-	// Omitted unless asked: the run now inherits the function's saved
-	// default_runtime, and sending that value back would pin it.
 	if functionRunRuntime != "" {
 		if err := validateRuntime("runtime", functionRunRuntime); err != nil {
 			return err
 		}
-		requestBody["runtime"] = functionRunRuntime
 	}
-
-	bodyJSON, err := json.Marshal(requestBody)
-	if err != nil {
-		return fmt.Errorf("failed to marshal request body: %w", err)
-	}
-
-	url := fmt.Sprintf("%s/functions/%s/runs/start", client.BaseURL(), functionID)
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(bodyJSON))
-	if err != nil {
-		return fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-notte-api-key", client.APIKey())
-
-	httpResp, err := client.HTTPClient().Do(req)
-	if err != nil {
-		return fmt.Errorf("API request failed: %w", err)
-	}
-	defer func() { _ = httpResp.Body.Close() }()
-
-	body, err := io.ReadAll(httpResp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if err := HandleAPIResponse(httpResp, body); err != nil {
-		return err
-	}
-
-	// Parse and print the response
-	var result interface{}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	return GetFormatter().Print(result)
+	return startAndWaitFunction(cmd, client, variables)
 }
 
 func runFunctionRuns(cmd *cobra.Command, args []string) error {
@@ -948,6 +900,9 @@ func runFunctionRunStop(cmd *cobra.Command, args []string) error {
 }
 
 func runFunctionRunMetadata(cmd *cobra.Command, args []string) error {
+	if wait, _ := cmd.Flags().GetBool("wait"); wait {
+		return runFunctionRunWait(cmd, args)
+	}
 	if err := RequireFunctionID(); err != nil {
 		return err
 	}

--- a/internal/cmd/functionsextra_test.go
+++ b/internal/cmd/functionsextra_test.go
@@ -328,17 +328,16 @@ func TestFunctionHealth_ReadsTheRuntime(t *testing.T) {
 	}
 }
 
-// The API streams by default, so the field is sent only to turn it off.
-// Transmitting it either way would freeze today's server-side default into the
-// client — the same reasoning behind the generated builders' Changed() guards.
-func TestFunctionRun_SendsStreamOnlyWithNoStream(t *testing.T) {
+// --no-stream controls local log output. Startup always requests a stream so
+// the runner can acknowledge execution before the function finishes.
+func TestFunctionRun_AlwaysStartsWithStream(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		noStream bool
 		want     any
 	}{
-		{name: "default omits stream", noStream: false, want: nil},
-		{name: "--no-stream sends false", noStream: true, want: false},
+		{name: "default", noStream: false, want: true},
+		{name: "--no-stream", noStream: true, want: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			server := setupFunctionTest(t)
@@ -368,14 +367,8 @@ func TestFunctionRun_SendsStreamOnlyWithNoStream(t *testing.T) {
 			}
 			body := requestBody(t, requests[0])
 			got, present := body["stream"]
-			if tc.want == nil {
-				if present {
-					t.Errorf("stream was sent as %v without --no-stream", got)
-				}
-				return
-			}
 			if !present {
-				t.Fatal("stream was not sent despite --no-stream")
+				t.Fatal("stream was not sent")
 			}
 			if got != tc.want {
 				t.Errorf("stream = %v, want %v", got, tc.want)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -136,7 +136,14 @@ func GetClient() (*api.NotteClient, error) {
 		opts = append(opts, api.WithRequestOrigin(origin))
 	}
 
-	return api.NewClientWithURL(apiKey, baseURL, Version, opts...)
+	client, err := api.NewClientWithURL(apiKey, baseURL, Version, opts...)
+	if err != nil {
+		return nil, err
+	}
+	// Commands enforce --timeout through their request contexts. The client's
+	// shorter default must not silently override a caller's explicit timeout.
+	client.HTTPClient().Timeout = time.Duration(requestTimeout) * time.Second
+	return client, nil
 }
 
 // GetContextWithTimeout wraps the provided context with a timeout

--- a/tests/integration/function_polling_test.go
+++ b/tests/integration/function_polling_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Exercise the real runner's redirect and disconnect behavior through CLI
+// subprocesses. A quiet function takes longer than the 10-second HTTP timeout
+// without launching a browser or touching an external website.
+func TestFunctionRunPolling(t *testing.T) {
+	t.Setenv("NOTTE_CONFIG_DIR", t.TempDir())
+	const marker = "function-polling-integration-complete"
+	path := filepath.Join(t.TempDir(), "quiet.py")
+	code := "import time\n\ndef run() -> str:\n    time.sleep(20)\n    print('" + marker + "')\n    return '" + marker + "'\n"
+	if err := os.WriteFile(path, []byte(code), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	created := runCLI(t, "functions", "create", "--file", path, "--name", "cli-polling-integration")
+	requireSuccess(t, created)
+	var function struct {
+		ID string `json:"function_id"`
+	}
+	if err := json.Unmarshal([]byte(created.Stdout), &function); err != nil || function.ID == "" {
+		t.Fatalf("invalid create response: %s (%v)", created.Stdout, err)
+	}
+	defer cleanupFunction(t, function.ID)
+
+	type runMetadata struct {
+		FunctionID string `json:"function_id"`
+		RunID      string `json:"function_run_id"`
+		Status     string `json:"status"`
+		Result     string `json:"result"`
+	}
+	decodeRun := func(t *testing.T, result CLIResult) runMetadata {
+		t.Helper()
+		requireSuccess(t, result)
+		var run runMetadata
+		if err := json.Unmarshal([]byte(result.Stdout), &run); err != nil {
+			t.Fatalf("stdout must contain exactly one JSON document: %s (%v)", result.Stdout, err)
+		}
+		if run.FunctionID != function.ID || run.RunID == "" {
+			t.Fatalf("missing or mismatched run identity: %+v", run)
+		}
+		return run
+	}
+	assertCompleted := func(t *testing.T, result CLIResult) runMetadata {
+		t.Helper()
+		run := decodeRun(t, result)
+		if run.Status != "closed" || run.Result != marker {
+			t.Fatalf("function did not complete successfully after disconnect: %+v", run)
+		}
+		if strings.Contains(result.Stderr, marker) {
+			t.Fatalf("--no-stream printed function logs: %s", result.Stderr)
+		}
+		return run
+	}
+
+	t.Run("no-wait then resume after wait timeout", func(t *testing.T) {
+		started := runCLI(t, "functions", "run", "--function-id", function.ID, "--no-wait")
+		run := decodeRun(t, started)
+		completed := false
+		defer func() {
+			if !completed {
+				_ = runCLI(t, "functions", "run-stop", "--function-id", function.ID, "--run-id", run.RunID)
+			}
+		}()
+		metadata := decodeRun(t, runCLI(t, "functions", "run-metadata", "--function-id", function.ID, "--run-id", run.RunID))
+		if metadata.Status != "active" {
+			t.Fatalf("--no-wait waited for completion: %+v", metadata)
+		}
+		timedOut := runCLI(t, "functions", "run-metadata", "--function-id", function.ID, "--run-id", run.RunID,
+			"--wait", "--no-stream", "--wait-timeout", "1s")
+		requireFailure(t, timedOut)
+		if !strings.Contains(timedOut.Stderr, run.RunID) || !strings.Contains(timedOut.Stderr, "CLI did not stop") {
+			t.Fatalf("timeout lost recovery instructions: %s", timedOut.Stderr)
+		}
+		result := runCLIWithTimeout(t, 2*time.Minute, "functions", "run-metadata", "--function-id", function.ID,
+			"--run-id", run.RunID, "--wait", "--no-stream", "--timeout", "10", "--wait-timeout", "90s")
+		final := assertCompleted(t, result)
+		completed = true
+		if final.RunID != run.RunID {
+			t.Fatalf("resumed a different run: %s != %s", final.RunID, run.RunID)
+		}
+	})
+
+	t.Run("no-stream outlasts request timeout", func(t *testing.T) {
+		start := time.Now()
+		result := runCLIWithTimeout(t, 2*time.Minute, "functions", "run", "--function-id", function.ID,
+			"--no-stream", "--timeout", "10", "--wait-timeout", "90s")
+		_ = assertCompleted(t, result)
+		if elapsed := time.Since(start); elapsed < 10*time.Second {
+			t.Fatalf("run did not exercise execution beyond the request timeout: %s", elapsed)
+		}
+	})
+
+	// Starting and resuming must not create duplicate server runs.
+	listed := runCLI(t, "functions", "runs", "--function-id", function.ID)
+	requireSuccess(t, listed)
+	var runs []runMetadata
+	if err := json.Unmarshal([]byte(listed.Stdout), &runs); err != nil || len(runs) != 2 {
+		t.Fatalf("expected exactly two runs across start/wait/resume commands: %s (%v)", listed.Stdout, err)
+	}
+}


### PR DESCRIPTION
Long-running functions could finish successfully on the server while `functions run --no-stream` timed out waiting for the response body. The CLI now prints the run ID from the startup redirect, closes the response after the runner accepts the request, and polls run metadata with a fresh timeout per request. Quiet functions do not need to emit a log before the CLI can detach.

- Keep waiting by default; `--no-stream` suppresses logs and `--no-wait` returns the run ID after startup.
- Add `functions run-metadata --wait` to wait for an existing run, plus `--wait-timeout` to bound total waiting independently of the per-request `--timeout`.
- Preserve the run ID in startup and polling errors, with instructions to inspect or resume the existing run before starting another. Interrupted waits never stop the server run.
- Make retry backoffs cancellable so total wait deadlines remain effective during server and network errors.
- Honor `--timeout` in the underlying HTTP client instead of silently capping it at 45 seconds, and preserve `--runtime` overrides.

When waiting, JSON stdout contains final run metadata, including the stored `result` string. Logs and tracking instructions go to stderr; logs may only become available at completion on runners that persist them then. Older servers that return a complete JSON response directly retain that response format.

Validation: `go test -race -short ./...`, `go build ./...`, golangci-lint v2.12.0 (Go 1.26.1), and strict endpoint/skill coverage checks all pass. Regression tests cover execution beyond the request timeout, one start request, closing the runner stream before polling, quiet startup with `--no-wait`, interrupted waits, cancellation during both retry paths, terminal statuses, and JSON output. No live BenefitsCal run was started.

Live integration coverage: `NOTTE_API_URL=https://us-staging.notte.cc go test -v -tags=integration -run '^TestFunctionRunPolling$' -timeout=5m ./tests/integration` passes. It uploads a quiet 20-second function, verifies `--no-wait` returns while active, resumes the same run after a wait timeout, and confirms `--no-stream` completes beyond its 10-second per-request limit without duplicate runs. The fixture opens no browser and is deleted afterward. Lint with integration tags reports no issues in the new test (five existing unchecked-return warnings remain in `tests/integration/functions_test.go`).
