### PR TITLE
chore: regenerate API client from latest OpenAPI spec

### DIFF
--- a/internal/api/client.gen.go
+++ b/internal/api/client.gen.go
@@ -2350,6 +2350,8 @@ type PersonaCreateRequest struct {
 
 // PersonaResponse defines model for PersonaResponse.
 type PersonaResponse struct {
+	CreatedAt FlexibleTime `json:"created_at"`
+
 	// Email Public, human-readable email address of the persona
 	Email string `json:"email"`
 


### PR DESCRIPTION
Automated regeneration of the generated API client (`internal/api`, `internal/cmd/*_flags.gen.go`) from the latest OpenAPI spec.

**Last regenerated:** 2026-09-11 14:20 UTC